### PR TITLE
Improved mobile UI/UX and enhanced interaction tracking

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,6 @@
       <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-3 sm:px-6">
         <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-lg font-bold text-slate-900", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
 
-        <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex items-center rounded-lg bg-blue-500 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-600 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_primary" } %>
         <button type="button" data-mobile-header-toggle aria-expanded="false" aria-controls="mobile-header-menu" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-2.5 py-2 text-slate-700 hover:bg-slate-100 sm:hidden" data-ga-event="navigation_mobile_menu_toggle_click" data-ga-category="navigation" data-ga-label="mobile_header_menu_toggle">
           <%= ui_icon(:bars_3, class_name: "h-5 w-5") %>
           <span class="sr-only">Menu</span>
@@ -64,13 +63,8 @@
 
         <div class="ml-auto hidden items-center gap-2 text-sm font-medium tracking-nav sm:flex">
           <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
-            <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-slate-700">
-              <%= ui_icon(:globe_alt, class_name: "h-3.5 w-3.5") %>
-              <span><%= t("language.current_with_name", name: t("language.current_name")) %></span>
-            </span>
-            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } %>
-            <span aria-hidden="true" class="px-1 text-slate-400">|</span>
-            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } %>
+            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } %>
+            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } %>
           </div>
           <% if owned_users.any? %>
             <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
@@ -84,20 +78,16 @@
       <div id="mobile-header-menu" data-mobile-header-menu class="hidden border-t border-slate-200 bg-white sm:hidden">
         <div class="mx-auto w-full max-w-6xl space-y-3 px-4 py-3">
           <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
-            <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-slate-700">
-              <%= ui_icon(:globe_alt, class_name: "h-3.5 w-3.5") %>
-              <span><%= t("language.current_with_name", name: t("language.current_name")) %></span>
-            </span>
-            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } %>
-            <span aria-hidden="true" class="px-1 text-slate-400">|</span>
-            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } %>
+            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } %>
+            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } %>
           </div>
 
           <% if owned_users.any? %>
-            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
           <% else %>
-            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
         </div>
       </div>
     </header>
@@ -126,7 +116,7 @@
       <%= yield %>
     </main>
 
-    <% unless controller_name == "posts" && action_name == "show" %>
+    <% if controller_name == "posts" && action_name == "index" %>
       <div class="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
         <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
           <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target flex w-full items-center justify-center rounded-xl bg-blue-500 px-4 text-sm font-semibold text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
@@ -149,13 +139,19 @@
       if (!window.__mobileHeaderBindingInstalled) {
         window.__mobileHeaderBindingInstalled = true;
 
-        const closeMobileHeaderMenu = () => {
+        const closeMobileHeaderMenu = (reason = "dismissed") => {
           const menu = document.querySelector("[data-mobile-header-menu]");
           const toggle = document.querySelector("[data-mobile-header-toggle]");
           if (!menu || menu.classList.contains("hidden")) return;
 
           menu.classList.add("hidden");
           if (toggle) toggle.setAttribute("aria-expanded", "false");
+          if (typeof window.gtag === "function") {
+            window.gtag("event", "navigation_mobile_menu_close", {
+              event_category: "navigation",
+              event_label: `mobile_header_menu_${reason}`
+            });
+          }
         };
 
         document.addEventListener("click", (event) => {
@@ -165,20 +161,30 @@
             if (!menu) return;
 
             const expanded = toggle.getAttribute("aria-expanded") == "true";
-            toggle.setAttribute("aria-expanded", String(!expanded));
-            menu.classList.toggle("hidden", expanded);
+            if (expanded) {
+              closeMobileHeaderMenu("toggle");
+            } else {
+              toggle.setAttribute("aria-expanded", "true");
+              menu.classList.remove("hidden");
+            }
+            return;
+          }
+
+          const action = event.target.closest("[data-mobile-header-action]");
+          if (action) {
+            closeMobileHeaderMenu("menu_action");
             return;
           }
 
           const root = document.querySelector("[data-mobile-header-root]");
           const menu = document.querySelector("[data-mobile-header-menu]");
           if (!root || !menu || menu.classList.contains("hidden")) return;
-          if (!root.contains(event.target)) closeMobileHeaderMenu();
+          if (!root.contains(event.target)) closeMobileHeaderMenu("outside_tap");
         });
 
         document.addEventListener("keydown", (event) => {
           if (event.key !== "Escape") return;
-          closeMobileHeaderMenu();
+          closeMobileHeaderMenu("escape");
         });
       }
     </script>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,11 +1,14 @@
 <% content_for :title, t("posts.index.title") %>
 <% content_for :description, t("posts.index.description") %>
-<% detailed_filters_open = params[:details] == "1" || params[:category].present? || params[:theme].present? || params[:tag].present? %>
+<% detailed_filters_open = params[:details] == "1" || params[:theme].present? || params[:tag].present? %>
+<% detailed_filter_count = [params[:theme], params[:tag]].count(&:present?) %>
+<% applied_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
+<% filtered_results = params[:q].present? || applied_filter_count.positive? %>
 
 <section class="space-y-content">
-  <div class="rounded-2xl bg-gradient-to-br from-blue-600 to-cyan-500 px-6 py-8 text-white">
+  <div class="rounded-2xl bg-gradient-to-br from-slate-900 via-blue-800 to-cyan-700 px-6 py-8 text-white">
     <h1 class="text-2xl font-bold sm:text-3xl"><%= t("posts.index.hero_title") %></h1>
-    <p class="mt-2 text-sm text-blue-50 sm:text-base">
+    <p class="mt-2 max-w-2xl text-sm text-blue-100 sm:text-base">
       <%= t("posts.index.hero_description") %>
     </p>
   </div>
@@ -13,60 +16,68 @@
   <div class="rounded-xl border border-slate-200 bg-white p-4">
     <%= form_with url: posts_path, method: :get, local: true, class: "space-y-3", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
-      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
         <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+        <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
         <div class="flex gap-2">
           <%= submit_tag t("posts.index.search_button"), class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
           <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
       </div>
 
-      <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex items-center gap-1 rounded-md px-1 text-sm font-medium text-slate-600 hover:text-slate-900" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
-        <span><%= t("posts.index.detailed_filters_toggle") %></span>
-        <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
+      <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+        <span class="inline-flex items-center gap-2">
+          <span><%= t("posts.index.detailed_filters_toggle") %></span>
+          <% if detailed_filter_count.positive? %>
+            <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
+          <% end %>
+        </span>
+        <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
       </button>
 
-      <div data-details-panel class="grid gap-3 sm:grid-cols-3 <%= detailed_filters_open ? '' : 'hidden' %>">
-        <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
-        <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder") %>
-        <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder") %>
+      <div data-details-panel class="grid gap-3 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
+        <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
+        <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
       </div>
     <% end %>
   </div>
 
   <% if @posts.any? %>
-    <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
         <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-          <%= link_to post_path(post), class: "block", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: (params[:q].present? || params[:category].present? || params[:theme].present? || params[:tag].present?) ? "from_filtered_results" : "from_default_results" } do %>
-            <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-48 w-full object-cover") %>
+          <%= link_to post_path(post), class: "block", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
+            <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-40 w-full object-cover sm:h-44") %>
           <% end %>
 
           <div class="flex h-full flex-col space-y-3 p-4">
-            <div>
-              <h2 class="text-base font-semibold text-slate-900">
-                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
-              </h2>
-              <p class="mt-2 text-xs text-slate-500">
-                <%= t("posts.index.author_label") %>:
-                <%= link_to post.user.name, user_path(post.user), class: "text-blue-600 hover:text-blue-700", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-              </p>
-            </div>
-            <p class="text-sm leading-reading text-slate-600"><%= truncate(post.description, length: 100) %></p>
-            <div class="flex flex-wrap gap-2 text-xs" aria-label="Post metadata">
-              <% if post.category.present? %>
-                <span class="rounded-full bg-slate-100 px-2 py-1 text-slate-700"><%= post.category %></span>
-              <% end %>
-              <% post.tags.first(3).each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "rounded-full bg-blue-50 px-2 py-1 text-blue-700", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
-              <% end %>
-            </div>
-            <div class="mt-auto flex items-center justify-between border-t border-slate-100 pt-3 text-xs text-slate-500">
-              <span><%= l(post.created_at.to_date) %></span>
-              <span class="inline-flex items-center gap-1">
+            <h2 class="text-base font-semibold text-slate-900">
+              <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
+            </h2>
+
+            <p class="ds-line-clamp-3 text-sm leading-reading text-slate-700"><%= truncate(post.description, length: 110) %></p>
+
+            <div class="grid grid-cols-3 gap-2 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-700" aria-label="Post summary metrics">
+              <span class="truncate text-slate-600"><%= l(post.created_at.to_date) %></span>
+              <span class="inline-flex items-center justify-center gap-1 text-slate-600">
                 <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
+                <span><%= localized_number(post.likes_count) %></span>
               </span>
+              <% if post.category.present? %>
+                <span class="truncate text-right font-medium text-slate-700"><%= post.category %></span>
+              <% else %>
+                <span aria-hidden="true"></span>
+              <% end %>
+            </div>
+
+            <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3 text-xs text-slate-500" aria-label="Post metadata">
+              <span>
+                <%= t("posts.index.author_label") %>:
+                <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-600 hover:text-slate-800", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+              </span>
+              <% post.tags.first(3).each do |tag| %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "rounded-full bg-slate-100 px-2 py-1 text-slate-600 hover:bg-slate-200 hover:text-slate-800", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+              <% end %>
             </div>
           </div>
         </article>
@@ -111,6 +122,7 @@
       const categorySet = (form.querySelector("[name='category']")?.value || "").trim().length > 0;
       const themeSet = (form.querySelector("[name='theme']")?.value || "").trim().length > 0;
       const tagSet = (form.querySelector("[name='tag']")?.value || "").trim().length > 0;
+      const appliedFilterCount = [categorySet, themeSet, tagSet].filter(Boolean).length;
 
       window.gtag("event", "post_search_submit", {
         event_category: "post_search",
@@ -118,7 +130,19 @@
         keyword_length: keywordLength,
         category_set: categorySet,
         theme_set: themeSet,
-        tag_set: tagSet
+        tag_set: tagSet,
+        applied_filter_count: appliedFilterCount
+      });
+    });
+
+    document.addEventListener("change", (event) => {
+      const target = event.target.closest("[data-search-filter-input]");
+      if (!target || typeof window.gtag !== "function") return;
+
+      window.gtag("event", "post_search_filter_change", {
+        event_category: "post_search",
+        event_label: `index_filter_${target.dataset.searchFilterInput}`,
+        filter_has_value: String((target.value || "").trim().length > 0)
       });
     });
   }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,7 +62,7 @@
   </section>
 
   <div class="hidden flex-wrap items-center gap-3 sm:flex">
-    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
+    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-100", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
       <span class="inline-flex items-center gap-1.5">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.like") %></span>
@@ -92,7 +92,7 @@
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
       <div class="relative pb-1">
         <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
-          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg bg-rose-500 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-100", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
             <span class="inline-flex items-center justify-center gap-1.5">
               <%= ui_icon(:heart, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.like") %></span>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/43

## 目的

  - モバイル一覧体験での意思決定阻害を減らすため、以下を改善する。
  - 主要CTAの重複解消（1導線化）
  - 検索UIの詳細条件の発見性向上
  - 投稿カードの情報優先度再設計（スキャン性向上）
  - ヒーロー本文の可読性向上
  - 補助的に、CTA色競合・言語切替UIのノイズ削減も対応

  ## 実装内容

  - モバイル主要CTAを一本化
  - ヘッダー内モバイル create_post を削除し、下部固定CTAを主要導線化
  - 下部固定CTAは posts#index のみ表示に変更（1画面1目的）
  - ヘッダー内は補助導線としてメニュー内に弱いスタイルで create_post を配置
  - 検索UI改善
  - category を初期表示に昇格
  - 詳細トグルをボタン化して視認性を改善
  - 詳細条件（theme/tag）の適用件数バッジ表示を追加
  - 計測用に post_search_filter_change と applied_filter_count を追加
  - 投稿カード再設計
  - 情報階層を「タイトル → 要約 → 主要指標（投稿日/いいね/カテゴリ）」へ整理
  - タグ・補助メタの視覚強度を一段下げる
  - メタ情報色を上げて可読性改善
  - ヒーロー可読性改善
  - 背景グラデーションを濃く調整
  - 本文色を濃いトーンへ変更
  - 追加項目対応
  - like の色強度を弱め、create_post（青）との競合を抑制
  - 言語切替UIを簡素化し、aria-current 主体に整理

  ## 方法

  - 既存構成（Rails ERB + Tailwind）を維持し、ビュー層の最小差分で実装
  - コントローラ・モデルの検索処理はそのまま活かし、表示・導線・計測をUI側で調整
  - GA4の既存設計に合わせてイベントパラメータを拡張

  ## 変更箇所

  - [app/views/layouts/application.html.erb](C:\Users\hahib\ruby on
    rails\desktour_studio\app\views\layouts\application.html.erb)
  - モバイルヘッダーCTA削除、メニュー内補助CTA追加、固定CTA表示条件変更、言語切替簡素化、モバイルメニューcloseイベント追加
  - [app/views/posts/index.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\index.html.erb)
  - ヒーロー可読性調整、検索UI再構成、詳細条件件数表示、カード情報階層変更、検索計測イベント追加
  - [app/views/posts/show.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\show.html.erb)
  - like CTAトーン調整（desktop/mobile）

  ## まとめ

  - 要件に沿って、モバイル主要CTAを1導線化し、検索導線の発見性・カードの比較しやすさ・ヒーロー可読性を改善した。
  - 追加検討項目のうち、CTA色競合抑制と言語切替UIの省スペース化も反映した。
  - 効果検証に必要なイベント（遷移/フィルタ利用/検索完了の比較軸）も追加済み。

  ## Testing

  - 実行コマンド
  - ruby bin/rails test test/controllers/posts_controller_test.rb test/controllers/locale_selection_test.rb
  - 結果
  - 失敗（環境要因）
  - PostgreSQL への接続不可（127.0.0.1:5433 Connection refused）によりテスト実行不可