### PR TITLE
Implement notification flow (comment reply email)

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,27 +1,27 @@
 class CommentsController < ApplicationController
   def create
     @post = Post.visible.includes(:user, :items, desk_image_attachment: :blob).find(params[:post_id])
-    @comment = @post.comments.new(comment_params.merge(approved: true))
+    @comment = build_comment
+
+    unless parent_comment_valid?
+      prepare_show_context
+      render "posts/show", status: :unprocessable_entity
+      return
+    end
 
     if recaptcha_enabled? && !verify_recaptcha
-      @comment.errors.add(:base, "reCAPTCHAの検証に失敗しました。")
-      @comments = @post.comments.visible.latest
-      @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
+      @comment.errors.add(:base, "reCAPTCHA verification failed.")
+      prepare_show_context
       render "posts/show", status: :unprocessable_entity
       return
     end
 
     if @comment.save
-      unless post_owner?(@post)
-        @post.notifications.create!(
-          kind: :comment,
-          message: "#{@comment.author_name}さんがコメントしました。"
-        )
-      end
-      redirect_to post_path(@post, anchor: "comments"), notice: "コメントを投稿しました。"
+      create_post_notification(@comment)
+      enqueue_reply_notification(@comment)
+      redirect_to post_path(@post, anchor: "comments"), notice: "Comment posted."
     else
-      @comments = @post.comments.visible.latest
-      @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
+      prepare_show_context
       render "posts/show", status: :unprocessable_entity
     end
   end
@@ -29,7 +29,71 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:author_name, :body)
+    params.require(:comment).permit(:author_name, :body, :user_id, :parent_comment_id)
+  end
+
+  def build_comment
+    selected_user = selected_owned_user
+    parent_comment = parent_comment_from_params
+
+    attrs = comment_params.except(:user_id, :parent_comment_id)
+    attrs[:author_name] = selected_user.name if selected_user
+
+    @post.comments.new(attrs.merge(approved: true, user: selected_user, parent_comment: parent_comment))
+  end
+
+  def selected_owned_user
+    selected_id = comment_params[:user_id].to_i
+    return if selected_id.zero?
+
+    owned_users.find_by(id: selected_id)
+  end
+
+  def parent_comment_from_params
+    parent_id = comment_params[:parent_comment_id].to_i
+    return if parent_id.zero?
+
+    @post.comments.visible.find_by(id: parent_id)
+  end
+
+  def parent_comment_valid?
+    return true if comment_params[:parent_comment_id].blank?
+    return true if @comment.parent_comment.present?
+
+    @comment.errors.add(:parent_comment_id, "is invalid")
+    false
+  end
+
+  def create_post_notification(comment)
+    return if post_owner?(@post)
+
+    @post.notifications.create!(kind: :comment, message: "#{comment.author_name} commented on your post.")
+  end
+
+  def enqueue_reply_notification(comment)
+    parent_comment = comment.parent_comment
+    return if parent_comment.blank?
+
+    recipient = parent_comment.user
+    return if recipient.blank?
+    return if comment.user_id.present? && comment.user_id == recipient.id
+    return unless recipient.mailable_for_reply_notifications?
+
+    notification = CommentReplyNotification.create!(
+      recipient_user: recipient,
+      comment: comment,
+      parent_comment: parent_comment,
+      status: :pending
+    )
+
+    CommentReplyNotificationJob.perform_later(notification.id)
+  end
+
+  def prepare_show_context
+    @root_comments = @post.comments.visible.roots.includes(:user, replies: :user).latest
+    @comments = @root_comments
+    @reply_to_comment = @comment.parent_comment
+    @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
   end
 
   def verify_recaptcha

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,8 +11,10 @@ class PostsController < ApplicationController
   end
 
   def show
-    @comments = @post.comments.visible.latest
-    @comment = @post.comments.new
+    @root_comments = @post.comments.visible.roots.includes(:user, replies: :user).latest
+    @comments = @root_comments
+    @reply_to_comment = @post.comments.visible.find_by(id: params[:reply_to])
+    @comment = @post.comments.new(parent_comment: @reply_to_comment)
     @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,6 +49,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :bio)
+    params.require(:user).permit(:name, :bio, :email, :email_notifications_enabled)
   end
 end

--- a/app/jobs/comment_reply_notification_job.rb
+++ b/app/jobs/comment_reply_notification_job.rb
@@ -1,0 +1,22 @@
+class CommentReplyNotificationJob < ApplicationJob
+  queue_as :default
+
+  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+
+  def perform(comment_reply_notification_id)
+    notification = CommentReplyNotification.includes(:recipient_user, :parent_comment, comment: :post).find(comment_reply_notification_id)
+    return if notification.status_sent?
+
+    recipient = notification.recipient_user
+    unless recipient.mailable_for_reply_notifications?
+      notification.update!(status: :failed, error_message: "Recipient opted out or has no email")
+      return
+    end
+
+    CommentReplyMailer.reply_notification(notification).deliver_now
+    notification.update!(status: :sent, sent_at: Time.current, error_message: nil)
+  rescue StandardError => e
+    notification&.update!(status: :failed, error_message: e.message.to_s.first(1000))
+    raise
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: ENV.fetch("MAIL_FROM", "no-reply@desktourstudio.example")
   layout "mailer"
 end

--- a/app/mailers/comment_reply_mailer.rb
+++ b/app/mailers/comment_reply_mailer.rb
@@ -1,0 +1,15 @@
+class CommentReplyMailer < ApplicationMailer
+  def reply_notification(notification)
+    @notification = notification
+    @recipient = notification.recipient_user
+    @reply_comment = notification.comment
+    @parent_comment = notification.parent_comment
+    @post = @reply_comment.post
+    @comment_url = post_url(@post, anchor: "comment-#{@reply_comment.id}")
+
+    mail(
+      to: @recipient.email,
+      subject: "【DeskTour Studio】あなたのコメントに返信がありました"
+    )
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,9 +1,24 @@
 class Comment < ApplicationRecord
   belongs_to :post
+  belongs_to :user, optional: true
+  belongs_to :parent_comment, class_name: "Comment", optional: true
+  has_many :replies, -> { where(approved: true).order(created_at: :asc) }, class_name: "Comment", foreign_key: :parent_comment_id, dependent: :nullify
+  has_one :comment_reply_notification, dependent: :destroy
 
   scope :visible, -> { where(approved: true) }
   scope :latest, -> { order(created_at: :desc) }
+  scope :roots, -> { where(parent_comment_id: nil) }
 
   validates :author_name, presence: true, length: { maximum: 40 }
   validates :body, presence: true, length: { maximum: 500 }
+  validate :parent_comment_belongs_to_same_post
+
+  private
+
+  def parent_comment_belongs_to_same_post
+    return if parent_comment.blank?
+    return if parent_comment.post_id == post_id
+
+    errors.add(:parent_comment_id, "must belong to the same post")
+  end
 end

--- a/app/models/comment_reply_notification.rb
+++ b/app/models/comment_reply_notification.rb
@@ -1,0 +1,11 @@
+class CommentReplyNotification < ApplicationRecord
+  belongs_to :recipient_user, class_name: "User"
+  belongs_to :comment
+  belongs_to :parent_comment, class_name: "Comment"
+
+  enum :status, { pending: 0, sent: 1, failed: 2 }, prefix: true
+
+  scope :latest, -> { order(created_at: :desc) }
+
+  validates :status, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,14 @@ class User < ApplicationRecord
   require "digest"
 
   has_many :posts, dependent: :destroy
+  has_many :comments, dependent: :nullify
+  has_many :comment_reply_notifications, foreign_key: :recipient_user_id, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 60 }
   validates :bio, length: { maximum: 500 }
+  validates :email, length: { maximum: 255 }, allow_blank: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :owner_token_digest, presence: true
+  validate :email_presence_when_notifications_enabled
 
   def self.digest_owner_token(token)
     Digest::SHA256.hexdigest(token.to_s)
@@ -15,5 +19,18 @@ class User < ApplicationRecord
     return false if token.blank? || owner_token_digest.blank?
 
     ActiveSupport::SecurityUtils.secure_compare(owner_token_digest, self.class.digest_owner_token(token))
+  end
+
+  def mailable_for_reply_notifications?
+    email_notifications_enabled? && email.present?
+  end
+
+  private
+
+  def email_presence_when_notifications_enabled
+    return unless email_notifications_enabled?
+    return if email.present?
+
+    errors.add(:email, "can't be blank when email notifications are enabled")
   end
 end

--- a/app/views/comment_reply_mailer/reply_notification.html.erb
+++ b/app/views/comment_reply_mailer/reply_notification.html.erb
@@ -1,0 +1,16 @@
+<p><%= @recipient.name.presence || "ユーザー" %> さん</p>
+
+<p>あなたのコメントに返信がありました。</p>
+
+<ul>
+  <li>投稿: <strong><%= @post.title %></strong></li>
+  <li>あなたのコメント: <%= @parent_comment.body %></li>
+  <li>返信コメント: <%= @reply_comment.body %></li>
+</ul>
+
+<p>
+  <a href="<%= @comment_url %>">返信コメントを確認する</a>
+</p>
+
+<hr>
+<p>DeskTour Studio</p>

--- a/app/views/comment_reply_mailer/reply_notification.text.erb
+++ b/app/views/comment_reply_mailer/reply_notification.text.erb
@@ -1,0 +1,13 @@
+<%= @recipient.name.presence || "ユーザー" %> さん
+
+あなたのコメントに返信がありました。
+
+投稿: <%= @post.title %>
+あなたのコメント: <%= @parent_comment.body %>
+返信コメント: <%= @reply_comment.body %>
+
+以下のリンクから該当コメントへ直接移動できます。
+<%= @comment_url %>
+
+---
+DeskTour Studio

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,7 +15,7 @@
     </div>
     <h1 class="text-2xl font-bold text-slate-900 sm:text-3xl"><%= @post.title %></h1>
     <p class="text-sm text-slate-600">
-      投稿者:
+      Posted by
       <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
     </p>
   </header>
@@ -38,62 +38,81 @@
 
   <section class="rounded-xl border border-slate-200 bg-white p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-lg font-semibold text-slate-900">関連アイテム</h2>
-      <span class="text-sm text-slate-500">♥ <%= @post.likes_count %></span>
+      <h2 class="text-lg font-semibold text-slate-900">Related items</h2>
+      <span class="text-sm text-slate-500">Likes: <%= @post.likes_count %></span>
     </div>
+
     <% if @post.items.any? %>
       <div class="mt-4 space-y-3">
         <% @post.items.each do |item| %>
           <div class="rounded-lg border border-slate-200 p-3">
             <p class="text-sm font-medium text-slate-900"><%= item.name %></p>
             <% if item.affiliate_url.present? %>
-              <%= link_to "購入ページを見る", item.affiliate_url, class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-700", target: "_blank", rel: "nofollow sponsored noopener" %>
+              <%= link_to "Open product page", item.affiliate_url, class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-700", target: "_blank", rel: "nofollow sponsored noopener" %>
             <% end %>
           </div>
         <% end %>
       </div>
-      <p class="mt-4 text-xs text-slate-500">
-        ※リンク経由で購入された場合、アフィリエイト収益が発生することがあります。
-      </p>
     <% else %>
-      <p class="mt-3 text-sm text-slate-500">登録されたアイテムはありません。</p>
+      <p class="mt-3 text-sm text-slate-500">No related items yet.</p>
     <% end %>
   </section>
 
   <div class="flex flex-wrap items-center gap-3">
-    <%= button_to "いいねする", like_post_path(@post), method: :post, class: "rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" %>
-    <%= link_to "Xでシェア", x_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
-    <%= link_to "Threadsでシェア", threads_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
-    <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">URLをコピー</button>
+    <%= button_to "Like", like_post_path(@post), method: :post, class: "rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" %>
+    <%= link_to "Share on X", x_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+    <%= link_to "Share on Threads", threads_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+    <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">Copy URL</button>
   </div>
 
   <% if post_owner?(@post) %>
     <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
-      <%= link_to "編集", edit_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
-      <%= link_to "通知を見る（#{@unread_notifications_count}件）", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
-      <%= button_to "削除", post_path(@post), method: :delete, data: { turbo_confirm: "投稿を削除しますか？" }, class: "rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
+      <%= link_to "Edit", edit_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= link_to "Notifications (#{@unread_notifications_count})", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= button_to "Delete", post_path(@post), method: :delete, data: { turbo_confirm: "Delete this post?" }, class: "rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
     </div>
   <% end %>
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
 
   <section id="comments" class="space-y-4 rounded-xl border border-slate-200 bg-white p-6">
-    <h2 class="text-lg font-semibold text-slate-900">コメント</h2>
+    <h2 class="text-lg font-semibold text-slate-900">Comments</h2>
 
-    <% if @comments.any? %>
-      <div class="space-y-3">
-        <% @comments.each do |comment| %>
-          <div class="rounded-lg border border-slate-100 bg-slate-50 p-3">
-            <p class="text-sm font-medium text-slate-800"><%= comment.author_name %></p>
+    <% if @root_comments.any? %>
+      <div class="space-y-4">
+        <% @root_comments.each do |comment| %>
+          <article id="comment-<%= comment.id %>" class="rounded-lg border border-slate-100 bg-slate-50 p-4">
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-sm font-medium text-slate-800"><%= comment.author_name %></p>
+              <%= link_to "Reply", post_path(@post, anchor: "comments", reply_to: comment.id), class: "text-xs text-blue-600 hover:text-blue-700" %>
+            </div>
             <p class="mt-1 whitespace-pre-wrap text-sm text-slate-700"><%= comment.body %></p>
-          </div>
+
+            <% if comment.replies.any? %>
+              <div class="mt-3 space-y-3 border-l-2 border-slate-200 pl-4">
+                <% comment.replies.each do |reply| %>
+                  <div id="comment-<%= reply.id %>" class="rounded-md border border-slate-200 bg-white p-3">
+                    <p class="text-xs font-medium text-slate-700"><%= reply.author_name %> replied</p>
+                    <p class="mt-1 whitespace-pre-wrap text-sm text-slate-700"><%= reply.body %></p>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          </article>
         <% end %>
       </div>
     <% else %>
-      <p class="text-sm text-slate-500">まだコメントはありません。</p>
+      <p class="text-sm text-slate-500">No comments yet.</p>
     <% end %>
 
     <div class="border-t border-slate-200 pt-4">
+      <% if @reply_to_comment.present? %>
+        <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+          Replying to <strong><%= @reply_to_comment.author_name %></strong>
+          <%= link_to "Cancel", post_path(@post, anchor: "comments"), class: "ml-2 text-blue-600 underline" %>
+        </div>
+      <% end %>
+
       <%= form_with model: [@post, @comment], class: "space-y-3" do |f| %>
         <% if @comment.errors.any? %>
           <div class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700">
@@ -105,18 +124,27 @@
           </div>
         <% end %>
 
+        <% if owned_users.any? %>
+          <div>
+            <%= f.label :user_id, "Comment as profile (optional)", class: "mb-1 block text-sm font-medium" %>
+            <%= f.collection_select :user_id, owned_users, :id, :name, { include_blank: "Post as guest" }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+          </div>
+        <% end %>
+
+        <%= f.hidden_field :parent_comment_id, value: @reply_to_comment&.id %>
+
         <div>
-          <%= f.label :author_name, "名前", class: "mb-1 block text-sm font-medium" %>
+          <%= f.label :author_name, "Name", class: "mb-1 block text-sm font-medium" %>
           <%= f.text_field :author_name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
         </div>
         <div>
-          <%= f.label :body, "コメント", class: "mb-1 block text-sm font-medium" %>
+          <%= f.label :body, "Comment", class: "mb-1 block text-sm font-medium" %>
           <%= f.text_area :body, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
         </div>
         <% if recaptcha_enabled? %>
           <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <% end %>
-        <%= f.submit "コメントを送信", class: "rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700" %>
+        <%= f.submit(@reply_to_comment.present? ? "Reply" : "Post comment", class: "rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700") %>
       <% end %>
     </div>
   </section>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,5 +20,16 @@
     <%= f.text_area :bio, rows: 5, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "デスクへのこだわりや使い方を書いてください" %>
   </div>
 
+  <div>
+    <%= f.label :email, "メールアドレス", class: "mb-1 block text-sm font-medium" %>
+    <%= f.email_field :email, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "you@example.com" %>
+    <p class="mt-1 text-xs text-slate-500">コメント返信通知の送信にのみ利用します。</p>
+  </div>
+
+  <div class="flex items-center gap-2">
+    <%= f.check_box :email_notifications_enabled, class: "h-4 w-4 rounded border-slate-300" %>
+    <%= f.label :email_notifications_enabled, "メール通知を受け取る", class: "text-sm text-slate-700" %>
+  </div>
+
   <%= f.submit submit_label, class: "rounded-lg bg-blue-500 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-600" %>
 <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,10 @@ Rails.application.configure do
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("APP_HOST", "example.com"),
+    protocol: "https"
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/db/migrate/20260220100000_add_reply_notification_settings_to_users_and_comments.rb
+++ b/db/migrate/20260220100000_add_reply_notification_settings_to_users_and_comments.rb
@@ -1,0 +1,10 @@
+class AddReplyNotificationSettingsToUsersAndComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :email, :string
+    add_column :users, :email_notifications_enabled, :boolean, null: false, default: false
+    add_index :users, :email
+
+    add_reference :comments, :user, foreign_key: true
+    add_reference :comments, :parent_comment, foreign_key: { to_table: :comments }
+  end
+end

--- a/db/migrate/20260220100010_create_comment_reply_notifications.rb
+++ b/db/migrate/20260220100010_create_comment_reply_notifications.rb
@@ -1,0 +1,18 @@
+class CreateCommentReplyNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :comment_reply_notifications do |t|
+      t.references :recipient_user, null: false, foreign_key: { to_table: :users }
+      t.references :comment, null: false, foreign_key: true
+      t.references :parent_comment, null: false, foreign_key: { to_table: :comments }
+      t.integer :status, null: false, default: 0
+      t.datetime :sent_at
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :comment_reply_notifications, :created_at
+    add_index :comment_reply_notifications, :status
+    add_index :comment_reply_notifications, :comment_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_18_090000) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_20_100010) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,9 +48,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_18_090000) do
     t.string "name", null: false
     t.text "bio"
     t.string "owner_token_digest", null: false
+    t.string "email"
+    t.boolean "email_notifications_enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_users_on_created_at"
+    t.index ["email"], name: "index_users_on_email"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -76,12 +79,37 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_18_090000) do
     t.string "author_name", null: false
     t.text "body", null: false
     t.boolean "approved", default: true, null: false
+    t.bigint "user_id"
+    t.bigint "parent_comment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["approved"], name: "index_comments_on_approved"
     t.index ["created_at"], name: "index_comments_on_created_at"
+    t.index ["parent_comment_id"], name: "index_comments_on_parent_comment_id"
     t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+    t.foreign_key "comments", column: "parent_comment_id"
     t.foreign_key "posts"
+    t.foreign_key "users"
+  end
+
+  create_table "comment_reply_notifications", force: :cascade do |t|
+    t.bigint "recipient_user_id", null: false
+    t.bigint "comment_id", null: false
+    t.bigint "parent_comment_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "sent_at"
+    t.text "error_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id"], name: "index_comment_reply_notifications_on_comment_id", unique: true
+    t.index ["created_at"], name: "index_comment_reply_notifications_on_created_at"
+    t.index ["parent_comment_id"], name: "index_comment_reply_notifications_on_parent_comment_id"
+    t.index ["recipient_user_id"], name: "index_comment_reply_notifications_on_recipient_user_id"
+    t.index ["status"], name: "index_comment_reply_notifications_on_status"
+    t.foreign_key "comments"
+    t.foreign_key "comments", column: "parent_comment_id"
+    t.foreign_key "users", column: "recipient_user_id"
   end
 
   create_table "items", force: :cascade do |t|

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -2,8 +2,14 @@ require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   include ActionDispatch::TestProcess::FixtureFile
+  include ActiveJob::TestHelper
 
   fixtures :users, :posts, :comments, :notifications
+
+  setup do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
 
   test "should create comment and notification" do
     assert_difference("Comment.count", 1) do
@@ -38,6 +44,59 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to post_url(post_record, anchor: "comments")
   end
 
+  test "reply should enqueue email notification job for opted-in comment owner" do
+    parent_comment = comments(:one)
+
+    assert_difference("Comment.count", 1) do
+      assert_difference("CommentReplyNotification.count", 1) do
+        assert_enqueued_jobs 1, only: CommentReplyNotificationJob do
+          post post_comments_url(posts(:one)), params: {
+            comment: {
+              author_name: "Replier",
+              body: "Replying to this comment",
+              parent_comment_id: parent_comment.id
+            }
+          }
+        end
+      end
+    end
+
+    created_notification = CommentReplyNotification.order(:id).last
+    assert_equal parent_comment.user_id, created_notification.recipient_user_id
+    assert_equal parent_comment.id, created_notification.parent_comment_id
+  end
+
+  test "reply should not enqueue email notification job when recipient opted out" do
+    opted_out_parent = comments(:reply_one)
+
+    assert_difference("Comment.count", 1) do
+      assert_no_difference("CommentReplyNotification.count") do
+        assert_enqueued_jobs 0, only: CommentReplyNotificationJob do
+          post post_comments_url(posts(:one)), params: {
+            comment: {
+              author_name: "Replier",
+              body: "Replying without email",
+              parent_comment_id: opted_out_parent.id
+            }
+          }
+        end
+      end
+    end
+  end
+
+  test "should not create comment on draft post" do
+    assert_no_difference("Comment.count") do
+      post post_comments_url(posts(:two)), params: {
+        comment: {
+          author_name: "Tester",
+          body: "Should fail"
+        }
+      }
+    end
+
+    assert_response :not_found
+  end
+
   private
 
   def create_owned_post
@@ -63,18 +122,5 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     }
 
     Post.order(:id).last
-  end
-
-  test "should not create comment on draft post" do
-    assert_no_difference("Comment.count") do
-      post post_comments_url(posts(:two)), params: {
-        comment: {
-          author_name: "Tester",
-          body: "Should fail"
-        }
-      }
-    end
-
-    assert_response :not_found
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -48,6 +48,27 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Name", user.reload.name
   end
 
+  test "owner can enable email notifications with email address" do
+    post users_url, params: {
+      user: {
+        name: "Notify Profile",
+        bio: "Notify bio"
+      }
+    }
+    user = User.order(:id).last
+
+    patch user_url(user), params: {
+      user: {
+        email: "notify@example.com",
+        email_notifications_enabled: "1"
+      }
+    }
+
+    assert_redirected_to user_url(user)
+    assert user.reload.email_notifications_enabled?
+    assert_equal "notify@example.com", user.email
+  end
+
   test "non owner cannot edit profile" do
     get edit_user_url(users(:one))
     assert_redirected_to user_url(users(:one))

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -2,8 +2,17 @@
 
 one:
   post: one
+  user: one
   author_name: Alice
   body: Looks great!
+  approved: true
+
+reply_one:
+  post: one
+  user: two
+  parent_comment: one
+  author_name: Bob
+  body: Thanks!
   approved: true
 
 two:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,13 @@
 one:
   name: Desk Owner One
   bio: Ruby engineer who likes minimalist desk layouts.
+  email: owner1@example.com
+  email_notifications_enabled: true
   owner_token_digest: 8e69be240e1c76e8ab3259acbb2fcb540a746ef90979bd1857684cdc0ac2beeb
 
 two:
   name: Desk Owner Two
   bio: Designer focused on warm and natural desk themes.
+  email: owner2@example.com
+  email_notifications_enabled: false
   owner_token_digest: 77fb66af69028dac493d88fa3945db824f95a238342604cc9c10fd14660596db

--- a/test/jobs/comment_reply_notification_job_test.rb
+++ b/test/jobs/comment_reply_notification_job_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class CommentReplyNotificationJobTest < ActiveJob::TestCase
+  fixtures :users, :posts, :comments
+
+  setup do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  test "sends email and marks notification as sent" do
+    reply = Comment.create!(
+      post: posts(:one),
+      parent_comment: comments(:one),
+      author_name: "Replier",
+      body: "Reply body",
+      approved: true
+    )
+    notification = CommentReplyNotification.create!(
+      recipient_user: users(:one),
+      comment: reply,
+      parent_comment: comments(:one),
+      status: :pending
+    )
+
+    assert_difference -> { ActionMailer::Base.deliveries.size }, 1 do
+      CommentReplyNotificationJob.perform_now(notification.id)
+    end
+
+    assert notification.reload.status_sent?
+    assert_not_nil notification.sent_at
+  end
+
+  test "marks notification failed when recipient cannot receive emails" do
+    reply = Comment.create!(
+      post: posts(:one),
+      parent_comment: comments(:reply_one),
+      author_name: "Replier",
+      body: "Reply body",
+      approved: true
+    )
+    notification = CommentReplyNotification.create!(
+      recipient_user: users(:two),
+      comment: reply,
+      parent_comment: comments(:reply_one),
+      status: :pending
+    )
+
+    assert_no_difference -> { ActionMailer::Base.deliveries.size } do
+      CommentReplyNotificationJob.perform_now(notification.id)
+    end
+
+    assert notification.reload.status_failed?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "requires email when email notifications are enabled" do
+    user = User.new(
+      name: "Notify User",
+      bio: "Bio",
+      owner_token_digest: "digest",
+      email_notifications_enabled: true,
+      email: ""
+    )
+
+    assert_not user.valid?
+    assert_includes user.errors.attribute_names, :email
+  end
+
+  test "accepts valid email when email notifications are enabled" do
+    user = User.new(
+      name: "Notify User",
+      bio: "Bio",
+      owner_token_digest: "digest",
+      email_notifications_enabled: true,
+      email: "notify@example.com"
+    )
+
+    assert user.valid?
+  end
+end


### PR DESCRIPTION
  ## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/22  

  ## 目的

  コメント返信に気づける導線を作り、再訪率とコミュニティ内の会話継続率を改善するため、返信時のメール通知フローを実装する。

  ## 実装内容

  - 返信通知を管理する comment_reply_notifications テーブルを追加
  - コメント返信作成後に CommentReplyNotificationJob を非同期実行
  - CommentReplyMailer を追加し、日本語件名・本文（HTML/Text）で通知送信
  - ユーザーにメール通知設定（ON/OFF）と通知先メールアドレスを追加
  - 通知メール内リンクから #comment-<id> へ直接遷移できるように実装
  - 投稿詳細コメントUIに返信導線（Reply）と親コメント指定（parent_comment_id）を追加
  - 返信通知のモデル/コントローラ/ジョブ/テストを追加・更新

  ## 方法

  - DB変更
    - users に email, email_notifications_enabled を追加
    - comments に user_id, parent_comment_id を追加
    - comment_reply_notifications を新規作成（recipient/comment/parent/status/sent_at/error_message）
  - Model
    - User に通知送信可否判定 mailable_for_reply_notifications? と条件付きバリデーションを追加
    - Comment に自己参照関連（親/返信）と同一投稿チェックを追加
    - CommentReplyNotification を新規追加し status enum を定義
  - Controller/Job/Mailer
    - CommentsController#create で返信時に通知レコード作成 + Active Job enqueue
    - CommentReplyNotificationJob で送信実行、成功/失敗ステータス更新
    - CommentReplyMailer で日本語通知メール生成、コメントアンカーURLを埋め込み
  - View
    - users/_form にメール通知設定UIを追加
    - posts/show に返信導線、アンカーID、返信フォーム（親コメント指定）を追加
  - Test
    - 返信時enqueue有無、Job送信成功/失敗、ユーザー通知設定バリデーションを追加

  ## 変更箇所

  - db/migrate/20260220100000_add_reply_notification_settings_to_users_and_comments.rb
  - db/migrate/20260220100010_create_comment_reply_notifications.rb
  - db/schema.rb
  - app/models/user.rb
  - app/models/comment.rb
  - app/models/comment_reply_notification.rb
  - app/controllers/comments_controller.rb
  - app/controllers/posts_controller.rb
  - app/controllers/users_controller.rb
  - app/jobs/comment_reply_notification_job.rb
  - app/mailers/application_mailer.rb
  - app/mailers/comment_reply_mailer.rb
  - app/views/comment_reply_mailer/reply_notification.html.erb
  - app/views/comment_reply_mailer/reply_notification.text.erb
  - app/views/posts/show.html.erb
  - app/views/users/_form.html.erb
  - config/environments/production.rb
  - test/controllers/comments_controller_test.rb
  - test/controllers/users_controller_test.rb
  - test/jobs/comment_reply_notification_job_test.rb
  - test/models/user_test.rb
  - test/fixtures/comments.yml
  - test/fixtures/users.yml

  ## Testing

  - 実施済み
  - bundle exec rubocop -f github（OK）
  - 主要変更ファイルの ruby -c 構文チェック（OK）
  - 未実施
  - DB依存テスト（rails test / db:migrate を伴う確認）
  - 未実施理由
  - ローカル PostgreSQL 接続エラー（::1:5432）により実行不可