### PR TITLE
UI Refinement: Optimize content scannability and standardize CTA roles

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -105,6 +105,14 @@
     min-width: 44px;
   }
 
+  .cta-primary {
+    @apply inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700;
+  }
+
+  .cta-secondary {
+    @apply inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100;
+  }
+
   @media (max-width: 640px) {
     .tap-target {
       padding-top: 0.625rem;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,8 +53,13 @@
     <% tracked_events = analytics_events %>
 
     <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur" data-mobile-header-root>
-      <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-3 sm:px-6">
-        <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-lg font-bold text-slate-900", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
+      <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-2 sm:px-6 sm:py-3">
+        <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-base font-bold text-slate-900 sm:text-lg", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
+
+        <%= link_to new_post_path, class: "tap-target cta-primary px-3 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_icon" } do %>
+          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
+          <span class="sr-only"><%= t("navigation.create_post") %></span>
+        <% end %>
 
         <button type="button" data-mobile-header-toggle aria-expanded="false" aria-controls="mobile-header-menu" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-2.5 py-2 text-slate-700 hover:bg-slate-100 sm:hidden" data-ga-event="navigation_mobile_menu_toggle_click" data-ga-category="navigation" data-ga-label="mobile_header_menu_toggle">
           <%= ui_icon(:bars_3, class_name: "h-5 w-5") %>
@@ -71,12 +76,12 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex items-center rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
         </div>
       </div>
 
       <div id="mobile-header-menu" data-mobile-header-menu class="hidden border-t border-slate-200 bg-white sm:hidden">
-        <div class="mx-auto w-full max-w-6xl space-y-3 px-4 py-3">
+        <div class="mx-auto w-full max-w-6xl space-y-2 px-4 py-2.5">
           <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
             <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } %>
             <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } %>
@@ -87,7 +92,6 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target inline-flex w-full items-center justify-center rounded-md px-2 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_secondary" } %>
         </div>
       </div>
     </header>
@@ -119,7 +123,7 @@
     <% if controller_name == "posts" && action_name == "index" %>
       <div class="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
         <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target flex w-full items-center justify-center rounded-xl bg-blue-500 px-4 text-sm font-semibold text-white hover:bg-blue-600", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,6 +12,9 @@
 <% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
 <% basic_search_label = I18n.locale.to_s == "ja" ? "\u57FA\u672C\u691C\u7D22" : "Basic search" %>
 <% detailed_search_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u691C\u7D22" : "Detailed search" %>
+<% basic_step_label = I18n.locale.to_s == "ja" ? "\u30B9\u30C6\u30C3\u30D71" : "Step 1" %>
+<% optional_label = I18n.locale.to_s == "ja" ? "\u4EFB\u610F" : "Optional" %>
+<% max_card_tags = 2 %>
 <% active_filters = {
   category: params[:category].to_s.strip,
   theme: params[:theme].to_s.strip,
@@ -38,24 +41,30 @@
     </p>
   </div>
 
-  <div class="rounded-xl border border-slate-200 bg-white p-4">
-    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-3", data: { search_form: true } do %>
+  <div class="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5">
+    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-4", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
-      <div class="rounded-lg border border-slate-200 bg-white p-3">
-        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= basic_search_label %></p>
-        <div class="mt-2 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
+      <div class="rounded-xl border border-slate-200 bg-white p-3 sm:p-4">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= basic_search_label %></p>
+          <span class="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700"><%= basic_step_label %></span>
+        </div>
+        <div class="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
           <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
-          <div class="grid gap-2 sm:flex sm:gap-2">
-            <%= submit_tag t("posts.index.search_button"), class: "tap-target w-full rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700 sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
-            <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 sm:w-auto", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
-          </div>
+          <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-secondary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
+        </div>
+        <div class="mt-2 text-right">
+          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center px-1.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-900", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
       </div>
 
-      <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
-        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500"><%= detailed_search_label %></p>
-        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+      <div class="rounded-xl border border-slate-200 bg-slate-50/80 p-3 sm:p-4">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= detailed_search_label %></p>
+          <span class="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-600"><%= optional_label %></span>
+        </div>
+        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target mt-2 inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
           <span class="inline-flex items-center gap-2">
             <span><%= detailed_toggle_label %></span>
             <% if detailed_filter_count.positive? %>
@@ -94,39 +103,49 @@
     <% end %>
   </div>
 
-  <% if @posts.any? %>
+      <% if @posts.any? %>
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
+        <% visible_tags = post.tags.first(max_card_tags) %>
+        <% hidden_tag_count = [post.tags.size - visible_tags.size, 0].max %>
         <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
           <%= link_to post_path(post), class: "block", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
             <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-40 w-full object-cover sm:h-44") %>
           <% end %>
 
-          <div class="flex h-full flex-col space-y-2.5 p-4">
+          <div class="flex h-full flex-col p-4">
             <h2 class="text-base font-semibold text-slate-900">
               <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-5 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
             </h2>
 
-            <p class="ds-line-clamp-3 text-sm leading-6 text-slate-700"><%= truncate(post.description, length: 110) %></p>
+            <p class="mt-1 text-sm text-slate-600">
+              <%= t("posts.index.author_label") %>:
+              <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 hover:text-slate-900", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+            </p>
 
-            <div class="flex flex-wrap items-center gap-2 rounded-lg bg-slate-50/70 px-3 py-2 text-xs" aria-label="Post summary metrics">
-              <% if post.category.present? %>
-                <span class="rounded-full bg-blue-100/80 px-2 py-1 font-medium text-blue-700"><%= post.category %></span>
-              <% end %>
-              <span class="inline-flex items-center gap-1 text-slate-700">
-                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                <span><%= localized_number(post.likes_count) %></span>
-              </span>
-              <span class="text-slate-600"><%= l(post.created_at.to_date) %></span>
-            </div>
+            <p class="mt-2 ds-line-clamp-2 text-sm leading-6 text-slate-600"><%= truncate(post.description, length: 90) %></p>
 
-            <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3 text-xs text-slate-500" aria-label="Post metadata">
-              <span>
-                <%= t("posts.index.author_label") %>:
-                <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-600 hover:text-slate-800", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-              </span>
-              <% post.tags.first(3).each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-slate-600 hover:bg-slate-200 hover:text-slate-800", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+            <div class="mt-auto space-y-2 border-t border-slate-100 pt-3 text-xs text-slate-500" aria-label="Post metadata">
+              <div class="flex flex-wrap items-center gap-2">
+                <% if post.category.present? %>
+                  <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600"><%= post.category %></span>
+                <% end %>
+                <span><%= l(post.created_at.to_date) %></span>
+                <span class="inline-flex items-center gap-1">
+                  <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                  <span><%= localized_number(post.likes_count) %></span>
+                </span>
+              </div>
+              <div class="flex flex-wrap items-center gap-2">
+                <% visible_tags.each do |tag| %>
+                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+                <% end %>
+                <% if hidden_tag_count.positive? %>
+                  <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-slate-500">+<%= hidden_tag_count %></span>
+                <% end %>
+              </div>
+              <% if visible_tags.empty? && hidden_tag_count.zero? %>
+                <p class="text-slate-400"><%= no_filters_label %></p>
               <% end %>
             </div>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, @post.title %>
 <% content_for :description, truncate(@post.description, length: 120) %>
 <% content_for :og_image_url, og_image_url(@post) %>
+<% body_section_label = I18n.locale.to_s == "ja" ? "本文" : "Overview" %>
+<% comments_lead_label = I18n.locale.to_s == "ja" ? "本文と関連アイテムを読んだあとに、感想や質問を投稿できます。" : "After reading the post and related items, join the conversation below." %>
 
 <article class="space-y-content">
   <header class="space-y-3">
@@ -24,23 +26,23 @@
     <%= optimized_post_image_tag(@post, variant: :main, class: "w-full object-cover") %>
   </div>
 
-  <div class="rounded-xl border border-slate-200 bg-white p-6">
-    <div class="max-w-3xl">
+  <section class="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
+    <h2 class="text-lg font-semibold text-slate-900"><%= body_section_label %></h2>
+    <div class="mt-3 max-w-3xl">
       <p class="whitespace-pre-wrap text-base leading-reading text-slate-700"><%= @post.description %></p>
     </div>
-  </div>
+    <% if @post.tags.any? %>
+      <div class="mt-4 flex flex-wrap gap-2 border-t border-slate-100 pt-4">
+        <% @post.tags.each do |tag| %>
+          <%= link_to "##{tag}", posts_path(tag: tag), class: "rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600 hover:bg-slate-200 hover:text-slate-800" %>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
 
-  <% if @post.tags.any? %>
-    <div class="flex flex-wrap gap-2">
-      <% @post.tags.each do |tag| %>
-        <%= link_to "##{tag}", posts_path(tag: tag), class: "rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100" %>
-      <% end %>
-    </div>
-  <% end %>
-
-  <section class="rounded-xl border border-slate-200 bg-white p-6">
+  <section class="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-lg font-semibold text-slate-900"><%= t("posts.show.related_items") %></h2>
+      <h2 class="text-xl font-bold text-slate-900"><%= t("posts.show.related_items") %></h2>
       <span class="inline-flex items-center gap-1 text-sm text-slate-500">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span>
@@ -63,137 +65,14 @@
     <% end %>
   </section>
 
-  <div class="hidden flex-wrap items-center gap-3 sm:flex">
-    <%= button_to like_post_path(@post), method: :post, class: "tap-target rounded-lg bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
-      <span class="inline-flex items-center gap-1.5">
-        <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.like") %></span>
-      </span>
-    <% end %>
-    <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100", data: { ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x" } do %>
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.share_x") %></span>
-    <% end %>
-    <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100", data: { ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads" } do %>
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.share_threads") %></span>
-    <% end %>
-    <button type="button" data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100">
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.copy_url") %></span>
-    </button>
-    <% unless post_owner?(@post) %>
-      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target inline-flex items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-4 py-2 text-sm text-amber-800 hover:bg-amber-50">
-        <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.report") %></span>
-      </button>
-    <% end %>
-  </div>
-
-  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden" data-mobile-actions-root>
-    <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
-      <div class="relative pb-1">
-        <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
-          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target w-full rounded-lg bg-rose-500 px-3 py-2 text-sm font-semibold text-white hover:bg-rose-600", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
-            <span class="inline-flex items-center justify-center gap-1.5">
-              <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.like") %></span>
-            </span>
-          <% end %>
-          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">
-            <span class="inline-flex items-center gap-1.5">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share") %></span>
-            </span>
-          </button>
-          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-slate-700 hover:bg-slate-100">
-            <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
-            <span class="sr-only">More</span>
-          </button>
-        </div>
-
-        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-10 mb-2 hidden rounded-xl border border-slate-200 bg-white p-2 shadow-lg">
-          <div class="grid gap-1">
-            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_x") %></span>
-            <% end %>
-            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "mobile_share_threads_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_threads") %></span>
-            <% end %>
-            <button type="button" data-mobile-menu-action data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="mobile_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.copy_url") %></span>
-            </button>
-            <% unless post_owner?(@post) %>
-              <button type="button" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="mobile_report_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-amber-800 hover:bg-amber-50">
-                <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-                <span><%= t("posts.show.actions.report") %></span>
-              </button>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <% if post_owner?(@post) %>
-    <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
-      <%= link_to edit_post_path(@post), class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" do %>
-        <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.edit") %></span>
-      <% end %>
-      <%= link_to notifications_post_path(@post), class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm hover:bg-slate-100" do %>
-        <%= ui_icon(:bell, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span>
-      <% end %>
-      <%= button_to post_path(@post), method: :delete, form: { class: "inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" do %>
-        <%= ui_icon(:trash, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.delete") %></span>
-      <% end %>
-    </div>
-  <% end %>
-
-  <% unless post_owner?(@post) %>
-    <dialog id="report-modal-<%= @post.id %>" class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
-      <div class="border-b border-slate-200 px-4 py-3">
-        <h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2>
-        <p class="mt-1 text-xs text-slate-500"><%= t("posts.show.report.description") %></p>
-      </div>
-      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4" do |f| %>
-        <% if owned_users.any? %>
-          <div>
-            <%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %>
-            <%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
-          </div>
-        <% end %>
-
-        <div>
-          <%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
-        </div>
-
-        <div>
-          <%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.text_area :details, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.report.details_placeholder") %>
-        </div>
-
-        <div class="flex justify-end gap-2 pt-2">
-          <button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="tap-target rounded-lg border border-slate-300 px-3 py-2 text-sm hover:bg-slate-100"><%= t("posts.show.report.cancel") %></button>
-          <%= f.submit t("posts.show.report.submit"), class: "tap-target rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600" %>
-        </div>
-      <% end %>
-    </dialog>
-  <% end %>
-
-  <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
-
   <section id="comments" class="space-y-form rounded-xl border border-slate-200 bg-white p-4 sm:p-6">
-    <h2 class="inline-flex items-center gap-1.5 text-lg font-semibold text-slate-900">
-      <%= ui_icon(:chat, class_name: "h-5 w-5") %>
-      <span><%= t("posts.show.comments.title") %></span>
-    </h2>
+    <div class="space-y-2">
+      <h2 class="inline-flex items-center gap-1.5 text-xl font-bold text-slate-900">
+        <%= ui_icon(:chat, class_name: "h-5 w-5") %>
+        <span><%= t("posts.show.comments.title") %></span>
+      </h2>
+      <p class="text-sm text-slate-500"><%= comments_lead_label %></p>
+    </div>
 
     <% if @root_comments.any? %>
       <div class="space-y-5">
@@ -266,7 +145,7 @@
         <% if recaptcha_enabled? %>
           <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <% end %>
-        <%= f.button type: :submit, class: "tap-target rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700" do %>
+        <%= f.button type: :submit, class: "tap-target cta-primary" do %>
           <span class="inline-flex items-center gap-1.5">
             <%= ui_icon(:chat, class_name: "h-4 w-4") %>
             <span><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span>
@@ -275,6 +154,132 @@
       <% end %>
     </div>
   </section>
+
+  <div class="hidden flex-wrap items-center gap-3 sm:flex">
+    <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-secondary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
+      <span class="inline-flex items-center gap-1.5">
+        <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+        <span><%= t("posts.show.actions.like") %></span>
+      </span>
+    <% end %>
+    <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target cta-secondary", data: { ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x" } do %>
+      <%= ui_icon(:share, class_name: "h-4 w-4") %>
+      <span><%= t("posts.show.actions.share_x") %></span>
+    <% end %>
+    <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target cta-secondary", data: { ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads" } do %>
+      <%= ui_icon(:share, class_name: "h-4 w-4") %>
+      <span><%= t("posts.show.actions.share_threads") %></span>
+    <% end %>
+    <button type="button" data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url" class="tap-target cta-secondary">
+      <%= ui_icon(:share, class_name: "h-4 w-4") %>
+      <span><%= t("posts.show.actions.copy_url") %></span>
+    </button>
+    <% unless post_owner?(@post) %>
+      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target cta-secondary border-amber-300 text-amber-800 hover:bg-amber-50">
+        <%= ui_icon(:flag, class_name: "h-4 w-4") %>
+        <span><%= t("posts.show.actions.report") %></span>
+      </button>
+    <% end %>
+  </div>
+
+  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden" data-mobile-actions-root>
+    <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
+      <div class="relative pb-1">
+        <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-secondary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+            <span class="inline-flex items-center justify-center gap-1.5">
+              <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.like") %></span>
+            </span>
+          <% end %>
+          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target cta-secondary w-full justify-center">
+            <span class="inline-flex items-center gap-1.5">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share") %></span>
+            </span>
+          </button>
+          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target cta-secondary px-3 text-slate-700">
+            <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
+            <span class="sr-only">More</span>
+          </button>
+        </div>
+
+        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-10 mb-2 hidden rounded-xl border border-slate-200 bg-white p-2 shadow-lg">
+          <div class="grid gap-1">
+            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_x") %></span>
+            <% end %>
+            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "mobile_share_threads_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_threads") %></span>
+            <% end %>
+            <button type="button" data-mobile-menu-action data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="mobile_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.copy_url") %></span>
+            </button>
+            <% unless post_owner?(@post) %>
+              <button type="button" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="mobile_report_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-amber-800 hover:bg-amber-50">
+                <%= ui_icon(:flag, class_name: "h-4 w-4") %>
+                <span><%= t("posts.show.actions.report") %></span>
+              </button>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% if post_owner?(@post) %>
+    <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
+      <%= link_to edit_post_path(@post), class: "tap-target cta-primary" do %>
+        <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
+        <span><%= t("posts.show.actions.edit") %></span>
+      <% end %>
+      <%= link_to notifications_post_path(@post), class: "tap-target cta-secondary" do %>
+        <%= ui_icon(:bell, class_name: "h-4 w-4") %>
+        <span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span>
+      <% end %>
+      <%= button_to post_path(@post), method: :delete, form: { class: "inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700 hover:bg-red-100" do %>
+        <%= ui_icon(:trash, class_name: "h-4 w-4") %>
+        <span><%= t("posts.show.actions.delete") %></span>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% unless post_owner?(@post) %>
+    <dialog id="report-modal-<%= @post.id %>" class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
+      <div class="border-b border-slate-200 px-4 py-3">
+        <h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2>
+        <p class="mt-1 text-xs text-slate-500"><%= t("posts.show.report.description") %></p>
+      </div>
+      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4" do |f| %>
+        <% if owned_users.any? %>
+          <div>
+            <%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %>
+            <%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+          </div>
+        <% end %>
+
+        <div>
+          <%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %>
+          <%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+        </div>
+
+        <div>
+          <%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %>
+          <%= f.text_area :details, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.report.details_placeholder") %>
+        </div>
+
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="tap-target cta-secondary"><%= t("posts.show.report.cancel") %></button>
+          <%= f.submit t("posts.show.report.submit"), class: "tap-target cta-secondary border-amber-300 text-amber-800 hover:bg-amber-50" %>
+        </div>
+      <% end %>
+    </dialog>
+  <% end %>
+
+  <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %>
 </article>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/53

## 目的

  一覧ページ・詳細ページの情報階層を整理し、初見ユーザーが「最初の3秒」で画面構造を理解できる状態にする。
  具体的には、検索・閲覧・投稿の3導線を明確化し、次の行動（検索する／読む／投稿する）を迷いなく選べるUIにする。

  ## 実装内容

  - 検索UIを2段階化
  - 一覧カードの情報優先度を再設計（主: サムネ・タイトル・作者、従: 日付/いいね/カテゴリ/タグ）
  - タグ表示を上限2件 + +n 集約に変更
  - 詳細ページを「本文 → 関連アイテム → コメント」の順に再配置
  - CTAの役割色を統一（Primary/Secondary）
  - モバイルヘッダーを簡素化してファーストビュー占有率を改善

  ## 方法

  - 既存のERB構造を活かしつつ、セクション順序とクラス設計を調整
  - 再利用可能なCTAユーティリティクラスをTailwind層に追加
  - 既存イベント計測（data-ga-*）は維持してUI変更のみ反映
  - 文言追加はi18nを壊さない範囲でローカル変数化して対応

  ## 変更箇所

  - 一覧ページ
    app/views/posts/index.html.erb:44
  - 詳細ページ
    app/views/posts/show.html.erb:29
  - レイアウト（モバイルヘッダー・モバイル投稿導線）
    app/views/layouts/application.html.erb:55
  - CTA共通スタイル追加
    app/assets/tailwind/application.css:108

  ## まとめ

  要件に沿って、一覧・詳細・ヘッダーの情報設計を一貫して整理しました。
  特に「検索は段階的」「カードは主情報優先」「詳細は読み順固定」「CTA色は役割固定」を実装し、視線誘導と行動選択の明確化を行っています。

  ## Testing

  - 実行: ruby -c app/helpers/application_helper.rb; ruby -c app/controllers/posts_controller.rb
    結果: Syntax OK
  - 実行: ERBパースチェック（ERB.new(File.read(...)).src）
    結果: 問題なし
  - 実行: ruby bin/rails test test/controllers/posts_controller_test.rb test/controllers/locale_selection_test.rb
    結果: 失敗（PostgreSQL接続不可: 127.0.0.1:5433 connection refused）
