### PR TITLE
Implementing standardized content formats and visual semantics

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,23 @@ module ApplicationHelper
   }.freeze
 
   FALLBACK_POST_IMAGE = "default-desk.svg"
+  FLASH_VISUALS = {
+    "notice" => {
+      level: :success,
+      icon: :check_circle,
+      label_key: "status_levels.success"
+    },
+    "warning" => {
+      level: :warning,
+      icon: :exclamation_triangle,
+      label_key: "status_levels.warning"
+    },
+    "alert" => {
+      level: :error,
+      icon: :x_circle,
+      label_key: "status_levels.error"
+    }
+  }.freeze
 
   def ga4_measurement_id
     ENV["GA4_MEASUREMENT_ID"].to_s.strip.presence
@@ -96,6 +113,94 @@ module ApplicationHelper
 
   def threads_share_url(post)
     "https://www.threads.net/intent/post?text=#{ERB::Util.url_encode("#{post_share_text(post)} #{post_share_url(post)}")}"
+  end
+
+  def localized_number(value)
+    number_with_delimiter(value, locale: I18n.locale)
+  end
+
+  def flash_visual(type)
+    FLASH_VISUALS.fetch(type.to_s, FLASH_VISUALS.fetch("notice"))
+  end
+
+  def status_badge(level:, label:, icon:)
+    tones = {
+      success: "border-emerald-300 bg-emerald-50 text-emerald-700",
+      warning: "border-amber-300 bg-amber-50 text-amber-800",
+      error: "border-red-300 bg-red-50 text-red-700",
+      info: "border-blue-200 bg-blue-50 text-blue-700"
+    }
+    tone = tones.fetch(level.to_sym, tones.fetch(:info))
+
+    content_tag(:span, class: "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium #{tone}") do
+      safe_join([ ui_icon(icon, class_name: "h-3.5 w-3.5"), content_tag(:span, label) ])
+    end
+  end
+
+  def report_status_badge(status)
+    variants = {
+      "queued" => { level: :warning, icon: :clock, label_key: "report_status.queued" },
+      "dismissed" => { level: :info, icon: :minus_circle, label_key: "report_status.dismissed" },
+      "restored" => { level: :success, icon: :check_circle, label_key: "report_status.restored" }
+    }
+    visual = variants.fetch(status.to_s, { level: :info, icon: :information_circle, label_key: "report_status.unknown" })
+
+    status_badge(level: visual[:level], icon: visual[:icon], label: t(visual[:label_key]))
+  end
+
+  def post_status_badge(status)
+    variants = {
+      "draft" => { level: :warning, icon: :clock, label_key: "post_status.draft" },
+      "published" => { level: :success, icon: :check_circle, label_key: "post_status.published" },
+      "hidden" => { level: :error, icon: :x_circle, label_key: "post_status.hidden" }
+    }
+    visual = variants.fetch(status.to_s, { level: :info, icon: :information_circle, label_key: "post_status.unknown" })
+
+    status_badge(level: visual[:level], icon: visual[:icon], label: t(visual[:label_key]))
+  end
+
+  def ui_icon(name, class_name: "h-4 w-4")
+    path_attrs = { "stroke-linecap": "round", "stroke-linejoin": "round" }
+    paths = case name.to_sym
+    when :check_circle
+      [
+        tag.path(path_attrs.merge(d: "m9 12.75 2.25 2.25 3.75-3.75")),
+        tag.path(path_attrs.merge(d: "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"))
+      ]
+    when :exclamation_triangle
+      [
+        tag.path(path_attrs.merge(d: "M12 9v3.75m0 3.75h.008v.008H12v-.008Z")),
+        tag.path(path_attrs.merge(d: "m10.29 3.86-7.31 12.65A2 2 0 0 0 4.69 19.5h14.62a2 2 0 0 0 1.73-2.99L13.73 3.86a2 2 0 0 0-3.46 0Z"))
+      ]
+    when :x_circle
+      [
+        tag.path(path_attrs.merge(d: "m14.25 9.75-4.5 4.5m0-4.5 4.5 4.5")),
+        tag.path(path_attrs.merge(d: "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"))
+      ]
+    when :information_circle
+      [
+        tag.path(path_attrs.merge(d: "m11.25 11.25.041-.02a.75.75 0 0 1 1.06.852l-.708 2.836a.75.75 0 0 0 1.06.852l.041-.02")),
+        tag.path(path_attrs.merge(d: "M12 8.25h.008v.008H12V8.25Z")),
+        tag.path(path_attrs.merge(d: "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"))
+      ]
+    when :clock
+      [
+        tag.path(path_attrs.merge(d: "M12 6v6l4 2")),
+        tag.path(path_attrs.merge(d: "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"))
+      ]
+    when :minus_circle
+      [
+        tag.path(path_attrs.merge(d: "M9.75 12h4.5")),
+        tag.path(path_attrs.merge(d: "M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"))
+      ]
+    when :heart
+      [ tag.path(path_attrs.merge(d: "m21 8.25c0-2.485-2.015-4.5-4.5-4.5-1.74 0-3.248.99-4 2.438A4.484 4.484 0 0 0 8.5 3.75C6.015 3.75 4 5.765 4 8.25c0 4.025 4.5 7.5 8 10.5 3.5-3 8-6.475 8-10.5Z"))
+      ]
+    else
+      [ tag.path(path_attrs.merge(d: "M12 6v6m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z")) ]
+    end
+
+    content_tag(:svg, safe_join(paths), xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", stroke: "currentColor", "stroke-width": "1.8", class: class_name, "aria-hidden": "true")
   end
 
   private

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -25,8 +25,8 @@
                 <span><%= post.title.presence || "(Untitled draft)" %></span>
               <% end %>
             </td>
-            <td class="px-4 py-3"><%= post.status %></td>
-            <td class="px-4 py-3"><%= post.comments.count %></td>
+            <td class="px-4 py-3"><%= post_status_badge(post.status) %></td>
+            <td class="px-4 py-3"><%= localized_number(post.comments.count) %></td>
             <td class="px-4 py-3">
               <div class="flex flex-wrap gap-2">
                 <% next_status = post.published? ? "draft" : "published" %>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -73,7 +73,7 @@
             <tr class="border-t border-slate-200">
               <td class="px-4 py-3"><%= report.post&.title.presence || "(Deleted post)" %></td>
               <td class="px-4 py-3"><%= Report::REASON_LABELS.fetch(report.reason.to_sym) %></td>
-              <td class="px-4 py-3"><%= report.status %></td>
+              <td class="px-4 py-3"><%= report_status_badge(report.status) %></td>
               <td class="px-4 py-3"><%= report.reviewed_at.present? ? l(report.reviewed_at, format: :short) : "-" %></td>
             </tr>
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,8 +74,23 @@
     <main class="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6">
       <% flash.each do |type, message| %>
         <% next if type.to_s == "analytics_events" %>
-        <% tone = type.to_s == "alert" ? "border-red-300 bg-red-50 text-red-700" : "border-emerald-300 bg-emerald-50 text-emerald-700" %>
-        <div class="mb-4 rounded-lg border px-4 py-3 text-sm <%= tone %>"><%= message %></div>
+        <% visual = flash_visual(type) %>
+        <% tone = case visual[:level]
+        when :error
+          "border-red-300 bg-red-50 text-red-700"
+        when :warning
+          "border-amber-300 bg-amber-50 text-amber-800"
+        else
+          "border-emerald-300 bg-emerald-50 text-emerald-700"
+        end %>
+        <% role = visual[:level] == :error ? "alert" : "status" %>
+        <% live = visual[:level] == :error ? "assertive" : "polite" %>
+        <div class="mb-4 rounded-lg border px-4 py-3 text-sm <%= tone %>" role="<%= role %>" aria-live="<%= live %>">
+          <div class="flex items-start gap-2">
+            <%= status_badge(level: visual[:level], icon: visual[:icon], label: t(visual[:label_key])) %>
+            <p class="pt-0.5"><%= message %></p>
+          </div>
+        </div>
       <% end %>
       <%= yield %>
     </main>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -4,9 +4,10 @@
 <section class="mx-auto w-full max-w-3xl space-y-6">
     <div>
         <h1 class="text-2xl font-bold text-slate-900">Edit Post</h1>
-        <p class="mt-2 text-sm text-slate-600">
-            This post is currently <strong><%= @post.status %></strong>.
-        </p>
+        <div class="mt-2 flex items-center gap-2 text-sm text-slate-600">
+            <span>This post is currently</span>
+            <%= post_status_badge(@post.status) %>
+        </div>
     </div>
 
     <div class="rounded-xl border border-slate-200 bg-white p-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -35,7 +35,10 @@
               <h2 class="text-base font-semibold text-slate-900">
                 <%= link_to post.title, post_path(post), class: "hover:text-blue-600" %>
               </h2>
-              <span class="text-xs text-slate-500">♥ <%= post.likes_count %></span>
+              <span class="inline-flex items-center gap-1 text-xs text-slate-500">
+                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
+              </span>
             </div>
             <p class="text-xs text-slate-500">
               投稿者:

--- a/app/views/posts/notifications.html.erb
+++ b/app/views/posts/notifications.html.erb
@@ -22,7 +22,10 @@
             <p class="mt-1 text-xs text-slate-500">
               <%= l(notification.created_at, format: :short) %>
               <% if notification.read_at.present? %>
-                <span class="ml-2 rounded bg-emerald-50 px-2 py-0.5 text-emerald-700">既読</span>
+                <span class="ml-2 inline-flex items-center gap-1 rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-emerald-700">
+                  <%= ui_icon(:check_circle, class_name: "h-3.5 w-3.5") %>
+                  <span><%= t("notification_labels.read") %></span>
+                </span>
               <% end %>
             </p>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -39,7 +39,10 @@
   <section class="rounded-xl border border-slate-200 bg-white p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <h2 class="text-lg font-semibold text-slate-900">Related items</h2>
-      <span class="text-sm text-slate-500">Likes: <%= @post.likes_count %></span>
+      <span class="inline-flex items-center gap-1 text-sm text-slate-500">
+        <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+        <span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span>
+      </span>
     </div>
 
     <% if @post.items.any? %>
@@ -73,7 +76,7 @@
   <% if post_owner?(@post) %>
     <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
       <%= link_to "Edit", edit_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
-      <%= link_to "Notifications (#{@unread_notifications_count})", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= link_to "Notifications (#{localized_number(@unread_notifications_count)})", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
       <%= button_to "Delete", post_path(@post), method: :delete, data: { turbo_confirm: "Delete this post?" }, class: "rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
     </div>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,10 @@
               <h3 class="text-base font-semibold text-slate-900">
                 <%= link_to post.title, post_path(post), class: "hover:text-blue-600" %>
               </h3>
-              <span class="text-xs text-slate-500">Likes: <%= post.likes_count %></span>
+              <span class="inline-flex items-center gap-1 text-xs text-slate-500">
+                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
+              </span>
             </div>
             <p class="mt-2 text-sm text-slate-600"><%= truncate(post.description, length: 140) %></p>
           </article>

--- a/config/locales/datetime.en.yml
+++ b/config/locales/datetime.en.yml
@@ -1,0 +1,8 @@
+en:
+  date:
+    formats:
+      default: "%b %-d, %Y"
+      long: "%b %-d, %Y"
+  time:
+    formats:
+      short: "%b %-d, %Y %H:%M"

--- a/config/locales/datetime.ja.yml
+++ b/config/locales/datetime.ja.yml
@@ -1,7 +1,8 @@
 ja:
   date:
     formats:
-      default: "%Y-%m-%d"
+      default: "%Y/%m/%d"
+      long: "%Y/%m/%d"
   time:
     formats:
-      short: "%Y-%m-%d %H:%M"
+      short: "%Y/%m/%d %H:%M"

--- a/config/locales/ui_semantics.en.yml
+++ b/config/locales/ui_semantics.en.yml
@@ -1,0 +1,24 @@
+en:
+  number:
+    format:
+      delimiter: ","
+      separator: "."
+  metrics:
+    likes: "Likes"
+  status_levels:
+    success: "Success"
+    warning: "Warning"
+    error: "Error"
+    info: "Info"
+  report_status:
+    queued: "Queued"
+    dismissed: "Dismissed"
+    restored: "Restored"
+    unknown: "Unknown"
+  post_status:
+    draft: "Draft"
+    published: "Published"
+    hidden: "Hidden"
+    unknown: "Unknown"
+  notification_labels:
+    read: "Read"

--- a/config/locales/ui_semantics.ja.yml
+++ b/config/locales/ui_semantics.ja.yml
@@ -1,0 +1,24 @@
+ja:
+  number:
+    format:
+      delimiter: ","
+      separator: "."
+  metrics:
+    likes: "いいね"
+  status_levels:
+    success: "成功"
+    warning: "警告"
+    error: "エラー"
+    info: "情報"
+  report_status:
+    queued: "確認待ち"
+    dismissed: "却下"
+    restored: "復元"
+    unknown: "不明"
+  post_status:
+    draft: "下書き"
+    published: "公開"
+    hidden: "非表示"
+    unknown: "不明"
+  notification_labels:
+    read: "既読"


### PR DESCRIPTION
  ## Issue

https://github.com/hamasaki-code/DeskTour-Studio/issues/35  

  
  ## 目的

  日付・数値をローカライズし、ステータス伝達を色依存から脱却して、グローバルに通用するアイコンとテキストで情報スキャン性とアクセシビリティを向上させる。


  ## 実装内容

  - I18n で日付フォーマットを言語別に定義（ja: 2026/02/22, en: Feb 22, 2026）。
  - 数値の桁区切りをロケール準拠で表示する localized_number を追加。
  - ステータス表示を「色 + アイコン + テキスト」に統一する共通バッジを実装。
  - フラッシュメッセージをステータスラベル付きに変更し、role / aria-live を付与。
  - いいね等の記号表現を汎用SVGアイコンに置換。


  ## 方法

  - ApplicationHelper に共通UIヘルパーを追加。
      - localized_number
      - status_badge
      - report_status_badge
      - post_status_badge
      - ui_icon
      - flash_visual
  - ロケールファイルを追加・更新して、日付/数値/ステータス文言を定義。
  - 各ビューで直接文字列や記号を出していた箇所を、ヘルパー経由の表示に置換。


  ## 変更箇所

  - app/helpers/application_helper.rb
  - app/views/layouts/application.html.erb
  - app/views/posts/index.html.erb
  - app/views/posts/show.html.erb
  - app/views/users/show.html.erb
  - app/views/posts/edit.html.erb
  - app/views/posts/notifications.html.erb
  - app/views/admin/posts/index.html.erb
  - app/views/admin/reports/index.html.erb
  - config/locales/datetime.ja.yml（更新）
  - config/locales/datetime.en.yml（追加）
  - config/locales/ui_semantics.en.yml（追加）
  - config/locales/ui_semantics.ja.yml（追加）


  ## まとめ

  ローカライズ（日付・数値）と視覚セマンティクス（アイコン＋テキスト）を共通化し、画面全体の一貫性と可読性を改善した。今後はロケールとヘルパーの更新だけで拡張できる構成になっている。


  ## Testing

  - 実施:
      - ruby -c app/helpers/application_helper.rb（構文OK）
      - config/locales/*.yml のYAMLロード確認（locale yaml ok）
      - 日付/数値フォーマット確認（ja: 2026/02/22, en: Feb 22, 2026, 1,234,567）
  - 未実施:
      - rails test / test:system（DB接続が必要なため未実行）