### PR TITLE
Implement automatic language detection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
   helper_method :recaptcha_enabled?,
                 :recaptcha_site_key,
                 :adsense_enabled?,
                 :owned_users,
                 :user_owner?,
-                :post_owner?
+                :post_owner?,
+                :locale_switch_path,
+                :locale_selected?
 
   private
 
@@ -82,6 +86,82 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_locale
+    selected_locale = params_locale || cookie_locale || browser_locale || I18n.default_locale.to_s
+    I18n.locale = selected_locale
+
+    # Keep selection sticky across visits. A URL param is treated as explicit user intent.
+    persist_locale(selected_locale) if params_locale.present? || cookie_locale.blank?
+  end
+
+  def locale_switch_path(locale)
+    normalized = normalize_locale(locale)
+    return request.path unless locale_supported?(normalized)
+
+    params = request.query_parameters.merge(locale: normalized)
+    query = params.to_query
+    query.present? ? "#{request.path}?#{query}" : request.path
+  end
+
+  def locale_selected?(locale)
+    I18n.locale.to_s == normalize_locale(locale)
+  end
+
+  def params_locale
+    normalize_locale(params[:locale])
+  end
+
+  def cookie_locale
+    normalize_locale(cookies[:locale])
+  end
+
+  def browser_locale
+    parse_accept_language.each do |locale|
+      return locale if locale_supported?(locale)
+
+      base_locale = locale.split("_").first
+      return base_locale if locale_supported?(base_locale)
+    end
+
+    nil
+  end
+
+  def parse_accept_language
+    header = request.headers["Accept-Language"].to_s
+
+    header.split(",").filter_map do |entry|
+      tag, weight = entry.strip.split(";q=", 2)
+      locale = normalize_locale(tag)
+      next if locale.blank?
+
+      quality = weight.present? ? weight.to_f : 1.0
+      [ locale, quality ]
+    end
+      .sort_by { |(_, quality)| -quality }
+      .map(&:first)
+  end
+
+  def persist_locale(locale)
+    cookies[:locale] = {
+      value: locale,
+      expires: 1.year.from_now,
+      same_site: :lax
+    }
+  end
+
+  def normalize_locale(value)
+    locale = value.to_s.strip.downcase
+    return nil if locale.blank? || locale == "*"
+
+    locale.tr("-", "_")
+  end
+
+  def locale_supported?(locale)
+    return false if locale.blank?
+
+    I18n.available_locales.map(&:to_s).include?(locale)
+  end
 
   def owner_user_tokens
     parse_owner_tokens(cookies.encrypted[:owner_user_tokens])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
   end
 
   def meta_description(custom_description = nil)
-    custom_description.presence || "Discover desk setup ideas and share your workspace on DeskTour Studio."
+    custom_description.presence || t("meta.default_description")
   end
 
   def canonical_url

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title><%= page_title(content_for(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -53,15 +53,20 @@
     <% tracked_events = analytics_events %>
 
     <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
-      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+      <div class="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-3 px-4 py-4 sm:flex-nowrap sm:px-6">
         <%= link_to "DeskTour Studio", root_path, class: "text-lg font-bold text-slate-900" %>
-        <div class="flex items-center gap-2 text-sm font-medium">
+        <div class="ml-auto flex items-center gap-2 text-sm font-medium">
+          <div class="rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
+            <%= link_to "日本語", locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) } %>
+            <span aria-hidden="true" class="px-1 text-slate-400">|</span>
+            <%= link_to "English", locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) } %>
+          </div>
           <% if owned_users.any? %>
-            <%= link_to "マイプロフィール", user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
           <% else %>
-            <%= link_to "プロフィール作成", new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
           <% end %>
-          <%= link_to "投稿する", new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
         </div>
       </div>
     </header>
@@ -79,9 +84,9 @@
       <div class="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between sm:px-6">
         <p>&copy; <%= Date.current.year %> DeskTour Studio</p>
         <div class="flex flex-wrap gap-4">
-          <%= link_to "利用規約", terms_path, class: "hover:text-slate-900" %>
-          <%= link_to "プライバシーポリシー", privacy_policy_path, class: "hover:text-slate-900" %>
-          <%= link_to "Cookieポリシー", cookie_policy_path, class: "hover:text-slate-900" %>
+          <%= link_to t("footer.terms"), terms_path, class: "hover:text-slate-900" %>
+          <%= link_to t("footer.privacy_policy"), privacy_policy_path, class: "hover:text-slate-900" %>
+          <%= link_to t("footer.cookie_policy"), cookie_policy_path, class: "hover:text-slate-900" %>
         </div>
       </div>
     </footer>
@@ -93,9 +98,9 @@
         const target = button.getAttribute("data-copy-url");
         try {
           await navigator.clipboard.writeText(target);
-          button.textContent = "URLをコピーしました";
+          button.textContent = "<%= j(t('clipboard.copy_success')) %>";
         } catch (_) {
-          button.textContent = "コピーに失敗しました";
+          button.textContent = "<%= j(t('clipboard.copy_failed')) %>";
         }
       });
     </script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,9 @@ module DesktourStudio
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.i18n.available_locales = %i[ja en]
+    config.i18n.default_locale = :ja
+    config.i18n.fallbacks = true
   end
 end

--- a/config/locales/datetime.ja.yml
+++ b/config/locales/datetime.ja.yml
@@ -1,0 +1,7 @@
+ja:
+  date:
+    formats:
+      default: "%Y-%m-%d"
+  time:
+    formats:
+      short: "%Y-%m-%d %H:%M"

--- a/config/locales/ui.en.yml
+++ b/config/locales/ui.en.yml
@@ -1,0 +1,16 @@
+en:
+  language:
+    switch_aria: "Language switch"
+  navigation:
+    my_profile: "My Profile"
+    create_profile: "Create Profile"
+    create_post: "Create Post"
+  footer:
+    terms: "Terms"
+    privacy_policy: "Privacy Policy"
+    cookie_policy: "Cookie Policy"
+  clipboard:
+    copy_success: "URL copied."
+    copy_failed: "Failed to copy."
+  meta:
+    default_description: "Discover desk setup ideas and share your workspace on DeskTour Studio."

--- a/config/locales/ui.ja.yml
+++ b/config/locales/ui.ja.yml
@@ -1,0 +1,16 @@
+ja:
+  language:
+    switch_aria: "言語切り替え"
+  navigation:
+    my_profile: "マイプロフィール"
+    create_profile: "プロフィール作成"
+    create_post: "投稿する"
+  footer:
+    terms: "利用規約"
+    privacy_policy: "プライバシーポリシー"
+    cookie_policy: "Cookieポリシー"
+  clipboard:
+    copy_success: "URLをコピーしました"
+    copy_failed: "コピーに失敗しました"
+  meta:
+    default_description: "DeskTour Studioでデスクセットアップのアイデアを探し、あなたのワークスペースを共有しましょう。"

--- a/test/controllers/locale_selection_test.rb
+++ b/test/controllers/locale_selection_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class LocaleSelectionTest < ActionDispatch::IntegrationTest
+  test "auto-detects locale from accept-language when no preference exists" do
+    get root_url, headers: { "Accept-Language" => "en-US,en;q=0.9,ja;q=0.8" }
+
+    assert_response :success
+    assert_includes @response.body, I18n.t("navigation.create_post", locale: :en)
+    assert_equal "en", cookies[:locale]
+  end
+
+  test "explicit locale param overrides browser language and is persisted" do
+    get root_url(locale: :ja), headers: { "Accept-Language" => "en-US,en;q=0.9" }
+
+    assert_response :success
+    assert_includes @response.body, I18n.t("navigation.create_post", locale: :ja)
+    assert_equal "ja", cookies[:locale]
+  end
+
+  test "saved locale in cookie takes precedence on subsequent visits" do
+    get root_url(locale: :ja)
+    assert_equal "ja", cookies[:locale]
+
+    get root_url, headers: { "Accept-Language" => "en-US,en;q=0.9" }
+    assert_response :success
+    assert_includes @response.body, I18n.t("navigation.create_post", locale: :ja)
+  end
+
+  test "language toggle renders both options in header" do
+    get root_url
+
+    assert_response :success
+    assert_includes @response.body, "日本語"
+    assert_includes @response.body, "English"
+    assert_includes @response.body, "locale=ja"
+    assert_includes @response.body, "locale=en"
+  end
+end


### PR DESCRIPTION
  ## Issue 
  https://github.com/hamasaki-code/DeskTour-Studio/issues/30

  ## 目的

  - ブラウザの言語設定から初期言語を自動判定し、ユーザーの手動切替も可能にする
  - ヘッダー右上で 日本語 | English を常時切替できるようにする
  - 一度選んだ言語を次回訪問時も維持する

  ## 実装内容

  - Accept-Language を使った自動ロケール判定を追加
  - ヘッダーに言語トグル（日本語 | English）を追加
  - 選択言語を cookies[:locale] に1年間保存
  - i18n設定（利用可能ロケール・デフォルトロケール）を追加
  - ヘッダー/フッター/コピー通知の文言を翻訳キーに置換
  - ロケール選択の挙動を検証するコントローラテストを追加

  ## 方法

  - ロケール決定順序を以下に定義
    params[:locale] > cookie > Accept-Language > default(:ja)
  - Accept-Language は q 値を考慮して優先順に解析
  - en-US のような地域付きタグは en にフォールバックして判定
  - トグルリンクは現在URLのクエリを保持したまま locale=ja/en を付与
  - 手動切替（URLパラメータ）時はCookieを更新して永続化

  ## 変更箇所

  - config/application.rb
      - config.i18n.available_locales = %i[ja en]
      - config.i18n.default_locale = :ja
      - config.i18n.fallbacks = true
  - app/controllers/application_controller.rb
      - before_action :set_locale 追加
      - set_locale, parse_accept_language, persist_locale, locale_switch_path, locale_selected? など追加
  - app/views/layouts/application.html.erb
      - <html lang="<%= I18n.locale %>"> 追加
      - ヘッダー右上に言語トグル追加
      - ヘッダー/フッター文言を t(...) 化
      - コピー結果文言を t(...) 化
  - app/helpers/application_helper.rb
      - meta_description を t("meta.default_description") 利用に変更
  - config/locales/ui.ja.yml（新規）
  - config/locales/ui.en.yml（新規）
  - test/controllers/locale_selection_test.rb（新規）
      - 自動判定、明示切替、Cookie優先、トグル描画を検証

  ## まとめ

  - 要件の3点（自動判定、ヘッダートグル、永続化）を実装済みです。
  - 既存レイアウトにも自然に統合し、言語切替のUI/UXを改善しています。
  - テストも追加済みで、挙動確認しやすい状態です。

  ## Testing

  - 実施済み
      - ruby -c app/controllers/application_controller.rb → Syntax OK
      - ruby -c app/helpers/application_helper.rb → Syntax OK
      - ruby -c test/controllers/locale_selection_test.rb → Syntax OK
      - ruby -e "require 'yaml'; YAML.load_file('config/locales/ui.ja.yml'); YAML.load_file('config/locales/ui.en.yml')"
        → locales ok
  - 未実施（環境要因）
      - ruby bin/rails test ... は PostgreSQL サービス停止（127.0.0.1:5433 接続不可）のため未完了