### PR TITLE
Refine UI: Standardize focus states, CTA priority, and search UI layout

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -9,6 +9,8 @@
     --ds-letter-spacing-nav: 0.002em;
     --ds-space-content: 2rem;
     --ds-space-form: 1.5rem;
+    --ds-focus-ring-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
+    --ds-focus-border-color: rgb(37, 99, 235);
   }
 
   html[lang="ja"] {
@@ -40,6 +42,30 @@
   body {
     font-family: var(--ds-font-sans);
     letter-spacing: var(--ds-letter-spacing-body);
+  }
+
+  a,
+  button,
+  input,
+  select,
+  textarea {
+    transition: box-shadow 0.16s ease, border-color 0.16s ease;
+  }
+
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow: var(--ds-focus-ring-shadow);
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible {
+    border-color: var(--ds-focus-border-color);
   }
 
   h1,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-blue-200 bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-100", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
         </div>
       </div>
     </header>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,6 +8,8 @@
 <% detailed_status = detailed_filters_open ? "ON" : "OFF" %>
 <% applied_filters_label = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D\u30D5\u30A3\u30EB\u30BF" : "Applied filters" %>
 <% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
+<% basic_search_label = I18n.locale.to_s == "ja" ? "\u57FA\u672C\u691C\u7D22" : "Basic search" %>
+<% detailed_search_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u691C\u7D22" : "Detailed search" %>
 <% active_filters = {
   category: params[:category].to_s.strip,
   theme: params[:theme].to_s.strip,
@@ -37,31 +39,37 @@
   <div class="rounded-xl border border-slate-200 bg-white p-4">
     <%= form_with url: posts_path, method: :get, local: true, class: "space-y-3", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
-      <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
-        <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
-        <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
-        <div class="grid gap-2 sm:flex sm:gap-2">
-          <%= submit_tag t("posts.index.search_button"), class: "tap-target w-full rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700 sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
-          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 sm:w-auto", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
+      <div class="rounded-lg border border-slate-200 bg-white p-3">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= basic_search_label %></p>
+        <div class="mt-2 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
+          <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+          <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
+          <div class="grid gap-2 sm:flex sm:gap-2">
+            <%= submit_tag t("posts.index.search_button"), class: "tap-target w-full rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700 sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
+            <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 sm:w-auto", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
+          </div>
         </div>
       </div>
 
-      <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
-        <span class="inline-flex items-center gap-2">
-          <span><%= detailed_toggle_label %></span>
-          <% if detailed_filter_count.positive? %>
-            <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
-          <% end %>
-        </span>
-        <span class="inline-flex items-center gap-2">
-          <span data-details-state-badge class="rounded-full px-2 py-0.5 text-xs font-semibold <%= detailed_filters_open ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' %>"><%= detailed_status %></span>
-          <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
-        </span>
-      </button>
+      <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
+        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500"><%= detailed_search_label %></p>
+        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+          <span class="inline-flex items-center gap-2">
+            <span><%= detailed_toggle_label %></span>
+            <% if detailed_filter_count.positive? %>
+              <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
+            <% end %>
+          </span>
+          <span class="inline-flex items-center gap-2">
+            <span data-details-state-badge class="rounded-full px-2 py-0.5 text-xs font-semibold <%= detailed_filters_open ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' %>"><%= detailed_status %></span>
+            <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
+          </span>
+        </button>
 
-      <div data-details-panel class="grid gap-3 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
-        <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
-        <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
+        <div data-details-panel class="mt-3 grid gap-3 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
+          <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
+          <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
+        </div>
       </div>
 
       <% filter_container_class = active_filters.any? ? "rounded-lg border border-blue-200 bg-blue-50/60 px-3 py-2.5" : "px-1 py-1" %>
@@ -92,7 +100,7 @@
             <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-40 w-full object-cover sm:h-44") %>
           <% end %>
 
-          <div class="flex h-full flex-col space-y-3 p-4">
+          <div class="flex h-full flex-col space-y-2.5 p-4">
             <h2 class="text-base font-semibold text-slate-900">
               <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-5 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
             </h2>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,9 @@
   </div>
 
   <div class="rounded-xl border border-slate-200 bg-white p-6">
-    <p class="whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @post.description %></p>
+    <div class="max-w-3xl">
+      <p class="whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @post.description %></p>
+    </div>
   </div>
 
   <% if @post.tags.any? %>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/49

## 目的

  - 操作の視認性・一貫性・可読性を高め、一覧ページでの「検索→閲覧」導線をより明確にする。
  - 特にキーボード操作時の状態判別（focus-visible）を改善し、UIのアクセシビリティ品質を引き上げる。

  ## 実装内容

  - フォーカス可視性の統一（高）
  - a / button / input / select / textarea に共通 focus-visible リングを付与
  - 入力系は focus-visible 時に境界色も統一変更
  - CTA優先度ルールの統一（中）
  - create_post の副CTAであるモバイルメニュー内ボタンを中立トーンへ変更
  - 主CTA（デスクトップヘッダー・モバイル下部固定バー）は強い青を維持
  - 検索UIの情報密度段階化（中）
  - 検索エリアを「Basic search」「Detailed search」に視覚分離
  - 詳細トグルを ON/OFF バッジ表示に統一
  - 「適用中フィルタ」は空状態コンパクト、適用時のみ強調背景
  - 長文本文可読性の改善（低）
  - 投稿詳細本文カードに最大行長制御（max-w-3xl）を追加

  ## 方法

  - 既存構造（Rails ERB + Tailwind）を維持しつつ、UI層のみを最小差分で改修
  - 共通アクセシビリティ改善は tailwind/application.css のベースレイヤーに集約
  - CTAの主従はレイアウト側でトーンを統一
  - 検索UIは posts#index のフォーム構造を再編し、見出し・背景トーン・余白で段階化
  - 読みやすさ改善は posts#show の本文コンテナ幅制御で対応

  ## 変更箇所

  - [application.css](C:\Users\hahib\ruby on rails\desktour_studio\app\assets\tailwind\application.css)
  - focus-visible 共通リング、入力系フォーカス境界色、遷移の統一
  - [application.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\layouts\application.html.erb)
  - モバイルメニュー内 create_post を副CTAトーンへ変更
  - [index.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\index.html.erb)
  - Basic search / Detailed search 見出し追加
  - 詳細トグル ON/OFF バッジ化
  - 適用中フィルタの空/適用時スタイル分岐
  - モバイル時の検索ボタン群縦積み・フル幅化
  - [show.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\show.html.erb)
  - 本文領域に max-w-3xl 追加

  ## まとめ

  - フォーカス可視性を全体で統一し、キーボード操作時の判別性を改善した。
  - CTAの主従ルールを明確化し、create_post の見せ方の揺れを抑えた。
  - 検索UIを段階化して情報圧を軽減し、初見時の理解コストを下げた。
  - 長文本文は行長制御で可読性を向上させた。

  ## Testing

  - 自動テスト: 未実行（主にビュー/CSS改修のため）
  - 目視確認推奨:
  - キーボード操作時に主要リンク・ボタン・入力へ focus-visible が一貫表示されること
  - create_post の主CTA/副CTAのトーン差が画面間で一貫していること
  - 一覧検索エリアで「Basic/Detailed」の段階が直感的に判別できること
  - 投稿詳細本文で1行あたりの文字数が抑制され、長文が読みやすいこと