### PR TITLE
Modernize UX: Standardized UI hierarchy, improved form flow, and enhanced accessibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -11,6 +11,11 @@
     --ds-space-form: 1.5rem;
     --ds-focus-ring-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
     --ds-focus-border-color: rgb(37, 99, 235);
+    --ds-text-main: rgb(15 23 42);
+    --ds-text-body: rgb(51 65 85);
+    --ds-text-support: rgb(71 85 105);
+    --ds-text-meta: rgb(71 85 105);
+    --ds-text-muted: rgb(100 116 139);
   }
 
   html[lang="ja"] {
@@ -42,6 +47,7 @@
   body {
     font-family: var(--ds-font-sans);
     letter-spacing: var(--ds-letter-spacing-body);
+    color: var(--ds-text-main);
   }
 
   a,
@@ -76,6 +82,42 @@
 }
 
 @layer utilities {
+  .ds-heading-xl {
+    @apply text-2xl font-bold sm:text-3xl;
+  }
+
+  .ds-heading-lg {
+    @apply text-xl font-bold;
+  }
+
+  .ds-heading-md {
+    @apply text-lg font-semibold;
+  }
+
+  .ds-text-body {
+    @apply text-base;
+    color: var(--ds-text-body);
+    line-height: var(--ds-line-height-reading);
+  }
+
+  .ds-text-support {
+    @apply text-sm;
+    color: var(--ds-text-support);
+    line-height: 1.55;
+  }
+
+  .ds-text-meta {
+    @apply text-xs;
+    color: var(--ds-text-meta);
+    line-height: 1.45;
+  }
+
+  .ds-text-muted {
+    @apply text-xs;
+    color: var(--ds-text-muted);
+    line-height: 1.4;
+  }
+
   .leading-reading {
     line-height: var(--ds-line-height-reading);
   }
@@ -105,6 +147,18 @@
     min-width: 44px;
   }
 
+  .ds-card {
+    @apply rounded-xl border border-slate-200 bg-white;
+  }
+
+  .ds-badge {
+    @apply inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-600;
+  }
+
+  .ds-shadow-soft {
+    box-shadow: 0 6px 24px rgba(15, 23, 42, 0.06);
+  }
+
   .cta-primary {
     @apply inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700;
   }
@@ -113,11 +167,25 @@
     @apply inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100;
   }
 
+  .cta-tertiary {
+    @apply inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-900;
+  }
+
+  .cta-compact {
+    @apply px-3 py-1.5 text-xs;
+  }
+
   .cta-primary:focus-visible,
-  .cta-secondary:focus-visible {
+  .cta-secondary:focus-visible,
+  .cta-tertiary:focus-visible {
     outline: 2px solid transparent;
     outline-offset: 2px;
     box-shadow: var(--ds-focus-ring-shadow);
+  }
+
+  .mobile-sticky-bar {
+    @apply fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur;
+    box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
   }
 
   @media (max-width: 640px) {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy notifications]
   before_action :require_owned_user!, only: %i[new create]
   before_action :prepare_owned_users, only: %i[new create edit update]
+  before_action :prepare_form_suggestions, only: %i[new create edit update]
   before_action :require_post_owner!, only: %i[edit update destroy notifications]
 
   def index
@@ -157,6 +158,13 @@ class PostsController < ApplicationController
 
   def prepare_owned_users
     @owned_users = owned_users.to_a
+  end
+
+  def prepare_form_suggestions
+    @category_suggestions = Post.visible.where.not(category: [ nil, "" ]).distinct.order(:category).limit(24).pluck(:category)
+    @tag_suggestions = Post.visible.where.not(tag_list: [ nil, "" ]).pluck(:tag_list).flat_map { |list|
+      list.to_s.split(",").map(&:strip)
+    }.reject(&:blank?).uniq.first(40)
   end
 
   def selected_owned_user

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,12 +51,14 @@
 
   <body class="lang-<%= I18n.locale %> min-h-screen bg-slate-50 text-slate-800">
     <% tracked_events = analytics_events %>
+    <% mobile_sticky_active = controller_name == "posts" && action_name.in?(%w[index show]) %>
+    <% main_padding_class = mobile_sticky_active ? "pb-40 sm:pb-8" : "pb-10 sm:pb-8" %>
 
     <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur" data-mobile-header-root>
       <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-2 sm:px-6 sm:py-3">
         <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-base font-bold text-slate-900 sm:text-lg", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
 
-        <%= link_to new_post_path, class: "tap-target cta-primary px-3 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_icon" } do %>
+        <%= link_to new_post_path, class: "tap-target cta-tertiary px-3 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_icon" } do %>
           <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
           <span class="sr-only"><%= t("navigation.create_post") %></span>
         <% end %>
@@ -76,7 +78,7 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
         </div>
       </div>
 
@@ -96,7 +98,7 @@
       </div>
     </header>
 
-    <main class="mx-auto w-full max-w-6xl px-4 pb-28 pt-8 sm:px-6 sm:pb-8">
+    <main class="mx-auto w-full max-w-6xl px-4 pt-8 <%= main_padding_class %> sm:px-6">
       <% flash.each do |type, message| %>
         <% next if type.to_s == "analytics_events" %>
         <% visual = flash_visual(type) %>
@@ -121,9 +123,9 @@
     </main>
 
     <% if controller_name == "posts" && action_name == "index" %>
-      <div class="fixed inset-x-0 bottom-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden">
+      <div class="mobile-sticky-bar sm:hidden">
         <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
         </div>
       </div>
     <% end %>
@@ -138,10 +140,22 @@
         </div>
       </div>
     </footer>
+    <p id="ui-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></p>
 
     <script>
       if (!window.__mobileHeaderBindingInstalled) {
         window.__mobileHeaderBindingInstalled = true;
+        const menuOpenedMessage = "<%= j(I18n.locale.to_s == 'ja' ? 'メニューを開きました' : 'Menu opened') %>";
+        const menuClosedMessage = "<%= j(I18n.locale.to_s == 'ja' ? 'メニューを閉じました' : 'Menu closed') %>";
+        window.dsAnnounce = (message) => {
+          if (!message) return;
+          const region = document.getElementById("ui-live-region");
+          if (!region) return;
+          region.textContent = "";
+          requestAnimationFrame(() => {
+            region.textContent = message;
+          });
+        };
 
         const closeMobileHeaderMenu = (reason = "dismissed") => {
           const menu = document.querySelector("[data-mobile-header-menu]");
@@ -150,6 +164,7 @@
 
           menu.classList.add("hidden");
           if (toggle) toggle.setAttribute("aria-expanded", "false");
+          window.dsAnnounce(menuClosedMessage);
           if (typeof window.gtag === "function") {
             window.gtag("event", "navigation_mobile_menu_close", {
               event_category: "navigation",
@@ -170,6 +185,7 @@
             } else {
               toggle.setAttribute("aria-expanded", "true");
               menu.classList.remove("hidden");
+              window.dsAnnounce(menuOpenedMessage);
             }
             return;
           }
@@ -198,11 +214,22 @@
         const button = event.target.closest("[data-copy-url]");
         if (!button) return;
         const target = button.getAttribute("data-copy-url");
+        const labelNode = button.querySelector("[data-copy-label]") || button.querySelector("span:last-child");
+        const defaultLabel = button.dataset.defaultLabel || (labelNode ? labelNode.textContent.trim() : "");
         try {
           await navigator.clipboard.writeText(target);
-          button.textContent = "<%= j(t('clipboard.copy_success')) %>";
+          if (labelNode) labelNode.textContent = "<%= j(t('clipboard.copy_success')) %>";
+          button.dataset.defaultLabel = defaultLabel;
+          if (typeof window.dsAnnounce === "function") window.dsAnnounce("<%= j(t('clipboard.copy_success')) %>");
         } catch (_) {
-          button.textContent = "<%= j(t('clipboard.copy_failed')) %>";
+          if (labelNode) labelNode.textContent = "<%= j(t('clipboard.copy_failed')) %>";
+          button.dataset.defaultLabel = defaultLabel;
+          if (typeof window.dsAnnounce === "function") window.dsAnnounce("<%= j(t('clipboard.copy_failed')) %>");
+        }
+        if (labelNode && defaultLabel.length > 0) {
+          window.setTimeout(() => {
+            labelNode.textContent = defaultLabel;
+          }, 1800);
         }
       });
     </script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,77 +1,183 @@
 <% submit_label ||= t("posts.form.publish") %>
 <% owned_users ||= [] %>
+<% category_suggestions ||= [] %>
+<% tag_suggestions ||= [] %>
+<% locale_ja = I18n.locale.to_s == "ja" %>
+<% required_section_label = locale_ja ? "必須の基本情報" : "Required basics" %>
+<% required_section_lead = locale_ja ? "まずは投稿内容の核となる情報を入力します。" : "Start with the core information for your post." %>
+<% optional_section_label = locale_ja ? "任意の詳細情報" : "Optional details" %>
+<% optional_section_lead = locale_ja ? "カテゴリ・テーマ・タグで見つけやすくできます。" : "Add category, theme, and tags to improve discoverability." %>
+<% profile_example = locale_ja ? "例: メインの投稿プロフィールを選択" : "Example: select your default posting profile" %>
+<% title_example = locale_ja ? "例: 木目とブラックで統一した開発デスク" : "Example: Black and walnut developer desk setup" %>
+<% description_example = locale_ja ? "例: デバイス構成、レイアウトの工夫、1日の使い方を3〜5文で。" : "Example: describe your devices, layout choices, and daily workflow in 3-5 sentences." %>
+<% image_example = locale_ja ? "推奨: 横長で明るい写真（1200px以上）" : "Recommended: bright landscape photo (1200px or wider)" %>
+<% category_example = locale_ja ? "例: Engineering, Design, Writing" : "Example: Engineering, Design, Writing" %>
+<% theme_example = locale_ja ? "例: Dark, Minimal, Natural" : "Example: Dark, Minimal, Natural" %>
+<% tags_example = locale_ja ? "例: mechanical keyboard, standing desk（カンマ区切り）" : "Example: mechanical keyboard, standing desk (comma-separated)" %>
+<% item_name_example = locale_ja ? "例: HHKB Professional HYBRID Type-S" : "Example: HHKB Professional HYBRID Type-S" %>
+<% item_url_example = locale_ja ? "例: https://www.amazon.co.jp/... または公式ストアURL" : "Example: https://www.amazon.com/... or the official store URL" %>
+<% field_error = ->(attr) { post.errors.full_messages_for(attr).first } %>
+<% input_class = ->(error) { "w-full rounded-lg border px-3 py-2 text-sm #{error.present? ? 'border-red-400 bg-red-50' : 'border-slate-300'}" } %>
+<% title_error = field_error.call(:title) %>
+<% description_error = field_error.call(:description) %>
+<% category_error = field_error.call(:category) %>
+<% theme_error = field_error.call(:theme) %>
+<% tag_list_error = field_error.call(:tag_list) %>
+<% image_error = field_error.call(:desk_image) %>
+<% profile_error = field_error.call(:user) %>
 
-<%= form_with model: post, class: "space-y-form" do |f| %>
-<% if post.errors.any? %>
-<div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
-    <p class="mb-2 font-semibold"><%= t("posts.form.error_summary") %></p>
-    <ul class="list-disc pl-5">
+<%= form_with model: post, class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
+  <% if post.errors.any? %>
+    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
+      <p class="mb-2 font-semibold"><%= t("posts.form.error_summary") %></p>
+      <ul class="list-disc pl-5">
         <% post.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
+          <li><%= message %></li>
         <% end %>
-    </ul>
-</div>
-<% end %>
-
-<div class="grid gap-4 sm:grid-cols-2">
-    <% if owned_users.any? %>
-    <div class="sm:col-span-2">
-        <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2" %>
+      </ul>
     </div>
-    <% end %>
+  <% end %>
 
-    <div class="sm:col-span-2">
-        <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.text_field :title, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: t("posts.form.title_placeholder") %>
-    </div>
-
-    <div class="sm:col-span-2">
-        <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.text_area :description, rows: 7, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: t("posts.form.description_placeholder") %>
-    </div>
-
+  <section class="space-y-4 rounded-xl border border-slate-200 bg-white p-4 sm:p-5">
     <div>
-        <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.text_field :category, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: t("posts.form.category_placeholder") %>
+      <h2 class="ds-heading-md"><%= required_section_label %></h2>
+      <p class="mt-1 ds-text-support"><%= required_section_lead %></p>
     </div>
 
-    <div>
-        <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.text_field :theme, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: t("posts.form.theme_placeholder") %>
-    </div>
-
-    <div class="sm:col-span-2">
-        <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.text_field :tag_list, class: "w-full rounded-lg border border-slate-300 px-3 py-2", placeholder: t("posts.form.tags_placeholder") %>
-    </div>
-
-    <div class="sm:col-span-2">
-        <%= f.label :desk_image, t("posts.form.image_label"), class: "mb-1 block text-sm font-medium" %>
-        <%= f.file_field :desk_image, class: "w-full rounded-lg border border-slate-300 px-3 py-2", accept: "image/*" %>
-    </div>
-</div>
-
-<div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-    <p class="mb-3 text-sm font-semibold text-slate-700"><%= t("posts.form.related_items") %></p>
-    <div class="space-y-4">
-        <%= f.fields_for :items do |item_fields| %>
-        <div class="grid gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:grid-cols-2">
-            <div>
-                <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium text-slate-600" %>
-                <%= item_fields.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.item_name_placeholder") %>
-            </div>
-            <div>
-                <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium text-slate-600" %>
-                <%= item_fields.url_field :affiliate_url, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.affiliate_url_placeholder") %>
-            </div>
+    <div class="grid gap-4 sm:grid-cols-2">
+      <% if owned_users.any? %>
+        <div class="sm:col-span-2">
+          <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+          <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: input_class.call(profile_error), aria: { invalid: profile_error.present? ? "true" : nil, describedby: "post_user_id_help post_user_id_error" } %>
+          <p id="post_user_id_help" class="mt-1 ds-text-muted"><%= profile_example %></p>
+          <% if profile_error.present? %>
+            <p id="post_user_id_error" class="mt-1 text-xs font-medium text-red-700"><%= profile_error %></p>
+          <% end %>
         </div>
-        <% end %>
-    </div>
-</div>
+      <% end %>
 
-<div class="flex flex-wrap gap-3">
-    <%= f.submit t("posts.form.publish"), class: "tap-target rounded-lg bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-700" %>
-    <%= f.submit t("posts.form.save_draft"), name: "save_as_draft", value: "1", class: "tap-target rounded-lg border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-100" %>
-</div>
+      <div class="sm:col-span-2">
+        <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.text_field :title, class: input_class.call(title_error), placeholder: t("posts.form.title_placeholder"), aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_error" } %>
+        <p id="post_title_help" class="mt-1 ds-text-muted"><%= title_example %></p>
+        <% if title_error.present? %>
+          <p id="post_title_error" class="mt-1 text-xs font-medium text-red-700"><%= title_error %></p>
+        <% end %>
+      </div>
+
+      <div class="sm:col-span-2">
+        <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.text_area :description, rows: 7, class: input_class.call(description_error), placeholder: t("posts.form.description_placeholder"), aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_error" } %>
+        <p id="post_description_help" class="mt-1 ds-text-muted"><%= description_example %></p>
+        <% if description_error.present? %>
+          <p id="post_description_error" class="mt-1 text-xs font-medium text-red-700"><%= description_error %></p>
+        <% end %>
+      </div>
+
+      <div class="sm:col-span-2">
+        <%= f.label :desk_image, t("posts.form.image_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.file_field :desk_image, class: input_class.call(image_error), accept: "image/*", aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error" } %>
+        <p id="post_image_help" class="mt-1 ds-text-muted"><%= image_example %></p>
+        <% if image_error.present? %>
+          <p id="post_image_error" class="mt-1 text-xs font-medium text-red-700"><%= image_error %></p>
+        <% end %>
+      </div>
+    </div>
+  </section>
+
+  <section class="space-y-4 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:p-5">
+    <div>
+      <h2 class="ds-heading-md"><%= optional_section_label %></h2>
+      <p class="mt-1 ds-text-support"><%= optional_section_lead %></p>
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      <div>
+        <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.text_field :category, class: input_class.call(category_error), placeholder: t("posts.form.category_placeholder"), list: "post-category-options", aria: { invalid: category_error.present? ? "true" : nil, describedby: "post_category_help post_category_error" } %>
+        <p id="post_category_help" class="mt-1 ds-text-muted"><%= category_example %></p>
+        <% if category_error.present? %>
+          <p id="post_category_error" class="mt-1 text-xs font-medium text-red-700"><%= category_error %></p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.text_field :theme, class: input_class.call(theme_error), placeholder: t("posts.form.theme_placeholder"), aria: { invalid: theme_error.present? ? "true" : nil, describedby: "post_theme_help post_theme_error" } %>
+        <p id="post_theme_help" class="mt-1 ds-text-muted"><%= theme_example %></p>
+        <% if theme_error.present? %>
+          <p id="post_theme_error" class="mt-1 text-xs font-medium text-red-700"><%= theme_error %></p>
+        <% end %>
+      </div>
+
+      <div class="sm:col-span-2">
+        <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
+        <%= f.text_field :tag_list, class: input_class.call(tag_list_error), placeholder: t("posts.form.tags_placeholder"), list: "post-tag-options", aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_error" } %>
+        <p id="post_tag_list_help" class="mt-1 ds-text-muted"><%= tags_example %></p>
+        <% if tag_list_error.present? %>
+          <p id="post_tag_list_error" class="mt-1 text-xs font-medium text-red-700"><%= tag_list_error %></p>
+        <% end %>
+      </div>
+    </div>
+
+    <% if category_suggestions.any? %>
+      <datalist id="post-category-options">
+        <% category_suggestions.each do |category| %>
+          <option value="<%= category %>"></option>
+        <% end %>
+      </datalist>
+    <% end %>
+    <% if tag_suggestions.any? %>
+      <datalist id="post-tag-options">
+        <% tag_suggestions.each do |tag| %>
+          <option value="<%= tag %>"></option>
+        <% end %>
+      </datalist>
+    <% end %>
+  </section>
+
+  <section class="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4">
+    <p class="text-sm font-semibold text-slate-700"><%= t("posts.form.related_items") %></p>
+    <div class="space-y-4">
+      <%= f.fields_for :items do |item_fields| %>
+        <div class="grid gap-3 rounded-lg border border-slate-200 bg-white p-3 sm:grid-cols-2">
+          <div>
+            <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
+            <%= item_fields.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.item_name_placeholder") %>
+            <p class="mt-1 ds-text-muted"><%= item_name_example %></p>
+          </div>
+          <div>
+            <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
+            <%= item_fields.url_field :affiliate_url, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.affiliate_url_placeholder") %>
+            <p class="mt-1 ds-text-muted"><%= item_url_example %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+  <div class="flex flex-wrap gap-3">
+    <%= f.submit t("posts.form.publish"), class: "tap-target cta-primary" %>
+    <%= f.submit t("posts.form.save_draft"), name: "save_as_draft", value: "1", class: "tap-target cta-secondary" %>
+  </div>
 <% end %>
+
+<script>
+  if (!window.__postFormErrorAutofocusInstalled) {
+    window.__postFormErrorAutofocusInstalled = true;
+
+    const focusFirstErrorField = () => {
+      const form = document.querySelector("[data-form-autofocus-errors]");
+      if (!form) return;
+      const firstInvalid = form.querySelector("[aria-invalid='true']");
+      if (!firstInvalid) return;
+      firstInvalid.focus();
+      if (typeof firstInvalid.scrollIntoView === "function") {
+        firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    };
+
+    document.addEventListener("turbo:load", focusFirstErrorField);
+    document.addEventListener("DOMContentLoaded", focusFirstErrorField);
+  }
+</script>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -3,14 +3,14 @@
 
 <section class="mx-auto w-full max-w-3xl space-y-content">
     <div>
-        <h1 class="text-2xl font-bold text-slate-900"><%= t("posts.edit.heading") %></h1>
-        <div class="mt-2 flex items-center gap-2 text-sm text-slate-600">
+        <h1 class="ds-heading-xl"><%= t("posts.edit.heading") %></h1>
+        <div class="mt-2 flex items-center gap-2 ds-text-support">
             <span><%= t("posts.edit.current_status") %></span>
             <%= post_status_badge(@post.status) %>
         </div>
     </div>
 
-    <div class="rounded-xl border border-slate-200 bg-white p-6">
-        <%= render "form", post: @post %>
+    <div class="ds-card p-6">
+        <%= render "form", post: @post, owned_users: @owned_users, category_suggestions: @category_suggestions, tag_suggestions: @tag_suggestions %>
     </div>
 </section>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,10 +1,9 @@
 <% content_for :title, t("posts.index.title") %>
 <% content_for :description, t("posts.index.description") %>
-<% detailed_filters_open = params[:details] == "1" || params[:theme].present? || params[:tag].present? %>
-<% detailed_filter_count = [params[:theme], params[:tag]].count(&:present?) %>
+<% detailed_filters_open = params[:details] == "1" || params[:category].present? || params[:theme].present? || params[:tag].present? %>
+<% detailed_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
 <% applied_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
 <% filtered_results = params[:q].present? || applied_filter_count.positive? %>
-<% detailed_toggle_label = t("posts.index.detailed_filters_toggle") %>
 <% detailed_status_shown_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u8868\u793A\u4E2D" : "Details shown" %>
 <% detailed_status_hidden_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u306F\u975E\u8868\u793A" : "Details hidden" %>
 <% detailed_status_label = detailed_filters_open ? detailed_status_shown_label : detailed_status_hidden_label %>
@@ -14,6 +13,12 @@
 <% detailed_search_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u691C\u7D22" : "Detailed search" %>
 <% basic_step_label = I18n.locale.to_s == "ja" ? "\u30B9\u30C6\u30C3\u30D71" : "Step 1" %>
 <% optional_label = I18n.locale.to_s == "ja" ? "\u4EFB\u610F" : "Optional" %>
+<% no_results_title = I18n.locale.to_s == "ja" ? "\u6761\u4EF6\u3092\u7DE9\u548C\u3057\u3066\u518D\u691C\u7D22\u3057\u307E\u3057\u3087\u3046" : "Try broader filters" %>
+<% no_results_hint = I18n.locale.to_s == "ja" ? "\u691C\u7D22\u6761\u4EF6\u3092\u3064\u304F\u308A\u76F4\u3059\u3068\u3001\u65B0\u3057\u3044\u6295\u7A3F\u3092\u898B\u3064\u3051\u3084\u3059\u304F\u306A\u308A\u307E\u3059\u3002" : "Relax one condition at a time to discover more posts." %>
+<% clear_all_label = I18n.locale.to_s == "ja" ? "\u3059\u3079\u3066\u30AF\u30EA\u30A2" : "Clear all filters" %>
+<% remove_keyword_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u3092\u5916\u3059" : "Remove keyword" %>
+<% expand_details_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u958B\u304F" : "Open detailed filters" %>
+<% detail_collapsed_hint = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u958B\u304F\u3068\u3001\u30AB\u30C6\u30B4\u30EA\u30FC\u30FB\u30BF\u30B0\u306E\u8ABF\u6574\u304C\u3067\u304D\u307E\u3059\u3002" : "Open details to filter by category, theme, and tag." %>
 <% max_card_tags = 2 %>
 <% active_filters = {
   category: params[:category].to_s.strip,
@@ -46,59 +51,58 @@
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
       <div class="rounded-xl border border-slate-200 bg-white p-3 sm:p-4">
         <div class="flex items-center justify-between gap-2">
-          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= basic_search_label %></p>
+          <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= basic_search_label %></p>
           <span class="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700"><%= basic_step_label %></span>
         </div>
-        <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px_auto] sm:items-start">
+        <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
-          <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
           <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-primary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
         </div>
-        <div class="mt-2 text-right">
-          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target inline-flex items-center px-1.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-900", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
+        <div class="mt-2 flex flex-wrap items-center justify-between gap-1.5">
+          <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target cta-tertiary text-xs" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+            <span class="inline-flex items-center gap-1.5">
+              <span><%= detailed_search_label %> (<%= optional_label %>)</span>
+              <% if detailed_filter_count.positive? %>
+                <span class="rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
+              <% end %>
+              <span data-details-state-badge data-label-shown="<%= detailed_status_shown_label %>" data-label-hidden="<%= detailed_status_hidden_label %>" class="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-600"><%= detailed_status_label %></span>
+              <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-600 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
+            </span>
+          </button>
+          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
       </div>
 
-      <div class="rounded-xl border border-slate-100 bg-slate-50/40 p-3 sm:p-3.5">
-        <div class="flex items-center justify-between gap-2">
-          <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= detailed_search_label %></p>
-          <span class="rounded-full bg-slate-200 px-2 py-0.5 text-[11px] font-semibold text-slate-600"><%= optional_label %></span>
-        </div>
-        <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target mt-1.5 inline-flex w-full items-center justify-between rounded-lg border border-slate-100 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 hover:bg-white" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
-          <span class="inline-flex items-center gap-2">
-            <span><%= detailed_toggle_label %></span>
-            <% if detailed_filter_count.positive? %>
-              <span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
-          <% end %>
-        </span>
-        <span class="inline-flex items-center gap-2">
-          <span data-details-state-badge data-label-shown="<%= detailed_status_shown_label %>" data-label-hidden="<%= detailed_status_hidden_label %>" class="max-w-[10.5rem] truncate rounded-full px-2 py-0.5 text-xs font-semibold <%= detailed_filters_open ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-200 text-slate-600' %>"><%= detailed_status_label %></span>
-          <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-500 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
-        </span>
-      </button>
-
-        <div data-details-panel class="mt-2.5 grid gap-2.5 sm:grid-cols-2 <%= detailed_filters_open ? '' : 'hidden' %>">
+      <div data-details-panel class="rounded-xl border border-slate-100 bg-slate-50/40 p-3 sm:p-3.5 <%= detailed_filters_open ? '' : 'hidden' %>">
+        <div class="grid gap-2.5 sm:grid-cols-3">
+          <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
           <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
           <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
         </div>
-      </div>
 
-      <% filter_container_class = active_filters.any? ? "rounded-lg border border-blue-200 bg-blue-50/60 px-3 py-2.5" : "px-1 py-1" %>
-      <div class="<%= filter_container_class %>">
-        <p class="text-xs font-semibold <%= active_filters.any? ? 'text-blue-800' : 'text-slate-500' %>"><%= applied_filters_label %></p>
-        <div class="<%= active_filters.any? ? 'mt-2 flex flex-wrap gap-2' : 'mt-1' %>">
-          <% if active_filters.any? %>
-            <% active_filters.each do |key, value| %>
-              <% clear_params = persisted_query.except(key) %>
-              <%= link_to posts_path(clear_params), class: "tap-target inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_clear_#{key}" } do %>
-                <span><%= "#{filter_labels[key]}: #{value}" %></span>
-                <span aria-hidden="true" class="text-slate-500">&times;</span>
+        <div class="mt-2.5">
+          <p class="ds-text-meta font-semibold"><%= applied_filters_label %></p>
+          <div class="mt-1.5 flex flex-wrap items-center gap-2">
+            <% if active_filters.any? %>
+              <% active_filters.each do |key, value| %>
+                <% clear_params = persisted_query.except(key) %>
+                <%= link_to posts_path(clear_params), class: "tap-target inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_clear_#{key}" } do %>
+                  <span><%= "#{filter_labels[key]}: #{value}" %></span>
+                  <span aria-hidden="true" class="text-slate-600">&times;</span>
+                <% end %>
               <% end %>
+            <% else %>
+              <span class="ds-text-muted"><%= no_filters_label %></span>
             <% end %>
-          <% else %>
-            <span class="text-xs text-slate-500"><%= no_filters_label %></span>
-          <% end %>
+          </div>
         </div>
+      </div>
+      <% unless detailed_filters_open %>
+        <p class="ds-text-muted px-1"><%= detail_collapsed_hint %></p>
+      <% end %>
+      <div class="px-1">
+        <p class="ds-text-meta font-semibold"><%= applied_filters_label %></p>
+        <p class="ds-text-muted mt-1"><%= active_filters.any? ? active_filters.map { |key, value| "#{filter_labels[key]}: #{value}" }.join(" / ") : no_filters_label %></p>
       </div>
     <% end %>
   </div>
@@ -118,31 +122,31 @@
               <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-5 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
             </h2>
 
-            <p class="mt-1 text-sm text-slate-600">
-              <%= t("posts.index.author_label") %>:
-              <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 hover:text-slate-900", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-            </p>
-
             <p class="mt-2 ds-line-clamp-2 text-sm leading-6 text-slate-600"><%= truncate(post.description, length: 90) %></p>
 
-            <div class="mt-auto space-y-2 border-t border-slate-100 pt-3 text-xs text-slate-500" aria-label="Post metadata">
+            <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
+              <% visible_tags.each do |tag| %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+              <% end %>
+              <% if hidden_tag_count.positive? %>
+                <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
+              <% end %>
+            </div>
+
+            <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta" aria-label="Post metadata">
               <div class="flex flex-wrap items-center gap-2">
                 <% if post.category.present? %>
                   <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600"><%= post.category %></span>
                 <% end %>
+                <span>
+                  <%= t("posts.index.author_label") %>:
+                  <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 hover:text-slate-900", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+                </span>
                 <span><%= l(post.created_at.to_date) %></span>
                 <span class="inline-flex items-center gap-1">
                   <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
                   <span><%= localized_number(post.likes_count) %></span>
                 </span>
-              </div>
-              <div class="mt-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
-                <% visible_tags.each do |tag| %>
-                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
-                <% end %>
-                <% if hidden_tag_count.positive? %>
-                  <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
-                <% end %>
               </div>
               <% if visible_tags.empty? && hidden_tag_count.zero? %>
                 <p class="text-slate-400"><%= no_filters_label %></p>
@@ -153,8 +157,25 @@
       <% end %>
     </div>
   <% else %>
-    <div class="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-12 text-center text-sm text-slate-500">
-      <%= t("posts.index.empty_state") %>
+    <div class="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-10 text-center">
+      <p class="ds-text-support font-semibold text-slate-700"><%= t("posts.index.empty_state") %></p>
+      <% if filtered_results %>
+        <p class="mt-2 text-sm font-semibold text-slate-700"><%= no_results_title %></p>
+        <p class="mt-1 ds-text-support"><%= no_results_hint %></p>
+        <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
+          <%= link_to clear_all_label, root_path, class: "tap-target cta-secondary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
+          <% if params[:q].present? %>
+            <%= link_to remove_keyword_label, posts_path(persisted_query.except(:q)), class: "tap-target cta-tertiary", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_keyword" } %>
+          <% end %>
+          <% unless detailed_filters_open %>
+            <%= link_to expand_details_label, posts_path(persisted_query.merge(details: "1")), class: "tap-target cta-tertiary", data: { ga_event: "post_search_details_toggle_click", ga_category: "post_search", ga_label: "index_empty_open_details" } %>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="mt-4">
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary" %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -3,13 +3,13 @@
 
 <section class="mx-auto w-full max-w-3xl space-y-content">
     <div>
-        <h1 class="text-2xl font-bold text-slate-900"><%= t("posts.new.heading") %></h1>
-        <p class="mt-2 text-sm text-slate-600">
+        <h1 class="ds-heading-xl"><%= t("posts.new.heading") %></h1>
+        <p class="mt-2 ds-text-support">
             <%= t("posts.new.lead") %>
         </p>
     </div>
 
-    <div class="rounded-xl border border-slate-200 bg-white p-6">
-        <%= render "form", post: @post, owned_users: @owned_users, submit_label: t("posts.form.publish") %>
+    <div class="ds-card p-6">
+        <%= render "form", post: @post, owned_users: @owned_users, submit_label: t("posts.form.publish"), category_suggestions: @category_suggestions, tag_suggestions: @tag_suggestions %>
     </div>
 </section>

--- a/app/views/posts/notifications.html.erb
+++ b/app/views/posts/notifications.html.erb
@@ -4,25 +4,25 @@
 <section class="mx-auto w-full max-w-3xl space-y-content">
   <header class="flex flex-wrap items-center justify-between gap-3">
     <div>
-      <h1 class="text-2xl font-bold text-slate-900"><%= t("posts.notifications.heading") %></h1>
-      <p class="mt-1 text-sm text-slate-600">
+      <h1 class="ds-heading-xl"><%= t("posts.notifications.heading") %></h1>
+      <p class="mt-1 ds-text-support">
         <%= link_to @post.title, post_path(@post), class: "text-blue-600 hover:text-blue-700" %>
         <%= t("posts.notifications.reactions_to_post") %>
       </p>
     </div>
-    <%= link_to post_path(@post), class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
+    <%= link_to post_path(@post), class: "tap-target cta-secondary" do %>
       <%= ui_icon(:arrow_uturn_left, class_name: "h-4 w-4") %>
       <span><%= t("posts.notifications.back_to_post") %></span>
     <% end %>
   </header>
 
-  <div class="rounded-xl border border-slate-200 bg-white p-6">
+  <div class="ds-card p-6">
     <% if @notifications.any? %>
       <div class="space-y-3">
         <% @notifications.each do |notification| %>
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
             <p class="text-sm text-slate-800"><%= notification.message %></p>
-            <p class="mt-1 text-xs text-slate-500">
+            <p class="mt-1 ds-text-meta">
               <%= l(notification.created_at, format: :short) %>
               <% if notification.read_at.present? %>
                 <span class="ml-2 inline-flex items-center gap-1 rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-emerald-700">
@@ -35,7 +35,15 @@
         <% end %>
       </div>
     <% else %>
-      <p class="text-sm text-slate-500"><%= t("posts.notifications.empty_state") %></p>
+      <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
+        <p class="ds-text-support"><%= t("posts.notifications.empty_state") %></p>
+        <div class="mt-3">
+          <%= link_to post_path(@post), class: "tap-target cta-secondary" do %>
+            <%= ui_icon(:arrow_uturn_left, class_name: "h-4 w-4") %>
+            <span><%= t("posts.notifications.back_to_post") %></span>
+          <% end %>
+        </div>
+      </div>
     <% end %>
   </div>
 </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,10 +3,13 @@
 <% content_for :og_image_url, og_image_url(@post) %>
 <% body_section_label = I18n.locale.to_s == "ja" ? "本文" : "Overview" %>
 <% comments_lead_label = I18n.locale.to_s == "ja" ? "本文と関連アイテムを読んだあとに、感想や質問を投稿できます。" : "After reading the post and related items, join the conversation below." %>
+<% comment_empty_cta = I18n.locale.to_s == "ja" ? "最初のコメントを書く" : "Write the first comment" %>
+<% mobile_menu_open_label = I18n.locale.to_s == "ja" ? "操作メニューを開きました" : "Action menu opened" %>
+<% mobile_menu_close_label = I18n.locale.to_s == "ja" ? "操作メニューを閉じました" : "Action menu closed" %>
 
 <article class="space-y-content">
   <header class="space-y-3">
-    <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+    <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600">
       <span><%= l(@post.created_at.to_date) %></span>
       <% if @post.category.present? %>
         <span class="rounded-full bg-slate-100 px-2 py-1 text-slate-700"><%= @post.category %></span>
@@ -43,7 +46,7 @@
   <section class="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <h2 class="text-xl font-bold text-slate-900"><%= t("posts.show.related_items") %></h2>
-      <span class="inline-flex items-center gap-1 text-sm text-slate-500">
+      <span class="inline-flex items-center gap-1 text-sm text-slate-600">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span>
       </span>
@@ -61,7 +64,7 @@
         <% end %>
       </div>
     <% else %>
-      <p class="mt-3 text-sm text-slate-500"><%= t("posts.show.no_related_items") %></p>
+      <p class="mt-3 text-sm text-slate-600"><%= t("posts.show.no_related_items") %></p>
     <% end %>
   </section>
 
@@ -71,7 +74,7 @@
         <%= ui_icon(:chat, class_name: "h-5 w-5") %>
         <span><%= t("posts.show.comments.title") %></span>
       </h2>
-      <p class="text-sm text-slate-500"><%= comments_lead_label %></p>
+      <p class="text-sm text-slate-600"><%= comments_lead_label %></p>
     </div>
 
     <% if @root_comments.any? %>
@@ -85,7 +88,7 @@
                 <span><%= t("posts.show.comments.reply") %></span>
               <% end %>
             </div>
-            <p class="mt-0.5 text-xs text-slate-500"><%= l(comment.created_at, format: :short) %></p>
+            <p class="mt-0.5 text-xs text-slate-600"><%= l(comment.created_at, format: :short) %></p>
             <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= comment.body %></p>
 
             <% if comment.replies.any? %>
@@ -93,7 +96,7 @@
                 <% comment.replies.each do |reply| %>
                   <div id="comment-<%= reply.id %>" class="rounded-lg border border-slate-300 bg-white p-3">
                     <p class="text-xs font-medium text-slate-700"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
-                    <p class="mt-0.5 text-xs text-slate-500"><%= l(reply.created_at, format: :short) %></p>
+                    <p class="mt-0.5 text-xs text-slate-600"><%= l(reply.created_at, format: :short) %></p>
                     <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= reply.body %></p>
                   </div>
                 <% end %>
@@ -103,10 +106,13 @@
         <% end %>
       </div>
     <% else %>
-      <p class="text-sm text-slate-500"><%= t("posts.show.comments.empty_state") %></p>
+      <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center">
+        <p class="ds-text-support"><%= t("posts.show.comments.empty_state") %></p>
+        <a href="#comment-form" class="mt-3 inline-flex tap-target cta-secondary cta-compact"><%= comment_empty_cta %></a>
+      </div>
     <% end %>
 
-    <div class="border-t border-slate-200 pt-4">
+    <div class="border-t border-slate-200 pt-4" id="comment-form">
       <% if @reply_to_comment.present? %>
         <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
           <%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %>
@@ -145,7 +151,7 @@
         <% if recaptcha_enabled? %>
           <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <% end %>
-        <%= f.button type: :submit, class: "tap-target cta-primary" do %>
+        <%= f.button type: :submit, class: "tap-target cta-secondary" do %>
           <span class="inline-flex items-center gap-1.5">
             <%= ui_icon(:chat, class_name: "h-4 w-4") %>
             <span><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span>
@@ -172,7 +178,7 @@
     <% end %>
     <button type="button" data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url" class="tap-target cta-secondary">
       <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.copy_url") %></span>
+      <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
     </button>
     <% unless post_owner?(@post) %>
       <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target cta-secondary border-amber-300 text-amber-800 hover:bg-amber-50">
@@ -182,7 +188,7 @@
     <% end %>
   </div>
 
-  <div class="fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur sm:hidden" data-mobile-actions-root>
+  <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-mobile-actions-root>
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
       <div class="relative pb-1">
         <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5">
@@ -216,7 +222,7 @@
             <% end %>
             <button type="button" data-mobile-menu-action data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="mobile_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
               <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.copy_url") %></span>
+              <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
             </button>
             <% unless post_owner?(@post) %>
               <button type="button" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="mobile_report_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-amber-800 hover:bg-amber-50">
@@ -232,7 +238,7 @@
 
   <% if post_owner?(@post) %>
     <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
-      <%= link_to edit_post_path(@post), class: "tap-target cta-primary" do %>
+      <%= link_to edit_post_path(@post), class: "tap-target cta-secondary" do %>
         <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
         <span><%= t("posts.show.actions.edit") %></span>
       <% end %>
@@ -251,7 +257,7 @@
     <dialog id="report-modal-<%= @post.id %>" class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
       <div class="border-b border-slate-200 px-4 py-3">
         <h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2>
-        <p class="mt-1 text-xs text-slate-500"><%= t("posts.show.report.description") %></p>
+        <p class="mt-1 text-xs text-slate-600"><%= t("posts.show.report.description") %></p>
       </div>
       <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4" do |f| %>
         <% if owned_users.any? %>
@@ -295,6 +301,7 @@
 
       menu.classList.add("hidden");
       if (toggle) toggle.setAttribute("aria-expanded", "false");
+      if (typeof window.dsAnnounce === "function") window.dsAnnounce("<%= j(mobile_menu_close_label) %>");
       if (typeof window.gtag === "function") {
         window.gtag("event", "post_action_more_menu_close", {
           event_category: "post_actions",
@@ -328,6 +335,8 @@
         const expanded = mobileActionsToggle.getAttribute("aria-expanded") == "true";
         menu.classList.toggle("hidden", expanded);
         mobileActionsToggle.setAttribute("aria-expanded", String(!expanded));
+        if (!expanded && typeof window.dsAnnounce === "function") window.dsAnnounce("<%= j(mobile_menu_open_label) %>");
+        if (expanded && typeof window.dsAnnounce === "function") window.dsAnnounce("<%= j(mobile_menu_close_label) %>");
         return;
       }
 
@@ -364,5 +373,18 @@
       if (event.key !== "Escape") return;
       closeMobileActionsMenu("escape");
     });
+
+    const mobileActionsRoot = document.querySelector("[data-mobile-actions-root]");
+    const commentForm = document.querySelector("#comment-form form");
+    if (mobileActionsRoot && commentForm) {
+      commentForm.addEventListener("focusin", () => {
+        mobileActionsRoot.classList.add("translate-y-full", "opacity-0", "pointer-events-none");
+      });
+      commentForm.addEventListener("focusout", (event) => {
+        const next = event.relatedTarget;
+        if (next && commentForm.contains(next)) return;
+        mobileActionsRoot.classList.remove("translate-y-full", "opacity-0", "pointer-events-none");
+      });
+    }
   }
 </script>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -11,19 +11,19 @@
   <% end %>
 
   <div>
-    <%= f.label :name, t("users.form.name_label"), class: "mb-1 block text-sm font-medium" %>
+    <%= f.label :name, t("users.form.name_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
     <%= f.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("users.form.name_placeholder") %>
   </div>
 
   <div>
-    <%= f.label :bio, t("users.form.bio_label"), class: "mb-1 block text-sm font-medium" %>
+    <%= f.label :bio, t("users.form.bio_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
     <%= f.text_area :bio, rows: 5, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("users.form.bio_placeholder") %>
   </div>
 
   <div>
-    <%= f.label :email, t("users.form.email_label"), class: "mb-1 block text-sm font-medium" %>
+    <%= f.label :email, t("users.form.email_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
     <%= f.email_field :email, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "you@example.com" %>
-    <p class="mt-1 text-xs text-slate-500"><%= t("users.form.email_hint") %></p>
+    <p class="mt-1 ds-text-muted"><%= t("users.form.email_hint") %></p>
   </div>
 
   <div class="flex items-center gap-2">
@@ -31,5 +31,5 @@
     <%= f.label :email_notifications_enabled, t("users.form.email_notifications"), class: "text-sm text-slate-700" %>
   </div>
 
-  <%= f.submit submit_label, class: "tap-target rounded-lg bg-blue-500 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-600" %>
+  <%= f.submit submit_label, class: "tap-target cta-primary" %>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -3,13 +3,13 @@
 
 <section class="mx-auto w-full max-w-3xl space-y-content">
   <div>
-    <h1 class="text-2xl font-bold text-slate-900"><%= t("users.edit.heading") %></h1>
-    <p class="mt-2 text-sm text-slate-600">
+    <h1 class="ds-heading-xl"><%= t("users.edit.heading") %></h1>
+    <p class="mt-2 ds-text-support">
       <%= t("users.edit.lead") %>
     </p>
   </div>
 
-  <div class="rounded-xl border border-slate-200 bg-white p-6">
+  <div class="ds-card p-6">
     <%= render "form", user: @user, submit_label: t("users.form.submit_update") %>
   </div>
 </section>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,13 +3,13 @@
 
 <section class="mx-auto w-full max-w-3xl space-y-content">
   <div>
-    <h1 class="text-2xl font-bold text-slate-900"><%= t("users.new.heading") %></h1>
-    <p class="mt-2 text-sm text-slate-600">
+    <h1 class="ds-heading-xl"><%= t("users.new.heading") %></h1>
+    <p class="mt-2 ds-text-support">
       <%= t("users.new.lead") %>
     </p>
   </div>
 
-  <div class="rounded-xl border border-slate-200 bg-white p-6">
+  <div class="ds-card p-6">
     <%= render "form", user: @user, submit_label: t("users.form.submit_create") %>
   </div>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,23 @@
 <% content_for :title, @user.name %>
 <% content_for :description, truncate(@user.bio.to_s, length: 120) %>
+<% locale_ja = I18n.locale.to_s == "ja" %>
+<% create_post_label = t("navigation.create_post") %>
+<% browse_gallery_label = locale_ja ? "投稿一覧を見る" : "Browse gallery" %>
+<% draft_hint = locale_ja ? "下書きは本人のみ表示されます。" : "Drafts are visible only to you." %>
 
 <section class="space-y-content">
-  <header class="rounded-xl border border-slate-200 bg-white p-6">
+  <header class="ds-card p-6">
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
-        <h1 class="text-2xl font-bold text-slate-900"><%= @user.name %></h1>
+        <h1 class="ds-heading-xl"><%= @user.name %></h1>
         <% if @user.bio.present? %>
-          <p class="mt-3 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= @user.bio %></p>
+          <p class="mt-3 whitespace-pre-wrap ds-text-support leading-reading"><%= @user.bio %></p>
         <% else %>
-          <p class="mt-3 text-sm text-slate-500"><%= t("users.show.no_profile_description") %></p>
+          <p class="mt-3 ds-text-support"><%= t("users.show.no_profile_description") %></p>
         <% end %>
       </div>
       <% if user_owner?(@user) %>
-        <%= link_to edit_user_path(@user), class: "tap-target inline-flex items-center gap-1.5 rounded-lg border border-slate-300 px-4 py-2 text-sm hover:bg-slate-100" do %>
+        <%= link_to edit_user_path(@user), class: "tap-target cta-secondary" do %>
           <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
           <span><%= t("users.show.edit_profile") %></span>
         <% end %>
@@ -21,50 +25,86 @@
     </div>
   </header>
 
-  <section class="rounded-xl border border-slate-200 bg-white p-6">
-    <h2 class="text-lg font-semibold text-slate-900"><%= t("users.show.published_posts") %></h2>
+  <section class="ds-card p-6">
+    <h2 class="ds-heading-md"><%= t("users.show.published_posts") %></h2>
     <% if @published_posts.any? %>
-      <div class="mt-4 space-y-3">
+      <div class="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <% @published_posts.each do |post| %>
-          <article class="rounded-lg border border-slate-200 bg-slate-50 p-4">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <h3 class="min-w-0 flex-1 text-base font-semibold text-slate-900">
-                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-6 hover:text-blue-600" %>
+          <% visible_tags = post.tags.first(2) %>
+          <% hidden_tag_count = [post.tags.size - visible_tags.size, 0].max %>
+          <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+            <%= link_to post_path(post), class: "block" do %>
+              <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-40 w-full object-cover sm:h-44") %>
+            <% end %>
+            <div class="flex h-full flex-col p-4">
+              <h3 class="text-base font-semibold text-slate-900">
+                <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-5 hover:text-blue-600" %>
               </h3>
-              <span class="inline-flex items-center gap-1 text-xs text-slate-500">
-                <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                <span><%= t("metrics.likes") %>: <%= localized_number(post.likes_count) %></span>
-              </span>
+              <p class="mt-2 ds-line-clamp-2 ds-text-support"><%= truncate(post.description, length: 90) %></p>
+              <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
+                <% visible_tags.each do |tag| %>
+                  <%= link_to "##{tag}", posts_path(tag: tag), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600" %>
+                <% end %>
+                <% if hidden_tag_count.positive? %>
+                  <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
+                <% end %>
+              </div>
+              <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span><%= l(post.created_at.to_date) %></span>
+                  <span class="inline-flex items-center gap-1">
+                    <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                    <span><%= localized_number(post.likes_count) %></span>
+                  </span>
+                </div>
+              </div>
             </div>
-            <p class="mt-2 text-sm text-slate-600"><%= truncate(post.description, length: 140) %></p>
           </article>
         <% end %>
       </div>
     <% else %>
-      <p class="mt-3 text-sm text-slate-500"><%= t("users.show.no_published_posts") %></p>
+      <div class="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
+        <p class="ds-text-support"><%= t("users.show.no_published_posts") %></p>
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-2">
+          <% if user_owner?(@user) %>
+            <%= link_to create_post_label, new_post_path, class: "tap-target cta-primary" %>
+          <% else %>
+            <%= link_to browse_gallery_label, root_path, class: "tap-target cta-secondary" %>
+          <% end %>
+        </div>
+      </div>
     <% end %>
   </section>
 
   <% if user_owner?(@user) %>
-    <section class="rounded-xl border border-slate-200 bg-white p-6">
-      <h2 class="text-lg font-semibold text-slate-900"><%= t("users.show.drafts") %></h2>
+    <section class="ds-card p-6">
+      <div class="flex flex-wrap items-end justify-between gap-2">
+        <h2 class="ds-heading-md"><%= t("users.show.drafts") %></h2>
+        <p class="ds-text-muted"><%= draft_hint %></p>
+      </div>
       <% if @draft_posts.any? %>
-        <div class="mt-4 space-y-3">
+        <div class="mt-4 grid gap-4 sm:grid-cols-2">
           <% @draft_posts.each do |post| %>
-            <article class="rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <div class="flex flex-wrap items-center justify-between gap-3">
-                <h3 class="min-w-0 flex-1 ds-line-clamp-2 text-base font-semibold leading-6 text-slate-900"><%= post.title.presence || t("users.show.untitled_draft") %></h3>
-                <%= link_to edit_post_path(post), class: "tap-target inline-flex items-center gap-1 rounded border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100" do %>
+            <article class="flex h-full flex-col rounded-lg border border-slate-200 bg-slate-50 p-4">
+              <h3 class="ds-line-clamp-2 text-base font-semibold text-slate-900"><%= post.title.presence || t("users.show.untitled_draft") %></h3>
+              <p class="mt-2 ds-line-clamp-2 ds-text-support"><%= truncate(post.description.to_s, length: 120) %></p>
+              <div class="mt-auto flex items-center justify-between border-t border-slate-200 pt-3">
+                <span class="ds-text-meta"><%= l(post.updated_at.to_date) %></span>
+                <%= link_to edit_post_path(post), class: "tap-target cta-secondary cta-compact" do %>
                   <%= ui_icon(:pencil_square, class_name: "h-3.5 w-3.5") %>
                   <span><%= t("users.show.continue_editing") %></span>
                 <% end %>
               </div>
-              <p class="mt-2 text-sm text-slate-600"><%= truncate(post.description.to_s, length: 140) %></p>
             </article>
           <% end %>
         </div>
       <% else %>
-        <p class="mt-3 text-sm text-slate-500"><%= t("users.show.no_drafts") %></p>
+        <div class="mt-4 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
+          <p class="ds-text-support"><%= t("users.show.no_drafts") %></p>
+          <div class="mt-3">
+            <%= link_to create_post_label, new_post_path, class: "tap-target cta-secondary" %>
+          </div>
+        </div>
       <% end %>
     </section>
   <% end %>

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -1,0 +1,65 @@
+# DeskTour Studio UI System
+
+## Core Tokens
+- Typography:
+  - `ds-heading-xl`: Page titles
+  - `ds-heading-lg`: Section titles
+  - `ds-heading-md`: Card and subsection titles
+  - `ds-text-body`: Main reading text
+  - `ds-text-support`: Supporting explanation text
+  - `ds-text-meta`: Metadata (date, small labels)
+  - `ds-text-muted`: Helper or hint text
+- Spacing:
+  - `space-y-content`: Major section rhythm
+  - `space-y-form`: Form field rhythm
+- Surfaces:
+  - `ds-card`: Standard card surface
+  - `ds-shadow-soft`: Soft elevation
+  - `ds-badge`: Compact metadata badge
+
+## CTA Hierarchy
+- `cta-primary`:
+  - Main conversion action for the current context.
+  - Keep to one primary per section whenever possible.
+- `cta-secondary`:
+  - Important but non-primary actions (navigation back, alternate action).
+- `cta-tertiary`:
+  - Utility actions (toggle, lightweight links, low emphasis controls).
+- `cta-compact`:
+  - Small variants for dense UI areas (chips, inline controls).
+
+## Fixed Mobile Bar Rules
+- Use `mobile-sticky-bar` for all fixed bottom action bars.
+- When fixed bars overlap critical inputs (comment forms), hide the bar while input fields are focused.
+- Keep a minimum `44px` tap target (`tap-target`) on all touch controls.
+
+## Card Layout Rules
+- Information order:
+  - `Title -> Summary -> Tags -> Meta`
+- Card height rhythm:
+  - Keep consistent thumbnail height (`h-40`/`h-44`) to avoid scroll jitter.
+- Tags:
+  - Show max 2 tags and aggregate overflow as `+n`.
+  - Use low-emphasis chip tone for tags to reduce visual noise.
+
+## States
+- Empty states must include:
+  - Context sentence
+  - Next action CTA
+- Search zero-results must include:
+  - "Clear all" action
+  - At least one condition-relax action
+
+## Accessibility Rules
+- All interactive controls must expose visible focus style (`:focus-visible`).
+- Announce asynchronous status changes (copy success/failure, menu open/close) through the live region.
+- Menus and toggles must keep `aria-expanded` synchronized with UI state.
+
+## New Screen Checklist
+- [ ] One primary CTA per section
+- [ ] Heading/body/meta typography classes applied
+- [ ] Empty/zero/error states have explicit next-step CTA
+- [ ] Touch targets are `>=44px`
+- [ ] Keyboard focus is visually clear on all controls
+- [ ] Screen reader status feedback exists for dynamic actions
+- [ ] Mobile fixed bars do not cover key inputs


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/57

## 目的

  主要導線の迷いを減らし、一覧・詳細・フォーム・モバイル操作を横断して一貫したUI/UXに改善する。
  具体的には、CTA優先度の統一、検索/入力の認知負荷低減、モバイル固定バーと本文コンテキストの競合解消、アクセシビリティ強化を実現する。

  ## 実装内容

  - CTA階層を Primary / Secondary / Tertiary で再定義し、全ページで再利用可能な共通クラス化
  - タイポグラフィ階層をトークン化（見出し/本文/補足/メタ）し、低コントラスト小文字を段階的に改善
  - 一覧検索UIを段階化
      - 初期はキーワード中心の最小UI
      - 詳細展開でカテゴリ/テーマ/タグ
      - 適用中フィルタチップとワンクリック解除
      - 0件時に条件緩和CTA（全解除/キーワード解除/詳細展開）
  - 投稿フォームUX改善
      - セクション再編（必須→任意→関連アイテム）
      - 入力例テキスト追加（placeholder依存を軽減）
      - カテゴリ/タグ候補サジェスト（datalist）
      - 上部サマリー + 項目直下エラー
      - 最初のエラー項目へ自動フォーカス
  - モバイル固定バー整流化
      - 共通 mobile-sticky-bar 適用
      - 詳細ページでコメント入力中は固定バーを自動退避
  - 空状態/初期状態強化
      - 投稿なし・検索なし・コメントなし・通知なしに次アクションCTAを追加
  - アクセシビリティ強化
      - フォーカスリング一貫化
      - コピー操作とメニュー開閉を live region で読み上げ通知
  - 運用ドキュメント追加
      - デザイン規約と新規画面チェックリストを作成

  ## 方法

  - 既存ERB構造とGAイベント属性を維持しつつ、Tailwindユーティリティ中心で設計を再編
  - 画面横断の再利用を優先し、まずCSSトークン/コンポーネント規約を整備してから各画面へ適用
  - フォーム改善はコントローラに候補データ準備を追加して実装
  - 動的状態変化は aria-expanded と aria-live の両面で同期

  ## 変更箇所

  - デザインシステム基盤
      - app/assets/tailwind/application.css:84
  - レイアウト（固定バー余白・live region・コピー/メニュー通知）
      - app/views/layouts/application.html.erb:54
  - 一覧ページ（検索段階化・0件導線・カード統一）
      - app/views/posts/index.html.erb:49
  - 投稿フォーム（構造/入力例/サジェスト/エラー/自動フォーカス）
      - app/views/posts/_form.html.erb:29
  - 投稿フォーム候補データ準備
      - app/controllers/posts_controller.rb:6
  - 詳細ページ（モバイル固定バー整流化・空状態CTA・SR通知）
      - app/views/posts/show.html.erb:191
  - プロフィール一覧（カード規約統一・空状態CTA）
      - app/views/users/show.html.erb:28
  - ユーザー作成/編集画面・フォームの規約寄せ
      - app/views/users/new.html.erb:5
      - app/views/users/edit.html.erb:5
      - app/views/users/_form.html.erb:13
  - 通知画面の空状態CTAと規約寄せ
      - app/views/posts/notifications.html.erb:5
  - 運用ドキュメント
      - docs/design_system.md:1

  ## まとめ

  要件の優先順に沿って、CTA統一・検索段階化・フォームUX改善・モバイル固定バー整流化・空状態/A11y/運用規約化まで一括実装した。
  これにより、第一行動の明確化、読みやすさ/入力しやすさ、モバイルでの操作一貫性が改善され、今後の画面追加でも同一基準で実装できる状態になった。

  ## Testing

  - 実行: ruby -c app/controllers/posts_controller.rb
      - 結果: Syntax OK
  - 実行: ruby -c app/controllers/users_controller.rb
      - 結果: Syntax OK
  - 実行: ruby -c app/helpers/application_helper.rb
      - 結果: Syntax OK
  - 実行: ERB構文チェック（application.html.erb, posts/index.html.erb, posts/show.html.erb, posts/_form.html.erb, users/
    show.html.erb）
      - 結果: 問題なし
  - 実行: git diff --check
      - 結果: 問題なし（CRLF警告のみ）
  - 備考: Railsテストは未実行（DB接続前提のため）