### PR TITLE
UI Optimization: Clarify search hierarchy and streamline mobile action bar

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -113,6 +113,13 @@
     @apply inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100;
   }
 
+  .cta-primary:focus-visible,
+  .cta-secondary:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow: var(--ds-focus-ring-shadow);
+  }
+
   @media (max-width: 640px) {
     .tap-target {
       padding-top: 0.625rem;

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -42,29 +42,29 @@
   </div>
 
   <div class="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5">
-    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-4", data: { search_form: true } do %>
+    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-2.5", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
       <div class="rounded-xl border border-slate-200 bg-white p-3 sm:p-4">
         <div class="flex items-center justify-between gap-2">
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= basic_search_label %></p>
           <span class="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700"><%= basic_step_label %></span>
         </div>
-        <div class="mt-3 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
+        <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
           <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
-          <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-secondary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
+          <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-primary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
         </div>
         <div class="mt-2 text-right">
           <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center px-1.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-900", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
       </div>
 
-      <div class="rounded-xl border border-slate-200 bg-slate-50/80 p-3 sm:p-4">
+      <div class="rounded-xl border border-slate-100 bg-slate-50/40 p-3 sm:p-3.5">
         <div class="flex items-center justify-between gap-2">
           <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= detailed_search_label %></p>
           <span class="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-600"><%= optional_label %></span>
         </div>
-        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target mt-2 inline-flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target mt-1.5 inline-flex w-full items-center justify-between rounded-lg border border-slate-100 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
           <span class="inline-flex items-center gap-2">
             <span><%= detailed_toggle_label %></span>
             <% if detailed_filter_count.positive? %>
@@ -77,7 +77,7 @@
         </span>
       </button>
 
-        <div data-details-panel class="mt-3 grid gap-3 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
+        <div data-details-panel class="mt-2.5 grid gap-2.5 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
           <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
           <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
         </div>
@@ -136,12 +136,12 @@
                   <span><%= localized_number(post.likes_count) %></span>
                 </span>
               </div>
-              <div class="flex flex-wrap items-center gap-2">
+              <div class="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
                 <% visible_tags.each do |tag| %>
-                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-slate-500 hover:bg-slate-200 hover:text-slate-700", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
                 <% end %>
                 <% if hidden_tag_count.positive? %>
-                  <span class="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-slate-500">+<%= hidden_tag_count %></span>
+                  <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
                 <% end %>
               </div>
               <% if visible_tags.empty? && hidden_tag_count.zero? %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -185,26 +185,26 @@
   <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden" data-mobile-actions-root>
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
       <div class="relative pb-1">
-        <div class="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-2">
-          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-secondary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+        <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5">
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-primary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
             <span class="inline-flex items-center justify-center gap-1.5">
               <%= ui_icon(:heart, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.like") %></span>
             </span>
           <% end %>
-          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target cta-secondary w-full justify-center">
+          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target inline-flex items-center justify-center gap-1 rounded-lg px-2.5 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900">
             <span class="inline-flex items-center gap-1.5">
               <%= ui_icon(:share, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.share") %></span>
             </span>
           </button>
-          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target cta-secondary px-3 text-slate-700">
+          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target inline-flex items-center justify-center rounded-lg px-2.5 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
             <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
             <span class="sr-only">More</span>
           </button>
         </div>
 
-        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-10 mb-2 hidden rounded-xl border border-slate-200 bg-white p-2 shadow-lg">
+        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-20 mb-2 hidden rounded-xl border border-slate-300 bg-white/98 p-2 shadow-2xl ring-1 ring-slate-900/5">
           <div class="grid gap-1">
             <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
               <%= ui_icon(:share, class_name: "h-4 w-4") %>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/55

## 目的

  投稿一覧と投稿詳細において、初見ユーザーの判断コストを下げるため、主アクションと補助情報の優先度を明確化する。
  特に、一覧の検索導線と詳細のモバイル固定アクションで「まず何をするか」を視覚的に即理解できる状態にする。

  ## 実装内容

  - 一覧検索の主従を再調整
  - 基本検索ボタンを Primary 化（1st CTA）
  - 詳細検索ブロックを低コントラスト化し、入力群との距離を縮小
  - カードメタ情報の密度調整
  - タグ行を主要メタより一段弱い視覚（薄色・小さめ）に変更
  - タグ表示は既存方針の 2件 + +n を維持
  - 詳細モバイル固定アクションの簡素化
  - Like のみ塗り（Primary）
  - Share / More はテキスト寄りの軽い見た目に変更
  - More 展開メニューの背景/影/境界を強化
  - フォーカス可視性の一貫性向上
  - cta-primary / cta-secondary に同一の focus-visible リングを明示適用

  ## 方法

  - 既存ERB構造とGAイベント属性を維持したまま、Tailwindクラスのみ中心に調整
  - UIの情報階層を壊さないよう、色・余白・境界線の強度を段階的に変更
  - 共通化可能なフォーカス定義は application.css の @layer utilities で一元管理

  ## 変更箇所

  - 一覧ページ検索・カードメタ
      - app/views/posts/index.html.erb:44
  - 詳細ページモバイル固定アクション・Moreメニュー
      - app/views/posts/show.html.erb:185
  - CTAフォーカス一貫化
      - app/assets/tailwind/application.css:116

  ## まとめ

  要件どおり、一覧は「基本検索優先・詳細検索控えめ」、詳細は「Like優先・補助操作軽量」の構造に寄せました。
  また、CTAのフォーカス視認性を統一し、キーボード操作時の品質も揃えています。

  ## Testing

  - 実行: ERB構文チェック（ERB.new(...).src）
      - 対象: app/views/posts/index.html.erb, app/views/posts/show.html.erb
      - 結果: 問題なし
  - 実行: git diff --check
      - 結果: 問題なし（CRLF警告のみ）
  - 備考: Railsテストは未実行（この変更範囲は主にビュー/CSS）