### PR TITLE
Improve UX: Streamline primary CTAs, search status labels, and post readability

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-md px-2 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
         </div>
       </div>
     </header>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,9 @@
 <% applied_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
 <% filtered_results = params[:q].present? || applied_filter_count.positive? %>
 <% detailed_toggle_label = t("posts.index.detailed_filters_toggle") %>
-<% detailed_status = detailed_filters_open ? "ON" : "OFF" %>
+<% detailed_status_shown_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u8868\u793A\u4E2D" : "Details shown" %>
+<% detailed_status_hidden_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u306F\u975E\u8868\u793A" : "Details hidden" %>
+<% detailed_status_label = detailed_filters_open ? detailed_status_shown_label : detailed_status_hidden_label %>
 <% applied_filters_label = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D\u30D5\u30A3\u30EB\u30BF" : "Applied filters" %>
 <% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
 <% basic_search_label = I18n.locale.to_s == "ja" ? "\u57FA\u672C\u691C\u7D22" : "Basic search" %>
@@ -58,13 +60,13 @@
             <span><%= detailed_toggle_label %></span>
             <% if detailed_filter_count.positive? %>
               <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
-            <% end %>
-          </span>
-          <span class="inline-flex items-center gap-2">
-            <span data-details-state-badge class="rounded-full px-2 py-0.5 text-xs font-semibold <%= detailed_filters_open ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' %>"><%= detailed_status %></span>
-            <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
-          </span>
-        </button>
+          <% end %>
+        </span>
+        <span class="inline-flex items-center gap-2">
+          <span data-details-state-badge data-label-shown="<%= detailed_status_shown_label %>" data-label-hidden="<%= detailed_status_hidden_label %>" class="max-w-[10.5rem] truncate rounded-full px-2 py-0.5 text-xs font-semibold <%= detailed_filters_open ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' %>"><%= detailed_status_label %></span>
+          <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
+        </span>
+      </button>
 
         <div data-details-panel class="mt-3 grid gap-3 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
           <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
@@ -161,7 +163,9 @@
       panel.classList.toggle("hidden", expanded);
       if (icon) icon.classList.toggle("rotate-180", !expanded);
       if (stateLabel) {
-        stateLabel.textContent = nextExpanded ? "ON" : "OFF";
+        const shownLabel = stateLabel.dataset.labelShown || "Details shown";
+        const hiddenLabel = stateLabel.dataset.labelHidden || "Details hidden";
+        stateLabel.textContent = nextExpanded ? shownLabel : hiddenLabel;
         stateLabel.classList.toggle("bg-emerald-100", nextExpanded);
         stateLabel.classList.toggle("text-emerald-700", nextExpanded);
         stateLabel.classList.toggle("bg-slate-200", !nextExpanded);

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,7 +26,7 @@
 
   <div class="rounded-xl border border-slate-200 bg-white p-6">
     <div class="max-w-3xl">
-      <p class="whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @post.description %></p>
+      <p class="whitespace-pre-wrap text-base leading-reading text-slate-700"><%= @post.description %></p>
     </div>
   </div>
 
@@ -64,7 +64,7 @@
   </section>
 
   <div class="hidden flex-wrap items-center gap-3 sm:flex">
-    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg border border-rose-200 bg-rose-50 px-4 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-100", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
+    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
       <span class="inline-flex items-center gap-1.5">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.like") %></span>
@@ -83,7 +83,7 @@
       <span><%= t("posts.show.actions.copy_url") %></span>
     </button>
     <% unless post_owner?(@post) %>
-      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-sm text-amber-800 hover:bg-amber-100">
+      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm text-amber-800 hover:bg-amber-50">
         <%= ui_icon(:flag, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.report") %></span>
       </button>
@@ -94,7 +94,7 @@
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
       <div class="relative pb-1">
         <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
-          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-700 hover:bg-rose-100", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg bg-rose-500 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
             <span class="inline-flex items-center justify-center gap-1.5">
               <%= ui_icon(:heart, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.like") %></span>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/51

## 目的

  - 主要導線（投稿作成・検索・投稿アクション）の視覚優先度を画面ごとに明確化し、ユーザーが「次に押すべきボタン」を即判断できる状態にする。
  - 検索状態の理解コストを下げ、投稿本文の可読性を底上げする。

  ## 実装内容

  - CTA階層の統一
  - モバイルは下部固定の 投稿作成 を主CTAとして維持
  - モバイルヘッダーメニュー内の 投稿作成 はテキスト寄りの弱いサブ導線に変更
  - 検索状態表示を意味ラベル化
  - ON/OFF 表記を廃止
  - 状態を 詳細条件を表示中 / 詳細条件は非表示（英語: Details shown / Details hidden）に変更
  - トグル開閉時にJSで状態ラベルを同期更新
  - 投稿詳細アクション優先順位の再設計
  - いいね を主アクションとして塗りボタン化
  - 通報 はアウトライン寄せに変更
  - シェア は副行動としてアウトライン維持
  - 本文可読性の改善
  - 投稿詳細本文を text-sm から text-base に引き上げ
  - 既存の leading-reading は維持

  ## 方法

  - 既存のRails + ERB + Tailwind構成を維持し、UI層のみを最小差分で改修
  - 視覚優先度の調整はクラス変更で実施（ロジック変更なし）
  - 検索状態はサーバー側初期ラベル + クライアント側トグル同期で実装

  ## 変更箇所

  - [application.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\layouts\application.html.erb)
  - モバイルメニュー内 create_post をサブ導線トーンへ変更
  - [index.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\index.html.erb)
  - 詳細検索状態ラベルを意味ベース表現へ変更
  - data-label-* を使ったトグル時ラベル同期更新を追加
  - [show.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\show.html.erb)
  - 本文文字サイズを text-base に変更
  - like を塗りボタン化、report をアウトライン寄せ

  ## まとめ

  - 1画面1主役の方針に沿ってCTA優先度を整理し、操作判断の速さを改善した。
  - 検索状態は自己説明的な文言に変更し、特に日本語UIでの理解性を向上させた。
  - 投稿詳細では主行動と副行動の視線誘導を明確化し、本文も読みやすい密度に調整した。

  ## Testing

  - 自動テスト: 未実行（今回の変更はビュー中心）
  - 目視確認推奨:
  - モバイルで下部固定 投稿作成 が主役として認識できること
  - 検索詳細トグルで状態文言が正しく切り替わること
  - 投稿詳細で いいね が主、シェア/通報 が副として視覚分離されること
  - 長文本文の読み疲れが軽減されていること