### PR TITLE
Implement adaptive layout for mobile and multilingual cards

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -41,4 +41,24 @@
   .tracking-nav {
     letter-spacing: var(--ds-letter-spacing-nav);
   }
+
+  .ds-line-clamp-2 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  .tap-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  @media (max-width: 640px) {
+    .tap-target {
+      padding-top: 0.625rem;
+      padding-bottom: 0.625rem;
+    }
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,16 +62,16 @@
             <%= link_to "English", locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) } %>
           </div>
           <% if owned_users.any? %>
-            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
           <% else %>
-            <%= link_to t("navigation.create_profile"), new_user_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target hidden items-center rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 sm:inline-flex", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
         </div>
       </div>
     </header>
 
-    <main class="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6">
+    <main class="mx-auto w-full max-w-6xl px-4 pb-28 pt-8 sm:px-6 sm:pb-8">
       <% flash.each do |type, message| %>
         <% next if type.to_s == "analytics_events" %>
         <% visual = flash_visual(type) %>
@@ -94,6 +94,14 @@
       <% end %>
       <%= yield %>
     </main>
+
+    <% unless controller_name == "posts" && action_name == "show" %>
+      <div class="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
+        <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target flex w-full items-center justify-center rounded-xl bg-blue-500 px-4 text-sm font-semibold text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
+        </div>
+      </div>
+    <% end %>
 
     <footer class="mt-10 border-t border-slate-200 bg-white">
       <div class="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-600 sm:flex-row sm:items-center sm:justify-between sm:px-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,8 +16,8 @@
       <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "テーマ" %>
       <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "タグ" %>
       <div class="sm:col-span-4 flex flex-wrap gap-2">
-        <%= submit_tag "検索する", class: "rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700" %>
-        <%= link_to "リセット", root_path, class: "rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
+        <%= submit_tag "検索する", class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700" %>
+        <%= link_to "リセット", root_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
       </div>
     <% end %>
   </div>
@@ -25,17 +25,17 @@
   <% if @posts.any? %>
     <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
-        <article class="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
           <%= link_to post_path(post), class: "block" do %>
             <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-48 w-full object-cover") %>
           <% end %>
 
-          <div class="space-y-3 p-4">
+          <div class="flex h-full flex-col space-y-3 p-4">
             <div class="flex items-start justify-between gap-3">
-              <h2 class="text-base font-semibold text-slate-900">
-                <%= link_to post.title, post_path(post), class: "hover:text-blue-600" %>
+              <h2 class="min-w-0 flex-1 text-base font-semibold text-slate-900">
+                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600" %>
               </h2>
-              <span class="inline-flex items-center gap-1 text-xs text-slate-500">
+              <span class="inline-flex shrink-0 items-center gap-1 text-xs text-slate-500">
                 <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
                 <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
               </span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -61,23 +61,37 @@
     <% end %>
   </section>
 
-  <div class="flex flex-wrap items-center gap-3">
-    <%= button_to "Like", like_post_path(@post), method: :post, class: "rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" %>
-    <%= link_to "Share on X", x_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
-    <%= link_to "Share on Threads", threads_share_url(@post), target: "_blank", rel: "noopener", class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
-    <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">Copy URL</button>
+  <div class="hidden flex-wrap items-center gap-3 sm:flex">
+    <%= button_to "Like", like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" %>
+    <%= link_to "Share on X", x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+    <%= link_to "Share on Threads", threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+    <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="tap-target rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">Copy URL</button>
     <% unless post_owner?(@post) %>
-      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" class="rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
+      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
         Report
       </button>
     <% end %>
   </div>
 
+  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
+    <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
+      <div class="flex items-center gap-2 overflow-x-auto pb-1">
+        <%= button_to "Like", like_post_path(@post), method: :post, form: { class: "shrink-0" }, class: "tap-target whitespace-nowrap rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" %>
+        <%= link_to "Share on X", x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex shrink-0 items-center whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+        <%= link_to "Share on Threads", threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex shrink-0 items-center whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+        <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="tap-target shrink-0 whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">Copy URL</button>
+        <% unless post_owner?(@post) %>
+          <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target shrink-0 whitespace-nowrap rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">Report</button>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
   <% if post_owner?(@post) %>
     <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
-      <%= link_to "Edit", edit_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
-      <%= link_to "Notifications (#{localized_number(@unread_notifications_count)})", notifications_post_path(@post), class: "rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
-      <%= button_to "Delete", post_path(@post), method: :delete, data: { turbo_confirm: "Delete this post?" }, class: "rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
+      <%= link_to "Edit", edit_post_path(@post), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= link_to "Notifications (#{localized_number(@unread_notifications_count)})", notifications_post_path(@post), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" %>
+      <%= button_to "Delete", post_path(@post), method: :delete, form: { class: "inline-block" }, data: { turbo_confirm: "Delete this post?" }, class: "tap-target rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" %>
     </div>
   <% end %>
 
@@ -106,8 +120,8 @@
         </div>
 
         <div class="flex justify-end gap-2 pt-2">
-          <button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="rounded-lg border border-slate-300 px-3 py-2 text-sm hover:bg-slate-100">Cancel</button>
-          <%= f.submit "Submit report", class: "rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600" %>
+          <button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="tap-target rounded-lg border border-slate-300 px-3 py-2 text-sm hover:bg-slate-100">Cancel</button>
+          <%= f.submit "Submit report", class: "tap-target rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600" %>
         </div>
       <% end %>
     </dialog>
@@ -184,7 +198,7 @@
         <% if recaptcha_enabled? %>
           <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <% end %>
-        <%= f.submit(@reply_to_comment.present? ? "Reply" : "Post comment", class: "rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700") %>
+        <%= f.submit(@reply_to_comment.present? ? "Reply" : "Post comment", class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700") %>
       <% end %>
     </div>
   </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,7 +13,7 @@
         <% end %>
       </div>
       <% if user_owner?(@user) %>
-        <%= link_to "Edit profile", edit_user_path(@user), class: "rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
+        <%= link_to "Edit profile", edit_user_path(@user), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" %>
       <% end %>
     </div>
   </header>
@@ -25,8 +25,8 @@
         <% @published_posts.each do |post| %>
           <article class="rounded-lg border border-slate-200 bg-slate-50 p-4">
             <div class="flex flex-wrap items-center justify-between gap-3">
-              <h3 class="text-base font-semibold text-slate-900">
-                <%= link_to post.title, post_path(post), class: "hover:text-blue-600" %>
+              <h3 class="min-w-0 flex-1 text-base font-semibold text-slate-900">
+                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600" %>
               </h3>
               <span class="inline-flex items-center gap-1 text-xs text-slate-500">
                 <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
@@ -50,8 +50,8 @@
           <% @draft_posts.each do |post| %>
             <article class="rounded-lg border border-slate-200 bg-slate-50 p-4">
               <div class="flex flex-wrap items-center justify-between gap-3">
-                <h3 class="text-base font-semibold text-slate-900"><%= post.title.presence || "(Untitled draft)" %></h3>
-                <%= link_to "Continue editing", edit_post_path(post), class: "rounded border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100" %>
+                <h3 class="min-w-0 flex-1 ds-line-clamp-2 text-base font-semibold leading-6 text-slate-900"><%= post.title.presence || "(Untitled draft)" %></h3>
+                <%= link_to "Continue editing", edit_post_path(post), class: "tap-target inline-flex items-center rounded border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100" %>
               </div>
               <p class="mt-2 text-sm text-slate-600"><%= truncate(post.description.to_s, length: 140) %></p>
             </article>


### PR DESCRIPTION
## Issue 
https://github.com/hamasaki-code/DeskTour-Studio/issues/36

## 目的

  - 多言語で文字数が増減してもカードUIが崩れないようにする。
  - モバイルで主要操作を親指で押しやすい配置にする。
  - 主要ボタンのタップ領域を 44px 以上にする。

  ## 実装内容

  - カードタイトルを2行でクランプするユーティリティを追加し、一覧/プロフィール内カードへ適用。
  - モバイル時に主要アクションを画面下部へ固定表示。
  - tap-target クラスを追加し、主要ボタンに適用して最小タップサイズを確保。

  ## 方法

  - Tailwindユーティリティ層に以下を追加。
      - ds-line-clamp-2（2行制限）
      - tap-target（min-height/min-width: 44px）
  - 投稿一覧とユーザーページのカード見出しに ds-line-clamp-2 を適用。
  - 投稿詳細ページで、既存アクションを sm 以上表示にし、sm 未満では下部固定アクションバーを表示。
  - レイアウトにモバイル下部固定「投稿する」CTAを追加（投稿詳細ページでは非表示）。

  ## 変更箇所

  - app/assets/tailwind/application.css (/C:/Users/hahib/ruby%20on%20rails/desktour_studio/app/assets/tailwind/
    application.css:45)
  - app/views/layouts/application.html.erb (/C:/Users/hahib/ruby%20on%20rails/desktour_studio/app/views/layouts/
    application.html.erb:65)
  - app/views/posts/index.html.erb (/C:/Users/hahib/ruby%20on%20rails/desktour_studio/app/views/posts/index.html.erb:19)
  - app/views/posts/show.html.erb (/C:/Users/hahib/ruby%20on%20rails/desktour_studio/app/views/posts/show.html.erb:65)
  - app/views/users/show.html.erb (/C:/Users/hahib/ruby%20on%20rails/desktour_studio/app/views/users/show.html.erb:16)

  ## まとめ

  - 2行クランプで多言語時のカード高さ崩れを抑制。
  - モバイル下部固定で主要操作（投稿/いいね/シェア/通報）を親指ゾーンに集約。
  - 主要ボタンのタップ領域を 44px 以上に統一。

  ## Testing

  - 実行コマンド: ruby bin/rails test test/controllers/posts_controller_test.rb
  - 結果: 失敗（127.0.0.1:5433 の PostgreSQL に接続できず、DB接続エラー）