### PR TITLE
Improve UI: Streamline search logic, post actions, and mobile interaction consistency

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,15 +53,12 @@
     <% tracked_events = analytics_events %>
     <% mobile_sticky_active = controller_name == "posts" && action_name.in?(%w[index show]) %>
     <% main_padding_class = mobile_sticky_active ? "pb-40 sm:pb-8" : "pb-10 sm:pb-8" %>
+    <% current_language_label = I18n.locale.to_s == "ja" ? "現在の言語" : "Current language" %>
+    <% current_language_hint = I18n.locale.to_s == "ja" ? "選択中" : "Current" %>
 
     <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur" data-mobile-header-root>
       <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-2 sm:px-6 sm:py-3">
         <%= link_to "DeskTour Studio", root_path, class: "min-w-0 flex-1 truncate text-base font-bold text-slate-900 sm:text-lg", data: { ga_event: "navigation_home_click", ga_category: "navigation", ga_label: "header_logo" } %>
-
-        <%= link_to new_post_path, class: "tap-target cta-tertiary px-3 sm:hidden", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_icon" } do %>
-          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
-          <span class="sr-only"><%= t("navigation.create_post") %></span>
-        <% end %>
 
         <button type="button" data-mobile-header-toggle aria-expanded="false" aria-controls="mobile-header-menu" class="tap-target inline-flex items-center justify-center rounded-lg border border-slate-300 px-2.5 py-2 text-slate-700 hover:bg-slate-100 sm:hidden" data-ga-event="navigation_mobile_menu_toggle_click" data-ga-category="navigation" data-ga-label="mobile_header_menu_toggle">
           <%= ui_icon(:bars_3, class_name: "h-5 w-5") %>
@@ -69,31 +66,59 @@
         </button>
 
         <div class="ml-auto hidden items-center gap-2 text-sm font-medium tracking-nav sm:flex">
-          <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
-            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } %>
-            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } %>
-          </div>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
           <% if owned_users.any? %>
             <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
           <% end %>
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+          <div class="space-y-1">
+            <p class="text-[11px] font-semibold text-slate-700"><%= current_language_label %></p>
+            <div class="inline-flex items-center gap-1 rounded-full border border-slate-400 bg-slate-50 p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
+              <%= link_to locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
+                <span><%= t("language.option_ja") %></span>
+                <% if locale_selected?(:ja) %>
+                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                <% end %>
+              <% end %>
+              <%= link_to locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
+                <span><%= t("language.option_en") %></span>
+                <% if locale_selected?(:en) %>
+                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
 
       <div id="mobile-header-menu" data-mobile-header-menu class="hidden border-t border-slate-200 bg-white sm:hidden">
         <div class="mx-auto w-full max-w-6xl space-y-2 px-4 py-2.5">
-          <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-600" role="group" aria-label="<%= t('language.switch_aria') %>">
-            <%= link_to t("language.option_ja"), locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } %>
-            <%= link_to t("language.option_en"), locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-800 text-white' : 'text-slate-600 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } %>
-          </div>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_menu" } %>
 
           <% if owned_users.any? %>
             <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
+
+          <div class="rounded-xl border border-slate-300 bg-slate-50 p-2">
+            <p class="mb-1 text-xs font-semibold text-slate-700"><%= current_language_label %></p>
+            <div class="inline-flex items-center gap-1 rounded-full border border-slate-400 bg-white p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
+              <%= link_to locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } do %>
+                <span><%= t("language.option_ja") %></span>
+                <% if locale_selected?(:ja) %>
+                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                <% end %>
+              <% end %>
+              <%= link_to locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } do %>
+                <span><%= t("language.option_en") %></span>
+                <% if locale_selected?(:en) %>
+                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -13,6 +13,8 @@
 <% detailed_search_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u691C\u7D22" : "Detailed search" %>
 <% basic_step_label = I18n.locale.to_s == "ja" ? "\u30B9\u30C6\u30C3\u30D71" : "Step 1" %>
 <% optional_label = I18n.locale.to_s == "ja" ? "\u4EFB\u610F" : "Optional" %>
+<% details_applied_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: %{count}\u4EF6" : "Applied: %{count}" %>
+<% details_none_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: \u306A\u3057" : "Applied: none" %>
 <% no_results_title = I18n.locale.to_s == "ja" ? "\u6761\u4EF6\u3092\u7DE9\u548C\u3057\u3066\u518D\u691C\u7D22\u3057\u307E\u3057\u3087\u3046" : "Try broader filters" %>
 <% no_results_hint = I18n.locale.to_s == "ja" ? "\u691C\u7D22\u6761\u4EF6\u3092\u3064\u304F\u308A\u76F4\u3059\u3068\u3001\u65B0\u3057\u3044\u6295\u7A3F\u3092\u898B\u3064\u3051\u3084\u3059\u304F\u306A\u308A\u307E\u3059\u3002" : "Relax one condition at a time to discover more posts." %>
 <% clear_all_label = I18n.locale.to_s == "ja" ? "\u3059\u3079\u3066\u30AF\u30EA\u30A2" : "Clear all filters" %>
@@ -71,6 +73,11 @@
           </button>
           <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
+        <% if detailed_filters_open %>
+          <p class="mt-1.5 ds-text-muted">
+            <%= active_filters.any? ? format(details_applied_summary, count: active_filters.size) : details_none_summary %>
+          </p>
+        <% end %>
       </div>
 
       <div data-details-panel class="rounded-xl border border-slate-100 bg-slate-50/40 p-3 sm:p-3.5 <%= detailed_filters_open ? '' : 'hidden' %>">
@@ -98,12 +105,11 @@
         </div>
       </div>
       <% unless detailed_filters_open %>
-        <p class="ds-text-muted px-1"><%= detail_collapsed_hint %></p>
+        <div class="px-1">
+          <p class="ds-text-meta font-semibold"><%= active_filters.any? ? format(details_applied_summary, count: active_filters.size) : details_none_summary %></p>
+          <p class="ds-text-muted mt-1"><%= detail_collapsed_hint %></p>
+        </div>
       <% end %>
-      <div class="px-1">
-        <p class="ds-text-meta font-semibold"><%= applied_filters_label %></p>
-        <p class="ds-text-muted mt-1"><%= active_filters.any? ? active_filters.map { |key, value| "#{filter_labels[key]}: #{value}" }.join(" / ") : no_filters_label %></p>
-      </div>
     <% end %>
   </div>
 
@@ -124,19 +130,24 @@
 
             <p class="mt-2 ds-line-clamp-2 text-sm leading-6 text-slate-600"><%= truncate(post.description, length: 90) %></p>
 
-            <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
-              <% visible_tags.each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
-              <% end %>
-              <% if hidden_tag_count.positive? %>
-                <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
-              <% end %>
-            </div>
+            <% if post.tags.any? %>
+              <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
+                <% visible_tags.each do |tag| %>
+                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+                <% end %>
+                <% if hidden_tag_count.positive? %>
+                  <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
+                <% end %>
+              </div>
+            <% end %>
 
             <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta" aria-label="Post metadata">
               <div class="flex flex-wrap items-center gap-2">
                 <% if post.category.present? %>
                   <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600"><%= post.category %></span>
+                <% end %>
+                <% if post.tags.empty? %>
+                  <span><%= "#{t('posts.index.tag_placeholder')}: #{no_filters_label}" %></span>
                 <% end %>
                 <span>
                   <%= t("posts.index.author_label") %>:
@@ -148,9 +159,6 @@
                   <span><%= localized_number(post.likes_count) %></span>
                 </span>
               </div>
-              <% if visible_tags.empty? && hidden_tag_count.zero? %>
-                <p class="text-slate-400"><%= no_filters_label %></p>
-              <% end %>
             </div>
           </div>
         </article>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,6 +6,11 @@
 <% comment_empty_cta = I18n.locale.to_s == "ja" ? "最初のコメントを書く" : "Write the first comment" %>
 <% mobile_menu_open_label = I18n.locale.to_s == "ja" ? "操作メニューを開きました" : "Action menu opened" %>
 <% mobile_menu_close_label = I18n.locale.to_s == "ja" ? "操作メニューを閉じました" : "Action menu closed" %>
+<% item_preview_label = I18n.locale.to_s == "ja" ? "商品プレビュー" : "Item preview" %>
+<% item_price_unknown_label = I18n.locale.to_s == "ja" ? "価格: 情報なし" : "Price: unavailable" %>
+<% item_link_missing_label = I18n.locale.to_s == "ja" ? "リンク未設定" : "Link not available" %>
+<% related_items_owner_hint = I18n.locale.to_s == "ja" ? "関連アイテムを追加すると、読者が構成を比較しやすくなります。" : "Add related items to help readers compare your setup." %>
+<% mobile_more_label = I18n.locale.to_s == "ja" ? "その他の操作" : "More actions" %>
 
 <article class="space-y-content">
   <header class="space-y-3">
@@ -55,16 +60,40 @@
     <% if @post.items.any? %>
       <div class="mt-4 space-y-3">
         <% @post.items.each do |item| %>
-          <div class="rounded-lg border border-slate-200 p-3">
-            <p class="text-sm font-medium text-slate-900"><%= item.name %></p>
-            <% if item.affiliate_url.present? %>
-              <%= link_to t("posts.show.open_product_page"), item.affiliate_url, class: "mt-2 inline-block text-sm text-blue-600 hover:text-blue-700", target: "_blank", rel: "nofollow sponsored noopener" %>
-            <% end %>
-          </div>
+          <article class="rounded-lg border border-slate-200 bg-slate-50 p-3 sm:p-4">
+            <div class="grid gap-3 sm:grid-cols-[88px_minmax(0,1fr)] sm:items-center">
+              <div class="aspect-square rounded-md border border-slate-200 bg-white text-slate-400">
+                <div class="flex h-full items-center justify-center">
+                  <div class="text-center">
+                    <%= ui_icon(:information_circle, class_name: "mx-auto h-5 w-5") %>
+                    <p class="mt-1 text-[10px] font-medium"><%= item_preview_label %></p>
+                  </div>
+                </div>
+              </div>
+              <div class="space-y-2">
+                <p class="text-sm font-semibold text-slate-900"><%= item.name %></p>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="ds-text-meta"><%= item_price_unknown_label %></span>
+                  <% if item.affiliate_url.present? %>
+                    <%= link_to t("posts.show.open_product_page"), item.affiliate_url, class: "tap-target cta-secondary cta-compact", target: "_blank", rel: "nofollow sponsored noopener" %>
+                  <% else %>
+                    <span class="ds-text-muted"><%= item_link_missing_label %></span>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </article>
         <% end %>
       </div>
     <% else %>
       <p class="mt-3 text-sm text-slate-600"><%= t("posts.show.no_related_items") %></p>
+      <% if post_owner?(@post) %>
+        <p class="mt-2 ds-text-support"><%= related_items_owner_hint %></p>
+        <%= link_to edit_post_path(@post), class: "mt-3 inline-flex tap-target cta-secondary cta-compact" do %>
+          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.actions.edit") %></span>
+        <% end %>
+      <% end %>
     <% end %>
   </section>
 
@@ -83,18 +112,14 @@
           <article id="comment-<%= comment.id %>" class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <div class="flex items-center justify-between gap-3">
               <p class="text-sm font-medium text-slate-800"><%= comment.author_name %></p>
-              <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700", data: { ga_event: "comment_reply_click", ga_category: "comments", ga_label: "reply_to_parent" } do %>
-                <%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %>
-                <span><%= t("posts.show.comments.reply") %></span>
-              <% end %>
             </div>
             <p class="mt-0.5 text-xs text-slate-600"><%= l(comment.created_at, format: :short) %></p>
             <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= comment.body %></p>
 
             <% if comment.replies.any? %>
-              <div class="mt-4 space-y-3 rounded-r-lg border-l-4 border-blue-200 bg-slate-50 px-3 py-3 sm:pl-4 sm:pr-3">
+              <div class="mt-4 space-y-2 rounded-lg bg-slate-50 px-3 py-3 sm:pl-4 sm:pr-3">
                 <% comment.replies.each do |reply| %>
-                  <div id="comment-<%= reply.id %>" class="rounded-lg border border-slate-300 bg-white p-3">
+                  <div id="comment-<%= reply.id %>" class="rounded-md bg-white/85 px-3 py-2">
                     <p class="text-xs font-medium text-slate-700"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
                     <p class="mt-0.5 text-xs text-slate-600"><%= l(reply.created_at, format: :short) %></p>
                     <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= reply.body %></p>
@@ -102,6 +127,13 @@
                 <% end %>
               </div>
             <% end %>
+
+            <div class="mt-3 border-t border-slate-100 pt-3">
+              <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700", data: { ga_event: "comment_reply_click", ga_category: "comments", ga_label: "reply_to_parent" } do %>
+                <%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %>
+                <span><%= t("posts.show.comments.reply") %></span>
+              <% end %>
+            </div>
           </article>
         <% end %>
       </div>
@@ -191,27 +223,25 @@
   <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-mobile-actions-root>
     <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
       <div class="relative pb-1">
-        <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1.5">
+        <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
           <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-primary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
             <span class="inline-flex items-center justify-center gap-1.5">
               <%= ui_icon(:heart, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.like") %></span>
             </span>
           <% end %>
-          <button type="button" data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary" class="tap-target inline-flex items-center justify-center gap-1 rounded-lg px-2.5 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-100 hover:text-slate-900">
-            <span class="inline-flex items-center gap-1.5">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share") %></span>
-            </span>
-          </button>
           <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target inline-flex items-center justify-center rounded-lg px-2.5 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
             <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
-            <span class="sr-only">More</span>
+            <span class="sr-only"><%= mobile_more_label %></span>
           </button>
         </div>
 
         <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-20 mb-2 hidden rounded-xl border border-slate-300 bg-white/98 p-2 shadow-2xl ring-1 ring-slate-900/5">
           <div class="grid gap-1">
+            <button type="button" data-mobile-menu-action data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share") %></span>
+            </button>
             <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
               <%= ui_icon(:share, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.share_x") %></span>
@@ -341,17 +371,32 @@
       }
 
       const mobileActionsMenu = document.querySelector("[data-mobile-actions-menu]");
+      const shareButton = event.target.closest("[data-native-share-url]");
       if (mobileActionsMenu && !mobileActionsMenu.classList.contains("hidden")) {
         const isMenuAction = event.target.closest("[data-mobile-menu-action]");
         const isInsideMenu = event.target.closest("[data-mobile-actions-menu]");
         if (isMenuAction) {
+          if (shareButton) {
+            const url = shareButton.getAttribute("data-native-share-url");
+            const text = shareButton.getAttribute("data-native-share-text");
+
+            if (navigator.share) {
+              navigator.share({ text, url }).catch(async (error) => {
+                if (error && error.name === "AbortError") return;
+                try {
+                  await navigator.clipboard.writeText(url);
+                } catch (_) {}
+              });
+            } else {
+              navigator.clipboard.writeText(url).catch(() => {});
+            }
+          }
           closeMobileActionsMenu("action_selected");
           return;
         }
         if (!isInsideMenu) closeMobileActionsMenu("outside_tap");
       }
 
-      const shareButton = event.target.closest("[data-native-share-url]");
       if (shareButton) {
         const url = shareButton.getAttribute("data-native-share-url");
         const text = shareButton.getAttribute("data-native-share-text");
@@ -377,12 +422,19 @@
     const mobileActionsRoot = document.querySelector("[data-mobile-actions-root]");
     const commentForm = document.querySelector("#comment-form form");
     if (mobileActionsRoot && commentForm) {
-      commentForm.addEventListener("focusin", () => {
-        mobileActionsRoot.classList.add("translate-y-full", "opacity-0", "pointer-events-none");
-      });
-      commentForm.addEventListener("focusout", (event) => {
-        const next = event.relatedTarget;
-        if (next && commentForm.contains(next)) return;
+      const setMobileBarVisibility = () => {
+        const activeElement = document.activeElement;
+        const shouldHide = activeElement && commentForm.contains(activeElement);
+        mobileActionsRoot.classList.toggle("translate-y-full", shouldHide);
+        mobileActionsRoot.classList.toggle("opacity-0", shouldHide);
+        mobileActionsRoot.classList.toggle("pointer-events-none", shouldHide);
+      };
+
+      document.addEventListener("focusin", setMobileBarVisibility, true);
+      document.addEventListener("focusout", () => {
+        window.setTimeout(setMobileBarVisibility, 0);
+      }, true);
+      commentForm.addEventListener("submit", () => {
         mobileActionsRoot.classList.remove("translate-y-full", "opacity-0", "pointer-events-none");
       });
     }


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/59

## 目的

  主要導線の優先順位を明確化し、一覧/詳細/モバイルで「最初に何をすべきか」が3秒以内に判断できるUIに寄せることを目的に実装しました。

  ## 実装内容

  - 一覧検索を段階化し、初期は基本検索中心、詳細は折りたたみ＋適用件数サマリで表示。
  - 検索CTAの優先度を Primary(検索) と Tertiary(詳細切替) で明確化。
  - 一覧カードのタグ表示を 2件 + +n に固定し、タグ0件時の なし 表示をメタ領域のみに移動。
  - 詳細画面のモバイル固定アクションを 主要1アクション(Like) + Moreメニュー に整理。
  - Moreメニューの視覚階層（背景/影）を強化し、Share系操作をメニュー配下へ集約。
  - コメント入力フォーカス中はモバイル固定バーを退避し、入力完了時に再表示。
  - 関連アイテムをサムネイル枠付きの固定レイアウトに変更し、空状態で投稿者向け編集導線を追加。
  - コメント階層を簡素化（返信は背景トーン差＋インデント寄り）し、返信導線を本文末尾側に統一。
  - ヘッダー/モバイルメニューの順序を 投稿 → プロフィール → 言語 に統一。
  - ロケール切替に「現在の言語」ラベル＋選択中表示を追加し、コントラストを強化。

  ## 方法

  ERBテンプレートと既存CTAクラスを中心に、情報階層・導線順序・モバイル時の行動密度を調整しました。
  JSは最小限で、検索詳細トグル/モバイルMoreメニュー/コメント入力時の固定バー退避のみを強化しています。

  ## 変更箇所

  - app/views/layouts/application.html.erb#L56
  - app/views/posts/index.html.erb#L16:16
  - app/views/posts/show.html.erb#L9:9

  ## まとめ

  要件に沿って、一覧では「検索主導」、詳細では「本文読了後の行動主導」、モバイルでは「主要操作の単純化」を実装しました。
  特に、検索段階化・カード情報密度調整・固定アクション整理・ヘッダー順序統一で、視線誘導と操作学習の一貫性を改善しています。

  ## Testing

  - ruby -rerb -e "ERB.new(File.read(%q{app/views/layouts/application.html.erb})).src": OK
  - ruby -rerb -e "ERB.new(File.read(%q{app/views/posts/index.html.erb})).src": OK
  - ruby -rerb -e "ERB.new(File.read(%q{app/views/posts/show.html.erb})).src": OK
  - git diff --check: 致命的な差分問題なし（CRLF警告のみ）
  - フルRailsテストは未実行です。