### PR TITLE
Add user account function

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,10 @@
 class ApplicationController < ActionController::Base
-  helper_method :recaptcha_enabled?, :recaptcha_site_key, :adsense_enabled?
+  helper_method :recaptcha_enabled?,
+                :recaptcha_site_key,
+                :adsense_enabled?,
+                :owned_users,
+                :user_owner?,
+                :post_owner?
 
   private
 
@@ -13,5 +18,73 @@ class ApplicationController < ActionController::Base
 
   def adsense_enabled?
     ENV["ADSENSE_ENABLED"] == "true" && ENV["ADSENSE_CLIENT_ID"].present?
+  end
+
+  def owned_users
+    ids = owner_user_tokens.keys.map(&:to_i)
+    return User.none if ids.empty?
+
+    User.where(id: ids).order(created_at: :desc)
+  end
+
+  def user_owner?(user)
+    user&.owned_by_token?(owner_user_tokens[user.id.to_s])
+  end
+
+  def post_owner?(post)
+    post&.owned_by_token?(owner_post_tokens[post.id.to_s])
+  end
+
+  def store_user_owner_token(user, raw_token)
+    tokens = owner_user_tokens
+    tokens[user.id.to_s] = raw_token
+    write_owner_user_tokens(tokens)
+  end
+
+  def store_post_owner_token(post, raw_token)
+    tokens = owner_post_tokens
+    tokens[post.id.to_s] = raw_token
+    write_owner_post_tokens(tokens)
+  end
+
+  def remove_post_owner_token(post)
+    tokens = owner_post_tokens
+    tokens.delete(post.id.to_s)
+    write_owner_post_tokens(tokens)
+  end
+
+  private
+
+  def owner_user_tokens
+    parse_owner_tokens(cookies.encrypted[:owner_user_tokens])
+  end
+
+  def owner_post_tokens
+    parse_owner_tokens(cookies.encrypted[:owner_post_tokens])
+  end
+
+  def write_owner_user_tokens(tokens)
+    cookies.encrypted[:owner_user_tokens] = {
+      value: tokens.to_json,
+      expires: 1.year.from_now,
+      httponly: true
+    }
+  end
+
+  def write_owner_post_tokens(tokens)
+    cookies.encrypted[:owner_post_tokens] = {
+      value: tokens.to_json,
+      expires: 1.year.from_now,
+      httponly: true
+    }
+  end
+
+  def parse_owner_tokens(raw_value)
+    return {} if raw_value.blank?
+
+    parsed = JSON.parse(raw_value)
+    parsed.is_a?(Hash) ? parsed : {}
+  rescue JSON::ParserError
+    {}
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,19 +1,27 @@
 class CommentsController < ApplicationController
   def create
-    @post = Post.visible.includes(:items, desk_image_attachment: :blob).find(params[:post_id])
+    @post = Post.visible.includes(:user, :items, desk_image_attachment: :blob).find(params[:post_id])
     @comment = @post.comments.new(comment_params.merge(approved: true))
 
     if recaptcha_enabled? && !verify_recaptcha
       @comment.errors.add(:base, "reCAPTCHAの検証に失敗しました。")
       @comments = @post.comments.visible.latest
+      @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
       render "posts/show", status: :unprocessable_entity
       return
     end
 
     if @comment.save
+      unless post_owner?(@post)
+        @post.notifications.create!(
+          kind: :comment,
+          message: "#{@comment.author_name}さんがコメントしました。"
+        )
+      end
       redirect_to post_path(@post, anchor: "comments"), notice: "コメントを投稿しました。"
     else
       @comments = @post.comments.visible.latest
+      @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
       render "posts/show", status: :unprocessable_entity
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,42 +1,88 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: %i[show like]
+  before_action :set_visible_post, only: %i[show like]
+  before_action :set_post, only: %i[edit update destroy notifications]
+  before_action :require_owned_user!, only: %i[new create]
+  before_action :prepare_owned_users, only: %i[new create edit update]
+  before_action :require_post_owner!, only: %i[edit update destroy notifications]
 
   def index
-    @posts = Post.visible.includes(:items, desk_image_attachment: :blob).filtered(params)
+    @posts = Post.visible.includes(:user, :items, desk_image_attachment: :blob).filtered(params)
     @categories = Post.visible.where.not(category: [ nil, "" ]).distinct.order(:category).pluck(:category)
   end
 
   def show
     @comments = @post.comments.visible.latest
     @comment = @post.comments.new
+    @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
   end
 
   def new
-    @post = Post.new(published: true)
+    @post = Post.new(published: true, user: @owned_users.first)
     build_item_fields
   end
 
   def create
-    @post = Post.new(post_params)
+    @post = Post.new(post_params.except(:user_id))
     @post.likes_count = 0
     @post.published = true
+    @post.user = selected_owned_user
+    assign_owner_token(@post)
+
+    unless @post.user
+      @post.errors.add(:user, "投稿者プロフィールを選択してください。")
+      build_item_fields
+      render :new, status: :unprocessable_entity
+      return
+    end
 
     if @post.save
-      redirect_to @post, notice: "投稿を公開しました。"
+      store_post_owner_token(@post, @raw_post_owner_token)
+      redirect_to @post, notice: "投稿を作成しました。"
     else
       build_item_fields
       render :new, status: :unprocessable_entity
     end
   end
 
+  def edit
+    build_item_fields
+  end
+
+  def update
+    if params.dig(:post, :user_id).present?
+      candidate_user = selected_owned_user
+      unless candidate_user
+        @post.errors.add(:user, "選択したプロフィールは利用できません。")
+        build_item_fields
+        render :edit, status: :unprocessable_entity
+        return
+      end
+      @post.user = candidate_user
+    end
+
+    if @post.update(post_params.except(:user_id))
+      redirect_to @post, notice: "投稿を更新しました。"
+    else
+      build_item_fields
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @post.destroy
+    remove_post_owner_token(@post)
+    redirect_to root_path, notice: "投稿を削除しました。"
+  end
+
   def like
     liked_ids = cookies.encrypted[:liked_post_ids].to_s.split(",").map(&:to_i)
     if liked_ids.include?(@post.id)
-      redirect_to @post, alert: "この投稿には既にいいね済みです。"
+      redirect_to @post, alert: "この投稿にはすでにいいね済みです。"
       return
     end
 
     @post.increment!(:likes_count)
+    @post.notifications.create!(kind: :like, message: "あなたの投稿にいいねが付きました。") unless post_owner?(@post)
     liked_ids << @post.id
     cookies.encrypted[:liked_post_ids] = {
       value: liked_ids.uniq.join(","),
@@ -47,14 +93,25 @@ class PostsController < ApplicationController
     redirect_to @post, notice: "いいねしました。"
   end
 
+  def notifications
+    now = Time.current
+    @post.notifications.unread.update_all(read_at: now, updated_at: now)
+    @notifications = @post.notifications.latest
+  end
+
   private
 
+  def set_visible_post
+    @post = Post.visible.includes(:user, :items, desk_image_attachment: :blob).find(params[:id])
+  end
+
   def set_post
-    @post = Post.visible.includes(:items, desk_image_attachment: :blob).find(params[:id])
+    @post = Post.includes(:user, :items, desk_image_attachment: :blob).find(params[:id])
   end
 
   def post_params
     params.require(:post).permit(
+      :user_id,
       :title,
       :description,
       :category,
@@ -67,5 +124,33 @@ class PostsController < ApplicationController
 
   def build_item_fields
     (3 - @post.items.size).times { @post.items.build }
+  end
+
+  def require_owned_user!
+    return if owned_users.exists?
+
+    redirect_to new_user_path, alert: "投稿するには先にプロフィール作成が必要です。"
+  end
+
+  def require_post_owner!
+    return if post_owner?(@post)
+
+    redirect_to post_path(@post), alert: "この操作は投稿者本人のみ実行できます。"
+  end
+
+  def prepare_owned_users
+    @owned_users = owned_users.to_a
+  end
+
+  def selected_owned_user
+    selected_id = params.dig(:post, :user_id).to_i
+    return @owned_users.first if selected_id.zero?
+
+    @owned_users.find { |user| user.id == selected_id }
+  end
+
+  def assign_owner_token(post)
+    @raw_post_owner_token = SecureRandom.urlsafe_base64(32)
+    post.owner_token_digest = Post.digest_owner_token(@raw_post_owner_token)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,52 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: %i[show edit update]
+  before_action :require_user_owner!, only: %i[edit update]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    raw_owner_token = SecureRandom.urlsafe_base64(32)
+    @user.owner_token_digest = User.digest_owner_token(raw_owner_token)
+
+    if @user.save
+      store_user_owner_token(@user, raw_owner_token)
+      redirect_to @user, notice: "プロフィールを作成しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @posts = @user.posts.visible.latest.includes(:items, desk_image_attachment: :blob)
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to @user, notice: "プロフィールを更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def require_user_owner!
+    return if user_owner?(@user)
+
+    redirect_to user_path(@user), alert: "このプロフィールは本人のみ編集できます。"
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :bio)
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,10 @@
+class Notification < ApplicationRecord
+  belongs_to :post
+
+  enum :kind, { like: 0, comment: 1 }, suffix: true
+
+  scope :latest, -> { order(created_at: :desc) }
+  scope :unread, -> { where(read_at: nil) }
+
+  validates :message, presence: true, length: { maximum: 255 }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,11 @@
 class Post < ApplicationRecord
+  require "digest"
+
   has_one_attached :desk_image
+  belongs_to :user
   has_many :items, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   accepts_nested_attributes_for :items, allow_destroy: true, reject_if: :all_blank
 
@@ -10,7 +14,12 @@ class Post < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 120 }
   validates :description, presence: true, length: { maximum: 2000 }
+  validates :owner_token_digest, presence: true
   validate :desk_image_presence
+
+  def self.digest_owner_token(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
 
   def self.filtered(params)
     posts = latest
@@ -36,6 +45,12 @@ class Post < ApplicationRecord
 
   def tags
     tag_list.to_s.split(",").map(&:strip).reject(&:blank?).uniq
+  end
+
+  def owned_by_token?(token)
+    return false if token.blank? || owner_token_digest.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(owner_token_digest, self.class.digest_owner_token(token))
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,19 @@
+class User < ApplicationRecord
+  require "digest"
+
+  has_many :posts, dependent: :destroy
+
+  validates :name, presence: true, length: { maximum: 60 }
+  validates :bio, length: { maximum: 500 }
+  validates :owner_token_digest, presence: true
+
+  def self.digest_owner_token(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  def owned_by_token?(token)
+    return false if token.blank? || owner_token_digest.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(owner_token_digest, self.class.digest_owner_token(token))
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,12 @@
     <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
       <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
         <%= link_to "DeskTour Studio", root_path, class: "text-lg font-bold text-slate-900" %>
-        <div class="flex items-center gap-3 text-sm font-medium">
+        <div class="flex items-center gap-2 text-sm font-medium">
+          <% if owned_users.any? %>
+            <%= link_to "マイプロフィール", user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100" %>
+          <% else %>
+            <%= link_to "プロフィール作成", new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100" %>
+          <% end %>
           <%= link_to "投稿する", new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600" %>
         </div>
       </div>
@@ -57,7 +62,7 @@
 
     <footer class="mt-10 border-t border-slate-200 bg-white">
       <div class="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between sm:px-6">
-        <p>© <%= Date.current.year %> DeskTour Studio</p>
+        <p>&copy; <%= Date.current.year %> DeskTour Studio</p>
         <div class="flex flex-wrap gap-4">
           <%= link_to "利用規約", terms_path, class: "hover:text-slate-900" %>
           <%= link_to "プライバシーポリシー", privacy_policy_path, class: "hover:text-slate-900" %>
@@ -65,6 +70,7 @@
         </div>
       </div>
     </footer>
+
     <script>
       document.addEventListener("click", async (event) => {
         const button = event.target.closest("[data-copy-url]");

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,7 +1,10 @@
+<% submit_label ||= "投稿を公開" %>
+<% owned_users ||= [] %>
+
 <%= form_with model: post, class: "space-y-6" do |f| %>
   <% if post.errors.any? %>
     <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
-      <p class="mb-2 font-semibold">入力内容を確認してください</p>
+      <p class="mb-2 font-semibold">入力内容を確認してください。</p>
       <ul class="list-disc pl-5">
         <% post.errors.full_messages.each do |message| %>
           <li><%= message %></li>
@@ -11,6 +14,13 @@
   <% end %>
 
   <div class="grid gap-4 sm:grid-cols-2">
+    <% if owned_users.any? %>
+      <div class="sm:col-span-2">
+        <%= f.label :user_id, "投稿者プロフィール", class: "mb-1 block text-sm font-medium" %>
+        <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2" %>
+      </div>
+    <% end %>
+
     <div class="sm:col-span-2">
       <%= f.label :title, "タイトル", class: "mb-1 block text-sm font-medium" %>
       <%= f.text_field :title, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: "例: Minimal Blue Desk Setup" %>
@@ -37,13 +47,13 @@
     </div>
 
     <div class="sm:col-span-2">
-      <%= f.label :desk_image, "デスク写真", class: "mb-1 block text-sm font-medium" %>
+      <%= f.label :desk_image, "デスク画像", class: "mb-1 block text-sm font-medium" %>
       <%= f.file_field :desk_image, class: "w-full rounded-lg border border-slate-300 px-3 py-2", accept: "image/*" %>
     </div>
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-    <p class="mb-3 text-sm font-semibold text-slate-700">紹介アイテム（任意）</p>
+    <p class="mb-3 text-sm font-semibold text-slate-700">関連アイテム（任意）</p>
     <div class="space-y-4">
       <%= f.fields_for :items do |item_fields| %>
         <div class="grid gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:grid-cols-2">
@@ -52,7 +62,7 @@
             <%= item_fields.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "例: HHKB Professional" %>
           </div>
           <div>
-            <%= item_fields.label :affiliate_url, "商品URL", class: "mb-1 block text-xs font-medium text-slate-600" %>
+            <%= item_fields.label :affiliate_url, "購入URL", class: "mb-1 block text-xs font-medium text-slate-600" %>
             <%= item_fields.url_field :affiliate_url, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "https://www.amazon.co.jp/..." %>
           </div>
         </div>
@@ -60,5 +70,5 @@
     </div>
   </div>
 
-  <%= f.submit "投稿を公開", class: "rounded-lg bg-blue-500 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-600" %>
+  <%= f.submit submit_label, class: "rounded-lg bg-blue-500 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-600" %>
 <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "投稿を編集" %>
+<% content_for :description, "投稿内容を編集します。" %>
+
+<section class="mx-auto w-full max-w-3xl space-y-6">
+  <div>
+    <h1 class="text-2xl font-bold text-slate-900">投稿を編集</h1>
+    <p class="mt-2 text-sm text-slate-600">
+      投稿者本人のみ、投稿内容を更新できます。
+    </p>
+  </div>
+
+  <div class="rounded-xl border border-slate-200 bg-white p-6">
+    <%= render "form", post: @post, owned_users: @owned_users, submit_label: "更新する" %>
+  </div>
+</section>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,17 +1,17 @@
-<% content_for :title, "世界のデスクギャラリー" %>
-<% content_for :description, "DeskTour Studioの投稿一覧。デスク写真や構成アイテムを見て作業環境のアイデアを見つけましょう。" %>
+<% content_for :title, "みんなのデスクギャラリー" %>
+<% content_for :description, "DeskTour Studioの投稿一覧。デスク写真や関連アイテムを探せます。" %>
 
 <section class="space-y-8">
   <div class="rounded-2xl bg-gradient-to-br from-blue-600 to-cyan-500 px-6 py-8 text-white">
-    <h1 class="text-2xl font-bold sm:text-3xl">世界の作業環境を、のぞく。</h1>
+    <h1 class="text-2xl font-bold sm:text-3xl">みんなの作業環境を見つけよう</h1>
     <p class="mt-2 text-sm text-blue-50 sm:text-base">
-      エンジニア・デザイナー・クリエイターのデスク構成を見て、あなたの環境づくりに活かせます。
+      エンジニア・デザイナー・クリエイターのデスク投稿をチェックできます。
     </p>
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-white p-4">
     <%= form_with url: posts_path, method: :get, local: true, class: "grid gap-3 sm:grid-cols-4" do %>
-      <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm sm:col-span-2", placeholder: "キーワード検索（タイトル・説明・アイテム名）" %>
+      <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm sm:col-span-2", placeholder: "キーワード（タイトル・説明・アイテム名）" %>
       <%= select_tag :category, options_for_select([["カテゴリ", ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
       <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "テーマ" %>
       <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "タグ" %>
@@ -41,6 +41,10 @@
               </h2>
               <span class="text-xs text-slate-500">♥ <%= post.likes_count %></span>
             </div>
+            <p class="text-xs text-slate-500">
+              投稿者:
+              <%= link_to post.user.name, user_path(post.user), class: "text-blue-600 hover:text-blue-700" %>
+            </p>
             <p class="text-sm text-slate-600"><%= truncate(post.description, length: 100) %></p>
             <div class="flex flex-wrap gap-2 text-xs">
               <% if post.category.present? %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,15 +1,15 @@
 <% content_for :title, "デスクを投稿" %>
-<% content_for :description, "DeskTour Studioにあなたの作業環境を投稿して、世界中にデスク構成を共有しましょう。" %>
+<% content_for :description, "DeskTour Studioにデスク投稿を作成します。" %>
 
 <section class="mx-auto w-full max-w-3xl space-y-6">
   <div>
     <h1 class="text-2xl font-bold text-slate-900">デスク投稿</h1>
     <p class="mt-2 text-sm text-slate-600">
-      投稿画像は、あなたが権利を持つもののみアップロードしてください。
+      投稿者プロフィールを選択し、デスクの情報を入力してください。
     </p>
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-white p-6">
-    <%= render "form", post: @post %>
+    <%= render "form", post: @post, owned_users: @owned_users, submit_label: "投稿を公開" %>
   </div>
 </section>

--- a/app/views/posts/notifications.html.erb
+++ b/app/views/posts/notifications.html.erb
@@ -1,0 +1,35 @@
+<% content_for :title, "通知" %>
+<% content_for :description, "投稿に届いた通知一覧です。" %>
+
+<section class="mx-auto w-full max-w-3xl space-y-6">
+  <header class="flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h1 class="text-2xl font-bold text-slate-900">通知</h1>
+      <p class="mt-1 text-sm text-slate-600">
+        <%= link_to @post.title, post_path(@post), class: "text-blue-600 hover:text-blue-700" %>
+        への反応
+      </p>
+    </div>
+    <%= link_to "投稿詳細に戻る", post_path(@post), class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+  </header>
+
+  <div class="rounded-xl border border-slate-200 bg-white p-6">
+    <% if @notifications.any? %>
+      <div class="space-y-3">
+        <% @notifications.each do |notification| %>
+          <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
+            <p class="text-sm text-slate-800"><%= notification.message %></p>
+            <p class="mt-1 text-xs text-slate-500">
+              <%= l(notification.created_at, format: :short) %>
+              <% if notification.read_at.present? %>
+                <span class="ml-2 rounded bg-emerald-50 px-2 py-0.5 text-emerald-700">既読</span>
+              <% end %>
+            </p>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm text-slate-500">通知はまだありません。</p>
+    <% end %>
+  </div>
+</section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,6 +14,10 @@
       <% end %>
     </div>
     <h1 class="text-2xl font-bold text-slate-900 sm:text-3xl"><%= @post.title %></h1>
+    <p class="text-sm text-slate-600">
+      投稿者:
+      <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
+    </p>
   </header>
 
   <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white">
@@ -38,7 +42,7 @@
 
   <section class="rounded-xl border border-slate-200 bg-white p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-lg font-semibold text-slate-900">紹介アイテム</h2>
+      <h2 class="text-lg font-semibold text-slate-900">関連アイテム</h2>
       <span class="text-sm text-slate-500">♥ <%= @post.likes_count %></span>
     </div>
     <% if @post.items.any? %>
@@ -47,13 +51,13 @@
           <div class="rounded-lg border border-slate-200 p-3">
             <p class="text-sm font-medium text-slate-900"><%= item.name %></p>
             <% if item.affiliate_url.present? %>
-              <%= link_to "商品ページを見る", item.affiliate_url, class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-700", target: "_blank", rel: "nofollow sponsored noopener" %>
+              <%= link_to "購入ページを見る", item.affiliate_url, class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-700", target: "_blank", rel: "nofollow sponsored noopener" %>
             <% end %>
           </div>
         <% end %>
       </div>
       <p class="mt-4 text-xs text-slate-500">
-        ※このページのリンクにはアフィリエイト広告を含む場合があります。
+        ※リンク経由で購入された場合、アフィリエイト収益が発生することがあります。
       </p>
     <% else %>
       <p class="mt-3 text-sm text-slate-500">登録されたアイテムはありません。</p>
@@ -66,6 +70,14 @@
     <%= link_to "Threadsでシェア", threads_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
     <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">URLをコピー</button>
   </div>
+
+  <% if post_owner?(@post) %>
+    <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
+      <%= link_to "編集", edit_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= link_to "通知を見る（#{@unread_notifications_count}件）", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= button_to "削除", post_path(@post), method: :delete, data: { turbo_confirm: "投稿を削除しますか？" }, class: "rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
+    </div>
+  <% end %>
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with model: user, class: "space-y-5" do |f| %>
+  <% if user.errors.any? %>
+    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
+      <p class="mb-2 font-semibold">入力内容を確認してください。</p>
+      <ul class="list-disc pl-5">
+        <% user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :name, "表示名", class: "mb-1 block text-sm font-medium" %>
+    <%= f.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "例: Desk Lover" %>
+  </div>
+
+  <div>
+    <%= f.label :bio, "プロフィール文", class: "mb-1 block text-sm font-medium" %>
+    <%= f.text_area :bio, rows: 5, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "デスクへのこだわりや使い方を書いてください" %>
+  </div>
+
+  <%= f.submit submit_label, class: "rounded-lg bg-blue-500 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-600" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "プロフィール編集" %>
+<% content_for :description, "投稿者プロフィールを編集します。" %>
+
+<section class="mx-auto w-full max-w-3xl space-y-6">
+  <div>
+    <h1 class="text-2xl font-bold text-slate-900">プロフィール編集</h1>
+    <p class="mt-2 text-sm text-slate-600">
+      このプロフィールは本人のみ編集できます。
+    </p>
+  </div>
+
+  <div class="rounded-xl border border-slate-200 bg-white p-6">
+    <%= render "form", user: @user, submit_label: "更新する" %>
+  </div>
+</section>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, "プロフィール作成" %>
+<% content_for :description, "投稿者プロフィールを作成します。" %>
+
+<section class="mx-auto w-full max-w-3xl space-y-6">
+  <div>
+    <h1 class="text-2xl font-bold text-slate-900">プロフィール作成</h1>
+    <p class="mt-2 text-sm text-slate-600">
+      投稿前に、表示されるプロフィールを作成してください。
+    </p>
+  </div>
+
+  <div class="rounded-xl border border-slate-200 bg-white p-6">
+    <%= render "form", user: @user, submit_label: "作成する" %>
+  </div>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, @user.name %>
+<% content_for :description, truncate(@user.bio.to_s, length: 120) %>
+
+<section class="space-y-6">
+  <header class="rounded-xl border border-slate-200 bg-white p-6">
+    <div class="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-slate-900"><%= @user.name %></h1>
+        <% if @user.bio.present? %>
+          <p class="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-700"><%= @user.bio %></p>
+        <% else %>
+          <p class="mt-3 text-sm text-slate-500">プロフィール文は未設定です。</p>
+        <% end %>
+      </div>
+      <% if user_owner?(@user) %>
+        <%= link_to "プロフィール編集", edit_user_path(@user), class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+      <% end %>
+    </div>
+  </header>
+
+  <section class="rounded-xl border border-slate-200 bg-white p-6">
+    <h2 class="text-lg font-semibold text-slate-900">投稿一覧</h2>
+    <% if @posts.any? %>
+      <div class="mt-4 space-y-3">
+        <% @posts.each do |post| %>
+          <article class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <h3 class="text-base font-semibold text-slate-900">
+                <%= link_to post.title, post_path(post), class: "hover:text-blue-600" %>
+              </h3>
+              <span class="text-xs text-slate-500">♥ <%= post.likes_count %></span>
+            </div>
+            <p class="mt-2 text-sm text-slate-600"><%= truncate(post.description, length: 140) %></p>
+          </article>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="mt-3 text-sm text-slate-500">公開中の投稿はまだありません。</p>
+    <% end %>
+  </section>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,11 @@ Rails.application.routes.draw do
 
   root "posts#index"
 
-  resources :posts, only: %i[index show new create] do
+  resources :users, only: %i[new create show edit update]
+
+  resources :posts, only: %i[index show new create edit update destroy] do
     post :like, on: :member
+    get :notifications, on: :member
     resources :comments, only: :create
   end
 

--- a/db/migrate/20260217090000_create_users.rb
+++ b/db/migrate/20260217090000_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.text :bio
+      t.string :owner_token_digest, null: false
+
+      t.timestamps
+    end
+
+    add_index :users, :created_at
+  end
+end

--- a/db/migrate/20260217090010_add_user_and_owner_token_digest_to_posts.rb
+++ b/db/migrate/20260217090010_add_user_and_owner_token_digest_to_posts.rb
@@ -1,0 +1,7 @@
+class AddUserAndOwnerTokenDigestToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :posts, :user, null: false, foreign_key: true
+    add_column :posts, :owner_token_digest, :string, null: false
+    add_index :posts, :owner_token_digest
+  end
+end

--- a/db/migrate/20260217090020_create_notifications.rb
+++ b/db/migrate/20260217090020_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :post, null: false, foreign_key: true
+      t.integer :kind, null: false, default: 0
+      t.string :message, null: false
+      t.datetime :read_at
+
+      t.timestamps
+    end
+
+    add_index :notifications, :created_at
+    add_index :notifications, :read_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_15_021142) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_17_090020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_021142) do
     t.foreign_key "active_storage_blobs", column: "blob_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "bio"
+    t.string "owner_token_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_users_on_created_at"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
     t.text "description", null: false
@@ -54,8 +63,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_021142) do
     t.boolean "published", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.string "owner_token_digest", null: false
     t.index ["created_at"], name: "index_posts_on_created_at"
+    t.index ["owner_token_digest"], name: "index_posts_on_owner_token_digest"
     t.index ["published"], name: "index_posts_on_published"
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -82,4 +95,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_15_021142) do
     t.foreign_key "posts"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.integer "kind", default: 0, null: false
+    t.string "message", null: false
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_notifications_on_created_at"
+    t.index ["post_id"], name: "index_notifications_on_post_id"
+    t.index ["read_at"], name: "index_notifications_on_read_at"
+    t.foreign_key "posts"
+  end
+
+  add_foreign_key "posts", "users"
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,18 +1,67 @@
 require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
-  fixtures :posts, :comments
+  include ActionDispatch::TestProcess::FixtureFile
 
-  test "should create comment" do
+  fixtures :users, :posts, :comments, :notifications
+
+  test "should create comment and notification" do
     assert_difference("Comment.count", 1) do
-      post post_comments_url(posts(:one)), params: {
-        comment: {
-          author_name: "Tester",
-          body: "Great setup!"
+      assert_difference("Notification.count", 1) do
+        post post_comments_url(posts(:one)), params: {
+          comment: {
+            author_name: "Tester",
+            body: "Great setup!"
+          }
         }
-      }
+      end
     end
 
     assert_redirected_to post_url(posts(:one), anchor: "comments")
+    assert_equal "comment", Notification.order(:id).last.kind
+  end
+
+  test "owner comment should not create notification" do
+    post_record = create_owned_post
+
+    assert_difference("Comment.count", 1) do
+      assert_no_difference("Notification.count") do
+        post post_comments_url(post_record), params: {
+          comment: {
+            author_name: "Owner",
+            body: "self comment"
+          }
+        }
+      end
+    end
+
+    assert_redirected_to post_url(post_record, anchor: "comments")
+  end
+
+  private
+
+  def create_owned_post
+    post users_url, params: {
+      user: {
+        name: "Comment Owner",
+        bio: "Owned user bio"
+      }
+    }
+    user = User.order(:id).last
+
+    image = fixture_file_upload("files/sample.jpg", "image/jpeg")
+    post posts_url, params: {
+      post: {
+        user_id: user.id,
+        title: "Owned post",
+        description: "Owned post description",
+        category: "Engineering",
+        theme: "White",
+        tag_list: "owner",
+        desk_image: image
+      }
+    }
+
+    Post.order(:id).last
   end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -49,7 +49,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     }
     user = User.order(:id).last
 
-    image = fixture_file_upload("files/sample.jpg", "image/jpeg")
+    image = fixture_file_upload("sample.jpg", "image/jpeg")
     post posts_url, params: {
       post: {
         user_id: user.id,

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,7 +1,9 @@
 require "test_helper"
 
 class PostsControllerTest < ActionDispatch::IntegrationTest
-  fixtures :posts
+  include ActionDispatch::TestProcess::FixtureFile
+
+  fixtures :users, :posts, :notifications
 
   test "should get index" do
     get root_url
@@ -18,11 +20,90 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "should like post once" do
+  test "should like post once and create notification" do
     assert_difference -> { posts(:one).reload.likes_count }, 1 do
-      post like_post_url(posts(:one))
+      assert_difference("Notification.count", 1) do
+        post like_post_url(posts(:one))
+      end
     end
 
     assert_redirected_to post_url(posts(:one))
+    assert_equal "like", Notification.order(:id).last.kind
+  end
+
+  test "should not like same post twice" do
+    post like_post_url(posts(:one))
+
+    assert_no_difference -> { posts(:one).reload.likes_count } do
+      assert_no_difference("Notification.count") do
+        post like_post_url(posts(:one))
+      end
+    end
+
+    assert_redirected_to post_url(posts(:one))
+  end
+
+  test "non owner cannot edit or view notifications" do
+    get edit_post_url(posts(:one))
+    assert_redirected_to post_url(posts(:one))
+
+    get notifications_post_url(posts(:one))
+    assert_redirected_to post_url(posts(:one))
+  end
+
+  test "owner can edit update destroy and read notifications" do
+    post_record = create_owned_post
+    post_record.notifications.create!(kind: :comment, message: "コメント通知")
+
+    get edit_post_url(post_record)
+    assert_response :success
+
+    patch post_url(post_record), params: {
+      post: {
+        user_id: post_record.user_id,
+        title: "Updated title",
+        description: "Updated description"
+      }
+    }
+    assert_redirected_to post_url(post_record)
+    assert_equal "Updated title", post_record.reload.title
+
+    get notifications_post_url(post_record)
+    assert_response :success
+    assert_not_nil post_record.notifications.order(:id).last.reload.read_at
+
+    assert_difference("Post.count", -1) do
+      delete post_url(post_record)
+    end
+    assert_redirected_to root_url
+  end
+
+  private
+
+  def create_owned_post
+    post users_url, params: {
+      user: {
+        name: "Owned User",
+        bio: "Owned user bio"
+      }
+    }
+    user = User.order(:id).last
+
+    image = fixture_file_upload("files/sample.jpg", "image/jpeg")
+    assert_difference("Post.count", 1) do
+      post posts_url, params: {
+        post: {
+          user_id: user.id,
+          title: "Owned post",
+          description: "Owned post description",
+          category: "Engineering",
+          theme: "Dark",
+          tag_list: "ruby",
+          desk_image: image
+        }
+      }
+    end
+
+    Post.order(:id).last
   end
 end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -89,7 +89,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     }
     user = User.order(:id).last
 
-    image = fixture_file_upload("files/sample.jpg", "image/jpeg")
+    image = fixture_file_upload("sample.jpg", "image/jpeg")
     assert_difference("Post.count", 1) do
       post posts_url, params: {
         post: {

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  fixtures :users
+
+  test "should get new" do
+    get new_user_url
+    assert_response :success
+  end
+
+  test "should create user profile" do
+    assert_difference("User.count", 1) do
+      post users_url, params: {
+        user: {
+          name: "New Profile",
+          bio: "New profile bio"
+        }
+      }
+    end
+
+    assert_redirected_to user_url(User.order(:id).last)
+  end
+
+  test "should show profile" do
+    get user_url(users(:one))
+    assert_response :success
+  end
+
+  test "owner can edit and update profile" do
+    post users_url, params: {
+      user: {
+        name: "Editable Profile",
+        bio: "Editable bio"
+      }
+    }
+    user = User.order(:id).last
+
+    get edit_user_url(user)
+    assert_response :success
+
+    patch user_url(user), params: {
+      user: {
+        name: "Updated Name",
+        bio: "Updated bio"
+      }
+    }
+    assert_redirected_to user_url(user)
+    assert_equal "Updated Name", user.reload.name
+  end
+
+  test "non owner cannot edit profile" do
+    get edit_user_url(users(:one))
+    assert_redirected_to user_url(users(:one))
+  end
+end

--- a/test/fixtures/files/sample.jpg
+++ b/test/fixtures/files/sample.jpg
@@ -1,0 +1,1 @@
+fake image bytes

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+like_for_one:
+  post: one
+  kind: 0
+  message: あなたの投稿にいいねが付きました。
+  read_at:
+
+comment_for_one:
+  post: one
+  kind: 1
+  message: Testerさんがコメントしました。
+  read_at:

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  user: one
   title: Minimal Desk Setup
   description: Example description for published desk.
   category: Engineering
@@ -8,8 +9,10 @@ one:
   tag_list: keyboard, monitor
   likes_count: 1
   published: true
+  owner_token_digest: bf55f41fc5560015003986cb2f7b76ea4df32143102b06091040c476116f8a5a
 
 two:
+  user: two
   title: Hidden Desk Setup
   description: Example description for hidden desk.
   category: Design
@@ -17,3 +20,4 @@ two:
   tag_list: camera, light
   likes_count: 2
   published: false
+  owner_token_digest: 5d03a3636109edfd47d91ad1d869f3b950f7cb0d5d1d942b51721c93a3cdafc0

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+one:
+  name: Desk Owner One
+  bio: Ruby engineer who likes minimalist desk layouts.
+  owner_token_digest: 8e69be240e1c76e8ab3259acbb2fcb540a746ef90979bd1857684cdc0ac2beeb
+
+two:
+  name: Desk Owner Two
+  bio: Designer focused on warm and natural desk themes.
+  owner_token_digest: 77fb66af69028dac493d88fa3945db824f95a238342604cc9c10fd14660596db


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/18

## 背景/目的
MVP機能（投稿・検索・コメント・いいね・管理・SEO・規約）が揃っており、公開ルートも閲覧/投稿中心なので、継続率とコミュニティ性を上げるために、ユーザーアカウントを実装する。

## 実装内容

ユーザー基盤の構築から、投稿の所有者管理、およびインタラクションに付随する通知機能まで、アプリケーションの根幹となる機能を一通り実装しました。

* **ユーザープロフィールの導入**: 投稿者としてのアイデンティティを持たせるためのUserモデルと管理機能の追加。
* **投稿の所有者認証**: CookieとDigest（ハッシュ化）を用いた、ログイン不要かつセキュアな投稿編集・削除権限の実装。
* **通知システム**: 「いいね」や「コメント」のアクティビティを投稿者に知らせる通知機能の構築。
* **UI/UXの改善**: 投稿詳細画面への管理用導線の追加、およびフォームの共通パーツ化（再利用性向上）。

## 方法

1. **認証ロジック**: `owner_post_tokens`（Cookie）とDB上の `owner_token_digest` を照合することで、セッションやパスワード管理を介さずに簡易的な所有者判定を実現。
2. **通知ロジック**: `CommentsController` および `PostsController`（いいね処理）において、アクション成功時に `Notification` レコードを生成。
3. **データベース拡張**: `users` / `notifications` テーブルを新規作成し、既存の `posts` テーブルに外部キー（`user_id`）と認証用カラムを追加。
4. **コードの効率化**: `_form.html.erb` に `submit_label` 引数を導入し、新規作成と編集でフォームを共通化。

## 変更箇所

### モデル・データベース

* `app/models/`: `user.rb`, `post.rb`, `notification.rb`
* `db/migrate/`: `20260217090000_create_users.rb`, `..._add_user_and_owner_token_digest_to_posts.rb`, `..._create_notifications.rb`
* `db/schema.rb`

### コントローラ・ルーティング

* `app/controllers/`: `users_controller.rb`, `posts_controller.rb`, `comments_controller.rb`, `application_controller.rb`
* `config/routes.rb`

### ビュー

* `app/views/users/`: `new.html.erb`, `show.html.erb`, `edit.html.erb`
* `app/views/posts/`: `show.html.erb`, `_form.html.erb`, `new.html.erb`, `index.html.erb`, `notifications.html.erb`
* `app/views/layouts/application.html.erb`

### テスト

* `test/controllers/`: `posts_controller_test.rb`, `comments_controller_test.rb`, `users_controller_test.rb`
* `test/fixtures/`: `users.yml`, `notifications.yml`, `posts.yml`, `files/sample.jpg`

## まとめ

本実装により、単なる投稿掲示板から「ユーザー同士の繋がり（通知）」や「投稿の管理（編集・削除）」が可能な、より実用的なWebアプリケーションへと変わりました。
