### PR TITLE
Implementing the ga4 search console

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ ADSENSE_SLOT_INDEX_BOTTOM=
 ADSENSE_SLOT_POST_BODY=
 ADSENSE_SLOT_POST_FOOTER=
 
+# Measurement (production only)
+GA4_MEASUREMENT_ID=
+SEARCH_CONSOLE_VERIFICATION_TOKEN=
+
 # Amazon Associate
 AMAZON_AFFILIATE_TAG=
 ```
@@ -76,4 +80,3 @@ AMAZON_AFFILIATE_TAG=
 - `/cookie-policy` Cookieポリシー
 - `/sitemap.xml` サイトマップ
 - `/admin/posts` 管理画面（Basic認証）
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,6 +53,19 @@ class ApplicationController < ActionController::Base
     write_owner_post_tokens(tokens)
   end
 
+  def queue_analytics_event(name, params = {})
+    event_name = name.to_s.strip
+    return if event_name.blank?
+
+    sanitized_params = params.to_h.each_with_object({}) do |(key, value), hash|
+      hash[key.to_s] = value
+    end
+
+    events = Array(flash[:analytics_events])
+    events << { name: event_name, params: sanitized_params }
+    flash[:analytics_events] = events
+  end
+
   private
 
   def owner_user_tokens

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,8 +61,10 @@ class ApplicationController < ActionController::Base
       hash[key.to_s] = value
     end
 
-    events = Array(flash[:analytics_events])
+    @queued_analytics_events ||= []
+    events = @queued_analytics_events
     events << { name: event_name, params: sanitized_params }
+    @queued_analytics_events = events
     flash[:analytics_events] = events
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -133,8 +133,10 @@ class PostsController < ApplicationController
 
   def redirect_after_save(post)
     if post.draft?
+      queue_analytics_event("post_draft_saved", post_id: post.id, trigger_action: action_name)
       redirect_to edit_post_path(post), notice: "Draft saved."
     else
+      queue_analytics_event("post_published", post_id: post.id, trigger_action: action_name)
       redirect_to post_path(post), notice: "Post published."
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,34 @@ module ApplicationHelper
 
   FALLBACK_POST_IMAGE = "default-desk.svg"
 
+  def ga4_measurement_id
+    ENV["GA4_MEASUREMENT_ID"].to_s.strip.presence
+  end
+
+  def ga4_enabled?
+    Rails.env.production? && ga4_measurement_id.present?
+  end
+
+  def search_console_verification_token
+    return unless Rails.env.production?
+
+    ENV["SEARCH_CONSOLE_VERIFICATION_TOKEN"].to_s.strip.presence
+  end
+
+  def analytics_events
+    Array(flash[:analytics_events]).filter_map do |event|
+      next unless event.is_a?(Hash)
+
+      name = event["name"] || event[:name]
+      next if name.blank?
+
+      params = event["params"] || event[:params] || {}
+      next unless params.is_a?(Hash)
+
+      { name: name.to_s, params: params }
+    end
+  end
+
   def page_title(custom_title = nil)
     base = "DeskTour Studio"
     return base if custom_title.blank?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <meta name="twitter:title" content="<%= page_title(content_for(:title)) %>">
     <meta name="twitter:description" content="<%= meta_description(content_for(:description)) %>">
     <meta name="twitter:image" content="<%= content_for(:og_image_url) || og_image_url %>">
+    <% if search_console_verification_token.present? %>
+      <meta name="google-site-verification" content="<%= search_console_verification_token %>">
+    <% end %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -29,6 +32,15 @@
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <% if ga4_enabled? %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ga4_measurement_id %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){ dataLayer.push(arguments); }
+        gtag("js", new Date());
+        gtag("config", "<%= ga4_measurement_id %>", { anonymize_ip: true });
+      </script>
+    <% end %>
     <% if recaptcha_enabled? %>
       <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <% end %>
@@ -38,22 +50,25 @@
   </head>
 
   <body class="min-h-screen bg-slate-50 text-slate-800">
+    <% tracked_events = analytics_events %>
+
     <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
       <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
         <%= link_to "DeskTour Studio", root_path, class: "text-lg font-bold text-slate-900" %>
         <div class="flex items-center gap-2 text-sm font-medium">
           <% if owned_users.any? %>
-            <%= link_to "マイプロフィール", user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100" %>
+            <%= link_to "マイプロフィール", user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
           <% else %>
-            <%= link_to "プロフィール作成", new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100" %>
+            <%= link_to "プロフィール作成", new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
           <% end %>
-          <%= link_to "投稿する", new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600" %>
+          <%= link_to "投稿する", new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
         </div>
       </div>
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6">
       <% flash.each do |type, message| %>
+        <% next if type.to_s == "analytics_events" %>
         <% tone = type.to_s == "alert" ? "border-red-300 bg-red-50 text-red-700" : "border-emerald-300 bg-emerald-50 text-emerald-700" %>
         <div class="mb-4 rounded-lg border px-4 py-3 text-sm <%= tone %>"><%= message %></div>
       <% end %>
@@ -84,5 +99,32 @@
         }
       });
     </script>
+    <% if ga4_enabled? && tracked_events.any? %>
+      <script>
+        document.addEventListener("turbo:load", () => {
+          if (typeof window.gtag !== "function") return;
+          const events = <%= raw(json_escape(tracked_events.to_json)) %>;
+          events.forEach((eventData) => {
+            window.gtag("event", eventData.name, eventData.params || {});
+          });
+        }, { once: true });
+      </script>
+    <% end %>
+    <% if ga4_enabled? %>
+      <script>
+        document.addEventListener("click", (event) => {
+          const trackedElement = event.target.closest("[data-ga-event]");
+          if (!trackedElement || typeof window.gtag !== "function") return;
+
+          const eventName = trackedElement.dataset.gaEvent;
+          if (!eventName) return;
+
+          const params = {};
+          if (trackedElement.dataset.gaCategory) params.event_category = trackedElement.dataset.gaCategory;
+          if (trackedElement.dataset.gaLabel) params.event_label = trackedElement.dataset.gaLabel;
+          window.gtag("event", eventName, params);
+        });
+      </script>
+    <% end %>
   </body>
 </html>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -13,6 +13,14 @@
   <p class="text-sm leading-7 text-slate-700">
     サービス運営、スパム対策、品質改善、広告配信最適化のために利用します。
   </p>
+  <h2 class="text-lg font-semibold text-slate-900">アクセス解析とデータ計測について</h2>
+  <p class="text-sm leading-7 text-slate-700">
+    当サイトでは、Google Analytics 4（GA4）および Google Search Console を利用し、閲覧ページ、遷移元、投稿完了などのイベントデータを計測する場合があります。これらの情報は、サイト改善と施策評価のために利用します。
+  </p>
+  <h2 class="text-lg font-semibold text-slate-900">Cookieおよび識別情報の取り扱い</h2>
+  <p class="text-sm leading-7 text-slate-700">
+    計測にはCookie等の技術が利用される場合があります。利用者はブラウザ設定によりCookieの保存・利用を制限できますが、その場合は一部機能が正しく動作しない可能性があります。
+  </p>
   <h2 class="text-lg font-semibold text-slate-900">第三者配信広告について</h2>
   <p class="text-sm leading-7 text-slate-700">
     当サイトでは将来的にGoogle AdSense等の第三者配信広告を利用する場合があります。広告配信事業者はCookieを利用してユーザーに適した広告を表示することがあります。

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -59,6 +59,8 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     created_post = Post.order(:id).last
     assert created_post.draft?
+    analytics_events = Array(flash[:analytics_events])
+    assert_equal "post_draft_saved", analytics_events.dig(0, "name") || analytics_events.dig(0, :name)
     assert_redirected_to edit_post_url(created_post)
   end
 
@@ -85,6 +87,8 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to post_url(draft_post)
     assert draft_post.reload.published?
+    analytics_events = Array(flash[:analytics_events])
+    assert_equal "post_published", analytics_events.dig(0, "name") || analytics_events.dig(0, :name)
 
     get root_url
     assert_includes @response.body, "Published Desk"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,6 +3,16 @@ require "test_helper"
 class ApplicationHelperTest < ActionView::TestCase
   fixtures :users, :posts
 
+  setup do
+    @original_ga4_measurement_id = ENV["GA4_MEASUREMENT_ID"]
+    @original_search_console_token = ENV["SEARCH_CONSOLE_VERIFICATION_TOKEN"]
+  end
+
+  teardown do
+    ENV["GA4_MEASUREMENT_ID"] = @original_ga4_measurement_id
+    ENV["SEARCH_CONSOLE_VERIFICATION_TOKEN"] = @original_search_console_token
+  end
+
   test "thumbnail variant uses webp" do
     assert_equal :webp, send(:variant_options, :thumbnail)[:format]
   end
@@ -17,5 +27,17 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "raises for unknown variant key" do
     assert_raises(ArgumentError) { send(:variant_options, :unknown) }
+  end
+
+  test "ga4 is disabled outside production environment" do
+    ENV["GA4_MEASUREMENT_ID"] = "G-TEST12345"
+
+    assert_not ga4_enabled?
+  end
+
+  test "search console verification token is nil outside production environment" do
+    ENV["SEARCH_CONSOLE_VERIFICATION_TOKEN"] = "token123"
+
+    assert_nil search_console_verification_token
   end
 end


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/23

## 目的

ユーザー行動を定量的に把握できる計測基盤を先行導入し、施策効果をデータで判断できる状態（PDCAの高速化）を作る。

## 実装内容

  - GA4測定IDを環境変数で管理する仕組みを追加
  - 本番環境のみGA4トラッキングコードをheadに埋め込み
  - Search Console所有権確認用metaタグを本番環境のみ出力
  - 主要アクションのカスタムイベント計測を追加
      - 投稿公開完了: post_published
      - 下書き保存: post_draft_saved
      - ヘッダー導線クリック: navigation_profile_click / navigation_profile_create_click / navigation_post_create_click
  - プライバシーポリシーにCookie・データ収集（GA4 / Search Console）に関する追記を追加

## 方法

  - Helperに計測用の判定・取得メソッドを実装
      - ga4_measurement_id, ga4_enabled?, search_console_verification_token, analytics_events
  - Controllerでサーバー側イベントをflash[:analytics_events]へ格納
      - ApplicationController#queue_analytics_event
      - PostsController#redirect_after_saveで公開/下書き保存イベントを積む
  - Layoutで本番限定の計測コードを有効化
      - GA4スニペットを挿入
      - google-site-verificationメタタグを出力
      - flash[:analytics_events]をgtag("event", ...)で送信
      - data-ga-*属性付きリンククリックをクライアント側で送信
  - Privacyページに計測・Cookie利用の説明を追記
  - READMEに新規ENVを追加

## 変更箇所

  - app/controllers/application_controller.rb
  - app/controllers/posts_controller.rb
  - app/helpers/application_helper.rb
  - app/views/layouts/application.html.erb
  - app/views/pages/privacy.html.erb
  - README.md
  - test/controllers/posts_controller_test.rb
  - test/helpers/application_helper_test.rb

## まとめ

  GA4とSearch Consoleの導入を本番限定で安全に有効化し、投稿公開/下書き保存/主要導線クリックのイベント計測を追加しまし
  た。あわせてプライバシーポリシーと環境変数定義も更新し、計測開始に必要な実装一式を揃えています。

## Testing

  - 実施済み
      - ruby -c（変更したRubyファイルの構文チェック）: OK
      - erb -x -T - ... | ruby -c（変更したERBの構文チェック）: OK
      - bundle exec rubocop -f github: OK（RuboCopキャッシュ作成の権限警告のみ）
  - 未実施
      - rails test（DB依存の実行テスト）