### PR TITLE
Implement improvements to the form experience and validation feedback

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,44 @@
 @import "tailwindcss";
+
+@layer base {
+  :root {
+    --ds-line-height-reading: 1.58;
+    --ds-letter-spacing-body: 0;
+    --ds-letter-spacing-heading: -0.012em;
+    --ds-letter-spacing-nav: 0.002em;
+  }
+
+  html[lang="ja"] {
+    --ds-line-height-reading: 1.75;
+    --ds-letter-spacing-body: 0.012em;
+    --ds-letter-spacing-heading: 0.015em;
+    --ds-letter-spacing-nav: 0.01em;
+  }
+
+  html[lang="en"] {
+    --ds-line-height-reading: 1.58;
+    --ds-letter-spacing-body: 0;
+    --ds-letter-spacing-heading: -0.012em;
+    --ds-letter-spacing-nav: 0.002em;
+  }
+
+  body {
+    letter-spacing: var(--ds-letter-spacing-body);
+  }
+
+  h1,
+  h2,
+  h3 {
+    letter-spacing: var(--ds-letter-spacing-heading);
+  }
+}
+
+@layer utilities {
+  .leading-reading {
+    line-height: var(--ds-line-height-reading);
+  }
+
+  .tracking-nav {
+    letter-spacing: var(--ds-letter-spacing-nav);
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
     <header class="border-b border-slate-200 bg-white/90 backdrop-blur">
       <div class="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-3 px-4 py-4 sm:flex-nowrap sm:px-6">
         <%= link_to "DeskTour Studio", root_path, class: "text-lg font-bold text-slate-900" %>
-        <div class="ml-auto flex items-center gap-2 text-sm font-medium">
+        <div class="ml-auto flex items-center gap-2 text-sm font-medium tracking-nav">
           <div class="rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
             <%= link_to "日本語", locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) } %>
             <span aria-hidden="true" class="px-1 text-slate-400">|</span>

--- a/app/views/pages/cookie.html.erb
+++ b/app/views/pages/cookie.html.erb
@@ -2,16 +2,16 @@
 
 <section class="mx-auto w-full max-w-4xl space-y-5 rounded-xl border border-slate-200 bg-white p-6">
   <h1 class="text-2xl font-bold text-slate-900">Cookieポリシー</h1>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     当サイトでは、表示最適化・アクセス解析・広告配信のためCookieを利用します。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">利用目的</h2>
-  <ul class="list-disc space-y-2 pl-5 text-sm leading-7 text-slate-700">
+  <ul class="list-disc space-y-2 pl-5 text-sm leading-reading text-slate-700">
     <li>いいね機能の重複防止</li>
     <li>サイト利用状況の分析</li>
     <li>第三者配信広告の最適化（導入時）</li>
   </ul>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     ブラウザ設定でCookieを無効化できますが、一部機能が利用できない場合があります。
   </p>
 </section>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,27 +2,27 @@
 
 <section class="mx-auto w-full max-w-4xl space-y-5 rounded-xl border border-slate-200 bg-white p-6">
   <h1 class="text-2xl font-bold text-slate-900">プライバシーポリシー</h1>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     DeskTour Studio（以下「当サイト」）は、利用者の個人情報を適切に取り扱います。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">取得する情報</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     投稿時の名前、コメント内容、アクセス解析情報（Cookieを含む）を取得する場合があります。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">利用目的</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     サービス運営、スパム対策、品質改善、広告配信最適化のために利用します。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">アクセス解析とデータ計測について</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     当サイトでは、Google Analytics 4（GA4）および Google Search Console を利用し、閲覧ページ、遷移元、投稿完了などのイベントデータを計測する場合があります。これらの情報は、サイト改善と施策評価のために利用します。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">Cookieおよび識別情報の取り扱い</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     計測にはCookie等の技術が利用される場合があります。利用者はブラウザ設定によりCookieの保存・利用を制限できますが、その場合は一部機能が正しく動作しない可能性があります。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">第三者配信広告について</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     当サイトでは将来的にGoogle AdSense等の第三者配信広告を利用する場合があります。広告配信事業者はCookieを利用してユーザーに適した広告を表示することがあります。
   </p>
 </section>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,17 +2,17 @@
 
 <section class="mx-auto w-full max-w-4xl space-y-5 rounded-xl border border-slate-200 bg-white p-6">
   <h1 class="text-2xl font-bold text-slate-900">利用規約</h1>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     当サイトの利用者は、本規約に同意したものとみなします。
   </p>
   <h2 class="text-lg font-semibold text-slate-900">禁止事項</h2>
-  <ul class="list-disc space-y-2 pl-5 text-sm leading-7 text-slate-700">
+  <ul class="list-disc space-y-2 pl-5 text-sm leading-reading text-slate-700">
     <li>権利を有しない画像の投稿</li>
     <li>誹謗中傷・差別的表現・公序良俗に反する内容の投稿</li>
     <li>スパム行為、虚偽情報の投稿</li>
   </ul>
   <h2 class="text-lg font-semibold text-slate-900">アフィリエイトリンクについて</h2>
-  <p class="text-sm leading-7 text-slate-700">
+  <p class="text-sm leading-reading text-slate-700">
     当サイトは一部ページでアフィリエイトプログラムを利用する場合があります。リンク経由で商品購入が行われると、運営者に報酬が発生することがあります。
   </p>
 </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,7 @@
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-white p-6">
-    <p class="whitespace-pre-wrap text-sm leading-7 text-slate-700"><%= @post.description %></p>
+    <p class="whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @post.description %></p>
   </div>
 
   <% if @post.tags.any? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
       <div>
         <h1 class="text-2xl font-bold text-slate-900"><%= @user.name %></h1>
         <% if @user.bio.present? %>
-          <p class="mt-3 whitespace-pre-wrap text-sm leading-7 text-slate-700"><%= @user.bio %></p>
+          <p class="mt-3 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @user.bio %></p>
         <% else %>
           <p class="mt-3 text-sm text-slate-500">No profile description yet.</p>
         <% end %>

--- a/config/locales/zz_navigation.en.yml
+++ b/config/locales/zz_navigation.en.yml
@@ -1,0 +1,5 @@
+en:
+  navigation:
+    my_profile: "My Profile"
+    create_profile: "New Profile"
+    create_post: "Create Post"

--- a/config/locales/zz_navigation.ja.yml
+++ b/config/locales/zz_navigation.ja.yml
@@ -1,0 +1,5 @@
+ja:
+  navigation:
+    my_profile: "マイページ"
+    create_profile: "プロフィール作成"
+    create_post: "投稿する"


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/33


## 目的

  日本語/英語それぞれで可読性を上げるために、言語特性に合わせたタイポグラフィ調整（行間・字間）と、ナビゲーションラベルの短文化を行う。

  ## 実装内容

  - 言語別の行間を CSS 変数で管理し、ja=1.75 / en=1.58 を適用。
  - 見出し・本文・ナビゲーションの字間を CSS 変数で調整。
  - ナビゲーション文言を 2〜3語に短文化（例: New Profile / マイページ）。
  - 既存の本文 leading-7 を可変行間クラスへ置換。


  ## 方法

  - Tailwind の入力 CSS に @layer base / @layer utilities を追加し、html[lang] で言語別変数を切替。
  - 新ユーティリティ leading-reading と tracking-nav を作成して既存ビューに適用。
  - 既存ロケールファイルの文字コード問題を避けるため、上書き用ロケールファイルを追加してナビ文言を反映。


  ## 変更箇所

  - app/assets/tailwind/application.css
      - --ds-line-height-reading、--ds-letter-spacing-* 追加
      - leading-reading、tracking-nav 追加
  - app/views/layouts/application.html.erb
      - ナビゲーションコンテナに tracking-nav 追加
  - app/views/pages/privacy.html.erb
      - leading-7 -> leading-reading
  - app/views/pages/cookie.html.erb
      - leading-7 -> leading-reading
  - app/views/pages/terms.html.erb
      - leading-7 -> leading-reading
  - app/views/posts/show.html.erb
      - leading-7 -> leading-reading
  - app/views/users/show.html.erb
      - leading-7 -> leading-reading
  - config/locales/zz_navigation.en.yml
      - navigation.create_profile: "New Profile" など
  - config/locales/zz_navigation.ja.yml
      - navigation.my_profile: "マイページ" など


  ## まとめ

  言語ごとの可読性に合わせて行間・字間を変えられる構成に変更し、ナビ文言も短文化した。
  今後は CSS 変数とロケール上書きファイルの更新だけで微調整できる。


  ## Testing

  - 実施: config/locales/*.yml の YAML 読み込み確認（locale yaml ok）。
  - 未実施: rails test / test:system（ローカルで PostgreSQL 接続不可のため）。