### PR TITLE
Implemented to improve mobile UI/UX and information density

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -207,6 +207,10 @@ module ApplicationHelper
         tag.path(path_attrs.merge(d: "M8.25 12a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm7.5 7.5a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Zm0-15a3.75 3.75 0 1 0 0 7.5 3.75 3.75 0 0 0 0-7.5Z")),
         tag.path(path_attrs.merge(d: "m11.4 10.3 3 1.4m-3 2 3.1-1.5"))
       ]
+    when :ellipsis_horizontal
+      [
+        tag.path(path_attrs.merge(d: "M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm6 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"))
+      ]
     when :flag
       [
         tag.path(path_attrs.merge(d: "M5.25 21V4.5m0 0h10.5l-1.5 3 1.5 3H5.25Z"))
@@ -232,6 +236,14 @@ module ApplicationHelper
     when :trash
       [
         tag.path(path_attrs.merge(d: "M6 7.5h12m-9 0v10.5m3-10.5v10.5M9 4.5h6m-8.25 3h10.5l-.75 11.25a2.25 2.25 0 0 1-2.25 2.1h-4.5a2.25 2.25 0 0 1-2.25-2.1L6.75 7.5Z"))
+      ]
+    when :bars_3
+      [
+        tag.path(path_attrs.merge(d: "M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"))
+      ]
+    when :chevron_down
+      [
+        tag.path(path_attrs.merge(d: "m19.5 8.25-7.5 7.5-7.5-7.5"))
       ]
     else
       [ tag.path(path_attrs.merge(d: "M12 6v6m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z")) ]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,25 +52,52 @@
   <body class="lang-<%= I18n.locale %> min-h-screen bg-slate-50 text-slate-800">
     <% tracked_events = analytics_events %>
 
-    <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur">
-      <div class="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-3 px-4 py-4 sm:flex-nowrap sm:px-6">
-        <%= link_to "DeskTour Studio", root_path, class: "text-lg font-bold text-slate-900" %>
-        <div class="ml-auto flex items-center gap-2 text-sm font-medium tracking-nav">
+    <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur" data-mobile-header-root>
+      <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-3 sm:px-6">
+        <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-lg font-bold text-slate-900", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
+
+        <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex items-center rounded-lg bg-blue-500 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-600 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_primary" } %>
+        <button type="button" data-mobile-header-toggle aria-expanded="false" aria-controls="mobile-header-menu" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-2.5 py-2 text-slate-700 hover:bg-slate-100 sm:hidden" data-ga-event="navigation_mobile_menu_toggle_click" data-ga-category="navigation" data-ga-label="mobile_header_menu_toggle">
+          <%= ui_icon(:bars_3, class_name: "h-5 w-5") %>
+          <span class="sr-only">Menu</span>
+        </button>
+
+        <div class="ml-auto hidden items-center gap-2 text-sm font-medium tracking-nav sm:flex">
           <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
             <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-slate-700">
               <%= ui_icon(:globe_alt, class_name: "h-3.5 w-3.5") %>
               <span><%= t("language.current_with_name", name: t("language.current_name")) %></span>
             </span>
-            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) } %>
+            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } %>
             <span aria-hidden="true" class="px-1 text-slate-400">|</span>
-            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) } %>
+            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } %>
           </div>
           <% if owned_users.any? %>
-            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "header_my_profile" } %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
           <% else %>
-            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "header_create_profile" } %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target hidden items-center rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 sm:inline-flex", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "header_create_post" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex items-center rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+        </div>
+      </div>
+
+      <div id="mobile-header-menu" data-mobile-header-menu class="hidden border-t border-slate-200 bg-white sm:hidden">
+        <div class="mx-auto w-full max-w-6xl space-y-3 px-4 py-3">
+          <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
+            <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-slate-700">
+              <%= ui_icon(:globe_alt, class_name: "h-3.5 w-3.5") %>
+              <span><%= t("language.current_with_name", name: t("language.current_name")) %></span>
+            </span>
+            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } %>
+            <span aria-hidden="true" class="px-1 text-slate-400">|</span>
+            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } %>
+          </div>
+
+          <% if owned_users.any? %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
+          <% else %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
+          <% end %>
         </div>
       </div>
     </header>
@@ -117,6 +144,44 @@
         </div>
       </div>
     </footer>
+
+    <script>
+      if (!window.__mobileHeaderBindingInstalled) {
+        window.__mobileHeaderBindingInstalled = true;
+
+        const closeMobileHeaderMenu = () => {
+          const menu = document.querySelector("[data-mobile-header-menu]");
+          const toggle = document.querySelector("[data-mobile-header-toggle]");
+          if (!menu || menu.classList.contains("hidden")) return;
+
+          menu.classList.add("hidden");
+          if (toggle) toggle.setAttribute("aria-expanded", "false");
+        };
+
+        document.addEventListener("click", (event) => {
+          const toggle = event.target.closest("[data-mobile-header-toggle]");
+          if (toggle) {
+            const menu = document.querySelector("[data-mobile-header-menu]");
+            if (!menu) return;
+
+            const expanded = toggle.getAttribute("aria-expanded") == "true";
+            toggle.setAttribute("aria-expanded", String(!expanded));
+            menu.classList.toggle("hidden", expanded);
+            return;
+          }
+
+          const root = document.querySelector("[data-mobile-header-root]");
+          const menu = document.querySelector("[data-mobile-header-menu]");
+          if (!root || !menu || menu.classList.contains("hidden")) return;
+          if (!root.contains(event.target)) closeMobileHeaderMenu();
+        });
+
+        document.addEventListener("keydown", (event) => {
+          if (event.key !== "Escape") return;
+          closeMobileHeaderMenu();
+        });
+      }
+    </script>
 
     <script>
       document.addEventListener("click", async (event) => {

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t("posts.index.title") %>
 <% content_for :description, t("posts.index.description") %>
+<% detailed_filters_open = params[:details] == "1" || params[:category].present? || params[:theme].present? || params[:tag].present? %>
 
 <section class="space-y-content">
   <div class="rounded-2xl bg-gradient-to-br from-blue-600 to-cyan-500 px-6 py-8 text-white">
@@ -10,14 +11,25 @@
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-white p-4">
-    <%= form_with url: posts_path, method: :get, local: true, class: "grid gap-3 sm:grid-cols-4" do %>
-      <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm sm:col-span-2", placeholder: t("posts.index.search_placeholder") %>
-      <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
-      <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder") %>
-      <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder") %>
-      <div class="sm:col-span-4 flex flex-wrap gap-2">
-        <%= submit_tag t("posts.index.search_button"), class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700" %>
-        <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100" %>
+    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-3", data: { search_form: true } do %>
+      <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
+      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+        <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+        <div class="flex gap-2">
+          <%= submit_tag t("posts.index.search_button"), class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
+          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
+        </div>
+      </div>
+
+      <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex items-center gap-1 rounded-md px-1 text-sm font-medium text-slate-600 hover:text-slate-900" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+        <span><%= t("posts.index.detailed_filters_toggle") %></span>
+        <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
+      </button>
+
+      <div data-details-panel class="grid gap-3 sm:grid-cols-3 <%= detailed_filters_open ? '' : 'hidden' %>">
+        <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+        <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder") %>
+        <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder") %>
       </div>
     <% end %>
   </div>
@@ -26,32 +38,35 @@
     <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
         <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-          <%= link_to post_path(post), class: "block" do %>
+          <%= link_to post_path(post), class: "block", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: (params[:q].present? || params[:category].present? || params[:theme].present? || params[:tag].present?) ? "from_filtered_results" : "from_default_results" } do %>
             <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-48 w-full object-cover") %>
           <% end %>
 
           <div class="flex h-full flex-col space-y-3 p-4">
-            <div class="flex items-start justify-between gap-3">
-              <h2 class="min-w-0 flex-1 text-base font-semibold text-slate-900">
-                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600" %>
+            <div>
+              <h2 class="text-base font-semibold text-slate-900">
+                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
               </h2>
-              <span class="inline-flex shrink-0 items-center gap-1 text-xs text-slate-500">
-                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
-              </span>
+              <p class="mt-2 text-xs text-slate-500">
+                <%= t("posts.index.author_label") %>:
+                <%= link_to post.user.name, user_path(post.user), class: "text-blue-600 hover:text-blue-700", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+              </p>
             </div>
-            <p class="text-xs text-slate-500">
-              <%= t("posts.index.author_label") %>:
-              <%= link_to post.user.name, user_path(post.user), class: "text-blue-600 hover:text-blue-700" %>
-            </p>
-            <p class="text-sm text-slate-600"><%= truncate(post.description, length: 100) %></p>
-            <div class="flex flex-wrap gap-2 text-xs">
+            <p class="text-sm leading-reading text-slate-600"><%= truncate(post.description, length: 100) %></p>
+            <div class="flex flex-wrap gap-2 text-xs" aria-label="Post metadata">
               <% if post.category.present? %>
                 <span class="rounded-full bg-slate-100 px-2 py-1 text-slate-700"><%= post.category %></span>
               <% end %>
               <% post.tags.first(3).each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag), class: "rounded-full bg-blue-50 px-2 py-1 text-blue-700" %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "rounded-full bg-blue-50 px-2 py-1 text-blue-700", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
               <% end %>
+            </div>
+            <div class="mt-auto flex items-center justify-between border-t border-slate-100 pt-3 text-xs text-slate-500">
+              <span><%= l(post.created_at.to_date) %></span>
+              <span class="inline-flex items-center gap-1">
+                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
+              </span>
             </div>
           </div>
         </article>
@@ -65,3 +80,46 @@
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_INDEX_BOTTOM"] %>
 </section>
+
+<script>
+  if (!window.__postIndexSearchBindingInstalled) {
+    window.__postIndexSearchBindingInstalled = true;
+
+    document.addEventListener("click", (event) => {
+      const toggle = event.target.closest("[data-details-toggle]");
+      if (!toggle) return;
+
+      const form = toggle.closest("form");
+      const panel = form ? form.querySelector("[data-details-panel]") : null;
+      const icon = toggle.querySelector(".js-details-toggle-icon");
+      const stateInput = form ? form.querySelector("[data-details-state-input]") : null;
+      if (!panel) return;
+
+      const expanded = toggle.getAttribute("aria-expanded") == "true";
+      toggle.setAttribute("aria-expanded", String(!expanded));
+      panel.classList.toggle("hidden", expanded);
+      if (icon) icon.classList.toggle("rotate-180", !expanded);
+      if (stateInput) stateInput.value = expanded ? "0" : "1";
+    });
+
+    document.addEventListener("submit", (event) => {
+      const form = event.target.closest("[data-search-form]");
+      if (!form || typeof window.gtag !== "function") return;
+
+      const detailsOpen = form.querySelector("[data-details-state-input]")?.value === "1";
+      const keywordLength = (form.querySelector("[data-search-keyword-input]")?.value || "").trim().length;
+      const categorySet = (form.querySelector("[name='category']")?.value || "").trim().length > 0;
+      const themeSet = (form.querySelector("[name='theme']")?.value || "").trim().length > 0;
+      const tagSet = (form.querySelector("[name='tag']")?.value || "").trim().length > 0;
+
+      window.gtag("event", "post_search_submit", {
+        event_category: "post_search",
+        event_label: detailsOpen ? "details_open" : "details_closed",
+        keyword_length: keywordLength,
+        category_set: categorySet,
+        theme_set: themeSet,
+        tag_set: tagSet
+      });
+    });
+  }
+</script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,59 +62,76 @@
   </section>
 
   <div class="hidden flex-wrap items-center gap-3 sm:flex">
-    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" do %>
+    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
       <span class="inline-flex items-center gap-1.5">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.like") %></span>
       </span>
     <% end %>
-    <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
+    <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100", data: { ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x" } do %>
       <%= ui_icon(:share, class_name: "h-4 w-4") %>
       <span><%= t("posts.show.actions.share_x") %></span>
     <% end %>
-    <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
+    <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100", data: { ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads" } do %>
       <%= ui_icon(:share, class_name: "h-4 w-4") %>
       <span><%= t("posts.show.actions.share_threads") %></span>
     <% end %>
-    <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">
+    <button type="button" data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">
       <%= ui_icon(:share, class_name: "h-4 w-4") %>
       <span><%= t("posts.show.actions.copy_url") %></span>
     </button>
     <% unless post_owner?(@post) %>
-      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
+      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
         <%= ui_icon(:flag, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.report") %></span>
       </button>
     <% end %>
   </div>
 
-  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
+  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden" data-mobile-actions-root>
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
-      <div class="flex items-center gap-2 overflow-x-auto pb-1">
-        <%= button_to like_post_path(@post), method: :post, form: { class: "shrink-0" }, class: "tap-target whitespace-nowrap rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600" do %>
-          <span class="inline-flex items-center gap-1.5">
-            <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.like") %></span>
-          </span>
-        <% end %>
-        <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
-          <%= ui_icon(:share, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.share_x") %></span>
-        <% end %>
-        <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
-          <%= ui_icon(:share, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.share_threads") %></span>
-        <% end %>
-        <button type="button" data-copy-url="<%= post_share_url(@post) %>" class="tap-target inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">
-          <%= ui_icon(:share, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.copy_url") %></span>
-        </button>
-        <% unless post_owner?(@post) %>
-          <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
-            <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.report") %></span>
+      <div class="relative pb-1">
+        <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg bg-rose-500 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+            <span class="inline-flex items-center justify-center gap-1.5">
+              <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.like") %></span>
+            </span>
+          <% end %>
+          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
+            <span class="inline-flex items-center gap-1.5">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share") %></span>
+            </span>
           </button>
-        <% end %>
+          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-slate-700 hover:bg-slate-100">
+            <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
+            <span class="sr-only">More</span>
+          </button>
+        </div>
+
+        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-10 mb-2 hidden rounded-xl border border-slate-200 bg-white p-2 shadow-lg">
+          <div class="grid gap-1">
+            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_x") %></span>
+            <% end %>
+            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "mobile_share_threads_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_threads") %></span>
+            <% end %>
+            <button type="button" data-mobile-menu-action data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="mobile_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.copy_url") %></span>
+            </button>
+            <% unless post_owner?(@post) %>
+              <button type="button" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="mobile_report_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-amber-800 hover:bg-amber-50">
+                <%= ui_icon(:flag, class_name: "h-4 w-4") %>
+                <span><%= t("posts.show.actions.report") %></span>
+              </button>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -170,33 +187,33 @@
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
 
-  <section id="comments" class="space-y-form rounded-xl border border-slate-200 bg-white p-6">
+  <section id="comments" class="space-y-form rounded-xl border border-slate-200 bg-white p-4 sm:p-6">
     <h2 class="inline-flex items-center gap-1.5 text-lg font-semibold text-slate-900">
       <%= ui_icon(:chat, class_name: "h-5 w-5") %>
       <span><%= t("posts.show.comments.title") %></span>
     </h2>
 
     <% if @root_comments.any? %>
-      <div class="space-y-4">
+      <div class="space-y-5">
         <% @root_comments.each do |comment| %>
-          <article id="comment-<%= comment.id %>" class="rounded-lg border border-slate-100 bg-slate-50 p-4">
+          <article id="comment-<%= comment.id %>" class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <div class="flex items-center justify-between gap-3">
               <p class="text-sm font-medium text-slate-800"><%= comment.author_name %></p>
-              <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700" do %>
+              <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700", data: { ga_event: "comment_reply_click", ga_category: "comments", ga_label: "reply_to_parent" } do %>
                 <%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %>
                 <span><%= t("posts.show.comments.reply") %></span>
               <% end %>
             </div>
             <p class="mt-0.5 text-xs text-slate-500"><%= l(comment.created_at, format: :short) %></p>
-            <p class="mt-1 whitespace-pre-wrap text-sm text-slate-700"><%= comment.body %></p>
+            <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= comment.body %></p>
 
             <% if comment.replies.any? %>
-              <div class="mt-3 space-y-3 border-l-2 border-slate-200 pl-4">
+              <div class="mt-4 space-y-3 rounded-r-lg border-l-4 border-blue-200 bg-slate-50 px-3 py-3 sm:pl-4 sm:pr-3">
                 <% comment.replies.each do |reply| %>
-                  <div id="comment-<%= reply.id %>" class="rounded-md border border-slate-200 bg-white p-3">
+                  <div id="comment-<%= reply.id %>" class="rounded-lg border border-slate-300 bg-white p-3">
                     <p class="text-xs font-medium text-slate-700"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
                     <p class="mt-0.5 text-xs text-slate-500"><%= l(reply.created_at, format: :short) %></p>
-                    <p class="mt-1 whitespace-pre-wrap text-sm text-slate-700"><%= reply.body %></p>
+                    <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= reply.body %></p>
                   </div>
                 <% end %>
               </div>
@@ -263,12 +280,29 @@
 <script>
   if (!window.__reportModalBindingInstalled) {
     window.__reportModalBindingInstalled = true;
+
+    const closeMobileActionsMenu = (reason = "dismissed") => {
+      const menu = document.querySelector("[data-mobile-actions-menu]");
+      const toggle = document.querySelector("[data-mobile-actions-toggle]");
+      if (!menu || menu.classList.contains("hidden")) return;
+
+      menu.classList.add("hidden");
+      if (toggle) toggle.setAttribute("aria-expanded", "false");
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "post_action_more_menu_close", {
+          event_category: "post_actions",
+          event_label: `mobile_more_menu_${reason}`
+        });
+      }
+    };
+
     document.addEventListener("click", (event) => {
       const openButton = event.target.closest("[data-open-report-modal]");
       if (openButton) {
         const modalId = openButton.getAttribute("data-open-report-modal");
         const dialog = document.getElementById(modalId);
         if (dialog && typeof dialog.showModal === "function") dialog.showModal();
+        closeMobileActionsMenu("modal_open");
         return;
       }
 
@@ -277,7 +311,51 @@
         const modalId = closeButton.getAttribute("data-close-report-modal");
         const dialog = document.getElementById(modalId);
         if (dialog && typeof dialog.close === "function") dialog.close();
+        return;
       }
+
+      const mobileActionsToggle = event.target.closest("[data-mobile-actions-toggle]");
+      if (mobileActionsToggle) {
+        const menu = document.querySelector("[data-mobile-actions-menu]");
+        if (!menu) return;
+        const expanded = mobileActionsToggle.getAttribute("aria-expanded") == "true";
+        menu.classList.toggle("hidden", expanded);
+        mobileActionsToggle.setAttribute("aria-expanded", String(!expanded));
+        return;
+      }
+
+      const mobileActionsMenu = document.querySelector("[data-mobile-actions-menu]");
+      if (mobileActionsMenu && !mobileActionsMenu.classList.contains("hidden")) {
+        const isMenuAction = event.target.closest("[data-mobile-menu-action]");
+        const isInsideMenu = event.target.closest("[data-mobile-actions-menu]");
+        if (isMenuAction) {
+          closeMobileActionsMenu("action_selected");
+          return;
+        }
+        if (!isInsideMenu) closeMobileActionsMenu("outside_tap");
+      }
+
+      const shareButton = event.target.closest("[data-native-share-url]");
+      if (shareButton) {
+        const url = shareButton.getAttribute("data-native-share-url");
+        const text = shareButton.getAttribute("data-native-share-text");
+
+        if (navigator.share) {
+          navigator.share({ text, url }).catch(async (error) => {
+            if (error && error.name === "AbortError") return;
+            try {
+              await navigator.clipboard.writeText(url);
+            } catch (_) {}
+          });
+        } else {
+          navigator.clipboard.writeText(url).catch(() => {});
+        }
+      }
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      closeMobileActionsMenu("escape");
     });
   }
 </script>

--- a/config/locales/app_ui.en.yml
+++ b/config/locales/app_ui.en.yml
@@ -20,6 +20,7 @@ en:
       tag_placeholder: "Tag"
       search_button: "Search"
       reset_button: "Reset"
+      detailed_filters_toggle: "Detailed filters"
       author_label: "Author"
       empty_state: "No posts match your filters."
     new:
@@ -60,6 +61,7 @@ en:
       no_related_items: "No related items yet."
       actions:
         like: "Like"
+        share: "Share"
         share_x: "Share on X"
         share_threads: "Share on Threads"
         copy_url: "Copy URL"

--- a/config/locales/app_ui.ja.yml
+++ b/config/locales/app_ui.ja.yml
@@ -20,6 +20,7 @@ ja:
       tag_placeholder: "タグ"
       search_button: "検索する"
       reset_button: "リセット"
+      detailed_filters_toggle: "詳細条件"
       author_label: "投稿者"
       empty_state: "条件に一致する投稿がありません。"
     new:
@@ -60,6 +61,7 @@ ja:
       no_related_items: "関連アイテムはまだありません。"
       actions:
         like: "いいね"
+        share: "共有"
         share_x: "Xでシェア"
         share_threads: "Threadsでシェア"
         copy_url: "URLをコピー"


### PR DESCRIPTION
 ## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/41

## 目的

  モバイル利用時の操作密度と探索体験を改善し、以下を達成することです。

  - 主要操作に迷わない
  - 一覧を素早くスキャンできる
  - コメント階層を追いやすい

  ## 実装内容

  - 投稿詳細のモバイル下部アクションを再設計
    主要2操作（Like / Share）+ その他メニュー に変更し、横スクロール依存を解消
  - 投稿一覧の検索UIを段階表示化
    基本検索（キーワード） と 詳細条件（カテゴリ/テーマ/タグ） に分離し、開閉状態を保持
  - 共通ヘッダーのモバイル情報密度を最適化
    モバイルでは Create Post を主導線にし、言語切替・プロフィール導線をメニューへ集約
  - 投稿カードの情報優先度を変更
    タイトル > 投稿者 > 概要 > メタ に再配置し、いいね数を下部メタ行へ移動
  - コメント階層の可読性を強化
    親/子の余白・背景・境界を強め、返信追跡性を改善
  - GA計測イベントを追加
    検索・カード遷移・ヘッダー操作・投稿詳細アクション（More開閉含む）・返信操作に計測属性を追加

  ## 方法

  - 既存の posts#index / posts#show / 共通レイアウトをベースに、UIを最小差分で再構成
  - 既存の data-ga-* トラッキング方式に合わせてイベント属性を追加
  - 小規模JSでモバイルメニュー開閉と検索詳細開閉を制御
  - 表示文言は i18n キーを追加して多言語対応（ja/en）

  ## 変更箇所

  - app/views/posts/show.html.erb
  - app/views/posts/index.html.erb
  - app/views/layouts/application.html.erb
  - app/helpers/application_helper.rb
  - config/locales/app_ui.en.yml
  - config/locales/app_ui.ja.yml

  ## まとめ

  Issueの5項目（投稿詳細アクション、一覧検索、ヘッダー、カード情報優先度、コメント可読性）に対応する実装を反映しました。
  加えて、比較評価に必要なイベント計測ポイントも実装済みです。

  ## Testing

  - 実施済み

  1. ERB構文チェック（index/show/layout）: OK
  2. i18n YAMLロード確認: OK

  - 未完了/要環境

  1. rails test 実行は PostgreSQL 接続不可（127.0.0.1:5433 refused）で失敗
  2. DB起動後にコントローラテスト再実行が必要