### PR TITLE
UX Overhaul: Streamlined search logic, mobile CTA reconciliation, and Japanese typography optimization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+- What problem does this PR solve?
+- Which screen(s)/component(s) are affected?
+
+## UI Change Scope
+- [ ] posts/index
+- [ ] posts/show
+- [ ] layout/header/mobile bar
+- [ ] forms
+- [ ] other:
+
+## Design System Audit
+- [ ] One primary CTA per section/screen context
+- [ ] No competing CTA between fixed bar and in-page task UI
+- [ ] Card hierarchy follows `Title > Summary > Primary meta > Secondary meta`
+- [ ] Badge semantics are consistent (`active / inactive / informational`)
+- [ ] Empty/zero/error states have a single emphasized next action
+- [ ] Focus-visible is clear on all interactive controls
+- [ ] Dynamic UI changes are announced where needed
+- [ ] Mobile tap target size is >=44px
+- [ ] Section/block/component spacing rhythm is preserved
+- [ ] Ads use `ad-slot-surface` and `ad-slot-label` rules
+
+## Accessibility Notes
+- Keyboard flow checked:
+- Screen reader announcement impact:
+- Contrast/state distinction impact:
+
+## Testing
+- [ ] Manual verification on desktop
+- [ ] Manual verification on mobile viewport
+- [ ] Relevant automated tests updated/passed
+
+## Screenshots / Recordings
+- Before:
+- After:
+

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -9,6 +9,9 @@
     --ds-letter-spacing-nav: 0.002em;
     --ds-space-content: 2rem;
     --ds-space-form: 1.5rem;
+    --ds-space-section: 2.25rem;
+    --ds-space-block: 1.5rem;
+    --ds-space-component: 0.875rem;
     --ds-focus-ring-shadow: 0 0 0 3px rgba(37, 99, 235, 0.3);
     --ds-focus-border-color: rgb(37, 99, 235);
     --ds-text-main: rgb(15 23 42);
@@ -26,6 +29,9 @@
     --ds-letter-spacing-nav: 0.01em;
     --ds-space-content: 2.25rem;
     --ds-space-form: 1.75rem;
+    --ds-space-section: 2.5rem;
+    --ds-space-block: 1.75rem;
+    --ds-space-component: 1rem;
   }
 
   html[lang="en"] {
@@ -134,6 +140,18 @@
     margin-top: var(--ds-space-form);
   }
 
+  .space-y-section > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--ds-space-section);
+  }
+
+  .space-y-block > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--ds-space-block);
+  }
+
+  .space-y-component > :not([hidden]) ~ :not([hidden]) {
+    margin-top: var(--ds-space-component);
+  }
+
   .ds-line-clamp-2 {
     display: -webkit-box;
     overflow: hidden;
@@ -153,6 +171,18 @@
 
   .ds-badge {
     @apply inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-600;
+  }
+
+  .ds-badge-active {
+    @apply inline-flex items-center gap-1 rounded-full border border-blue-300 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-800;
+  }
+
+  .ds-badge-inactive {
+    @apply inline-flex items-center rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100;
+  }
+
+  .ds-badge-info {
+    @apply inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-500;
   }
 
   .ds-shadow-soft {
@@ -186,6 +216,27 @@
   .mobile-sticky-bar {
     @apply fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur;
     box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
+  }
+
+  .ad-slot-surface {
+    @apply rounded-xl border border-slate-200 bg-slate-50/70 px-4 py-4;
+  }
+
+  .ad-slot-label {
+    @apply mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-slate-500;
+  }
+
+  .lang-ja .ds-reading-column {
+    max-width: 58ch;
+  }
+
+  .lang-ja .ds-text-body,
+  .lang-ja .ds-text-support {
+    line-height: 1.8;
+  }
+
+  .lang-ja section > p + p {
+    margin-top: 0.75rem;
   }
 
   @media (max-width: 640px) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,8 +53,6 @@
     <% tracked_events = analytics_events %>
     <% mobile_sticky_active = controller_name == "posts" && action_name.in?(%w[index show]) %>
     <% main_padding_class = mobile_sticky_active ? "pb-40 sm:pb-8" : "pb-10 sm:pb-8" %>
-    <% current_language_label = I18n.locale.to_s == "ja" ? "現在の言語" : "Current language" %>
-    <% current_language_hint = I18n.locale.to_s == "ja" ? "選択中" : "Current" %>
 
     <header class="sticky top-0 z-40 border-b border-slate-200 bg-white/90 backdrop-blur" data-mobile-header-root>
       <div class="mx-auto flex w-full max-w-6xl items-center gap-2 px-4 py-2 sm:px-6 sm:py-3">
@@ -65,56 +63,55 @@
           <span class="sr-only">Menu</span>
         </button>
 
-        <div class="ml-auto hidden items-center gap-2 text-sm font-medium tracking-nav sm:flex">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
-          <% if owned_users.any? %>
-            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
-          <% else %>
-            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex items-center rounded-lg border border-slate-300 px-4 py-2 text-slate-700 hover:bg-slate-100", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
-          <% end %>
-          <div class="space-y-1">
-            <p class="text-[11px] font-semibold text-slate-700"><%= current_language_label %></p>
-            <div class="inline-flex items-center gap-1 rounded-full border border-slate-400 bg-slate-50 p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
-              <%= link_to locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
-                <span><%= t("language.option_ja") %></span>
-                <% if locale_selected?(:ja) %>
-                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
-                <% end %>
+        <div class="ml-auto hidden flex-col items-end gap-1 sm:flex">
+          <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-50 p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
+            <%= link_to locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
+              <span><%= t("language.option_ja") %></span>
+              <% if locale_selected?(:ja) %>
+                <%= ui_icon(:check, class_name: "h-3 w-3") %>
               <% end %>
-              <%= link_to locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
-                <span><%= t("language.option_en") %></span>
-                <% if locale_selected?(:en) %>
-                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
-                <% end %>
+            <% end %>
+            <%= link_to locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
+              <span><%= t("language.option_en") %></span>
+              <% if locale_selected?(:en) %>
+                <%= ui_icon(:check, class_name: "h-3 w-3") %>
               <% end %>
-            </div>
+            <% end %>
+          </div>
+          <div class="flex items-center gap-2 text-sm font-medium tracking-nav">
+            <% if owned_users.any? %>
+              <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
+            <% else %>
+              <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
+            <% end %>
+            <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
           </div>
         </div>
       </div>
 
       <div id="mobile-header-menu" data-mobile-header-menu class="hidden border-t border-slate-200 bg-white sm:hidden">
         <div class="mx-auto w-full max-w-6xl space-y-2 px-4 py-2.5">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_menu" } %>
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_header_create_post_menu" } %>
 
           <% if owned_users.any? %>
-            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
+            <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target cta-tertiary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "mobile_header_my_profile" } %>
           <% else %>
-            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target inline-flex w-full items-center justify-center rounded-lg border border-slate-300 px-4 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
+            <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
 
           <div class="rounded-xl border border-slate-300 bg-slate-50 p-2">
-            <p class="mb-1 text-xs font-semibold text-slate-700"><%= current_language_label %></p>
+            <p class="mb-1 text-xs font-semibold text-slate-700"><%= t("language.switch_aria") %></p>
             <div class="inline-flex items-center gap-1 rounded-full border border-slate-400 bg-white p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
               <%= link_to locale_switch_path(:ja), class: "rounded-full px-2.5 py-1 #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } do %>
                 <span><%= t("language.option_ja") %></span>
                 <% if locale_selected?(:ja) %>
-                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                  <%= ui_icon(:check, class_name: "ml-1 h-3 w-3") %>
                 <% end %>
               <% end %>
               <%= link_to locale_switch_path(:en), class: "rounded-full px-2.5 py-1 #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } do %>
                 <span><%= t("language.option_en") %></span>
                 <% if locale_selected?(:en) %>
-                  <span class="ml-1 text-[10px] font-bold"><%= current_language_hint %></span>
+                  <%= ui_icon(:check, class_name: "ml-1 h-3 w-3") %>
                 <% end %>
               <% end %>
             </div>
@@ -148,7 +145,7 @@
     </main>
 
     <% if controller_name == "posts" && action_name == "index" %>
-      <div class="mobile-sticky-bar sm:hidden">
+      <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-index-mobile-cta>
         <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
           <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
         </div>
@@ -170,8 +167,8 @@
     <script>
       if (!window.__mobileHeaderBindingInstalled) {
         window.__mobileHeaderBindingInstalled = true;
-        const menuOpenedMessage = "<%= j(I18n.locale.to_s == 'ja' ? 'メニューを開きました' : 'Menu opened') %>";
-        const menuClosedMessage = "<%= j(I18n.locale.to_s == 'ja' ? 'メニューを閉じました' : 'Menu closed') %>";
+        const menuOpenedMessage = "Menu opened";
+        const menuClosedMessage = "Menu closed";
         window.dsAnnounce = (message) => {
           if (!message) return;
           const region = document.getElementById("ui-live-region");

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,37 +1,33 @@
 <% content_for :title, t("posts.index.title") %>
 <% content_for :description, t("posts.index.description") %>
-<% detailed_filters_open = params[:details] == "1" || params[:category].present? || params[:theme].present? || params[:tag].present? %>
-<% detailed_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
-<% applied_filter_count = [params[:category], params[:theme], params[:tag]].count(&:present?) %>
-<% filtered_results = params[:q].present? || applied_filter_count.positive? %>
-<% detailed_status_shown_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u8868\u793A\u4E2D" : "Details shown" %>
-<% detailed_status_hidden_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u306F\u975E\u8868\u793A" : "Details hidden" %>
-<% detailed_status_label = detailed_filters_open ? detailed_status_shown_label : detailed_status_hidden_label %>
-<% applied_filters_label = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D\u30D5\u30A3\u30EB\u30BF" : "Applied filters" %>
-<% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
-<% basic_search_label = I18n.locale.to_s == "ja" ? "\u57FA\u672C\u691C\u7D22" : "Basic search" %>
-<% detailed_search_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u691C\u7D22" : "Detailed search" %>
-<% basic_step_label = I18n.locale.to_s == "ja" ? "\u30B9\u30C6\u30C3\u30D71" : "Step 1" %>
-<% optional_label = I18n.locale.to_s == "ja" ? "\u4EFB\u610F" : "Optional" %>
-<% details_applied_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: %{count}\u4EF6" : "Applied: %{count}" %>
-<% details_none_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: \u306A\u3057" : "Applied: none" %>
-<% no_results_title = I18n.locale.to_s == "ja" ? "\u6761\u4EF6\u3092\u7DE9\u548C\u3057\u3066\u518D\u691C\u7D22\u3057\u307E\u3057\u3087\u3046" : "Try broader filters" %>
-<% no_results_hint = I18n.locale.to_s == "ja" ? "\u691C\u7D22\u6761\u4EF6\u3092\u3064\u304F\u308A\u76F4\u3059\u3068\u3001\u65B0\u3057\u3044\u6295\u7A3F\u3092\u898B\u3064\u3051\u3084\u3059\u304F\u306A\u308A\u307E\u3059\u3002" : "Relax one condition at a time to discover more posts." %>
-<% clear_all_label = I18n.locale.to_s == "ja" ? "\u3059\u3079\u3066\u30AF\u30EA\u30A2" : "Clear all filters" %>
-<% remove_keyword_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u3092\u5916\u3059" : "Remove keyword" %>
-<% expand_details_label = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u958B\u304F" : "Open detailed filters" %>
-<% detail_collapsed_hint = I18n.locale.to_s == "ja" ? "\u8A73\u7D30\u6761\u4EF6\u3092\u958B\u304F\u3068\u3001\u30AB\u30C6\u30B4\u30EA\u30FC\u30FB\u30BF\u30B0\u306E\u8ABF\u6574\u304C\u3067\u304D\u307E\u3059\u3002" : "Open details to filter by category, theme, and tag." %>
-<% max_card_tags = 2 %>
 <% active_filters = {
   category: params[:category].to_s.strip,
   theme: params[:theme].to_s.strip,
   tag: params[:tag].to_s.strip
 }.select { |_, value| value.present? } %>
+<% detailed_filters_open = params[:details] == "1" || active_filters.any? %>
+<% applied_filter_count = active_filters.size %>
+<% filtered_results = params[:q].present? || applied_filter_count.positive? %>
+<% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
+<% quick_search_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u691C\u7D22" : "Quick search" %>
+<% filters_open_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u3092\u958B\u304F" : "Open filters" %>
+<% filters_close_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u3092\u9589\u3058\u308B" : "Hide filters" %>
+<% filters_title = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F" : "Refine results" %>
+<% filters_hint = I18n.locale.to_s == "ja" ? "\u5FC5\u8981\u306A\u3068\u304D\u3060\u3051\u30AB\u30C6\u30B4\u30EA\u30FC\u30FB\u30BF\u30B0\u3092\u8FFD\u52A0\u3057\u3066\u7D5E\u308A\u8FBC\u307F\u307E\u3059\u3002" : "Open only when you need category, theme, or tag filters." %>
+<% details_applied_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: %{count}\u4EF6" : "%{count} filters applied" %>
+<% details_none_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: \u306A\u3057" : "No filters applied" %>
+<% no_results_title = I18n.locale.to_s == "ja" ? "\u6761\u4EF6\u3092\u7DE9\u548C\u3057\u3066\u518D\u691C\u7D22\u3057\u307E\u3057\u3087\u3046" : "Try broader filters" %>
+<% no_results_hint = I18n.locale.to_s == "ja" ? "\u307E\u305A\u306F1\u3064\u3060\u3051\u6761\u4EF6\u3092\u5916\u3059\u3068\u3001\u65B0\u3057\u3044\u6295\u7A3F\u304C\u898B\u3064\u304B\u308A\u3084\u3059\u304F\u306A\u308A\u307E\u3059\u3002" : "Relax one condition first to discover more posts." %>
+<% clear_all_label = I18n.locale.to_s == "ja" ? "\u3059\u3079\u3066\u30AF\u30EA\u30A2" : "Clear all filters" %>
+<% remove_keyword_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u3092\u5916\u3059" : "Remove keyword" %>
+<% remove_one_filter_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u30921\u3064\u5916\u3059" : "Remove one filter" %>
+<% max_card_tags = 2 %>
 <% filter_labels = {
   category: t("posts.index.category_placeholder"),
   theme: t("posts.index.theme_placeholder"),
   tag: t("posts.index.tag_placeholder")
 } %>
+<% first_active_filter_key = active_filters.keys.first %>
 <% persisted_query = {
   q: params[:q].presence,
   category: params[:category].presence,
@@ -40,76 +36,67 @@
   details: params[:details].presence
 }.compact %>
 
-<section class="space-y-6 sm:space-y-8">
+<section class="space-y-section">
   <div class="rounded-2xl bg-gradient-to-br from-slate-900 via-blue-800 to-cyan-700 px-6 py-6 text-white sm:py-8">
-    <h1 class="text-2xl font-bold sm:text-3xl"><%= t("posts.index.hero_title") %></h1>
-    <p class="mt-2 max-w-2xl text-sm text-blue-100 sm:text-base">
+    <h1 class="ds-heading-xl"><%= t("posts.index.hero_title") %></h1>
+    <p class="ds-text-support ds-reading-column mt-2 max-w-2xl text-blue-100">
       <%= t("posts.index.hero_description") %>
     </p>
   </div>
 
-  <div class="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5">
-    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-2.5", data: { search_form: true } do %>
+  <div class="rounded-2xl border border-slate-200 bg-white p-4 sm:p-5" data-index-search-root>
+    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
-      <div class="rounded-xl border border-slate-200 bg-white p-3 sm:p-4">
-        <div class="flex items-center justify-between gap-2">
-          <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= basic_search_label %></p>
-          <span class="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-semibold text-blue-700"><%= basic_step_label %></span>
-        </div>
+
+      <div class="rounded-xl border border-slate-200 bg-white p-4">
+        <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= quick_search_label %></p>
         <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
           <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-primary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
         </div>
-        <div class="mt-2 flex flex-wrap items-center justify-between gap-1.5">
-          <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target cta-tertiary text-xs" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
+      </div>
+
+      <div class="rounded-xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4">
+        <div class="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p class="text-sm font-semibold text-slate-800"><%= filters_title %></p>
+            <p class="ds-text-muted mt-0.5">
+              <%= active_filters.any? ? format(details_applied_summary, count: active_filters.size) : details_none_summary %>
+            </p>
+          </div>
+          <button type="button" data-details-toggle aria-expanded="<%= detailed_filters_open %>" class="tap-target cta-tertiary" data-ga-event="post_search_details_toggle_click" data-ga-category="post_search" data-ga-label="index_search_details_toggle">
             <span class="inline-flex items-center gap-1.5">
-              <span><%= detailed_search_label %> (<%= optional_label %>)</span>
-              <% if detailed_filter_count.positive? %>
-                <span class="rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-semibold text-blue-700" data-detailed-filter-count><%= detailed_filter_count %></span>
-              <% end %>
-              <span data-details-state-badge data-label-shown="<%= detailed_status_shown_label %>" data-label-hidden="<%= detailed_status_hidden_label %>" class="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] text-slate-600"><%= detailed_status_label %></span>
+              <span data-details-toggle-label data-label-open="<%= filters_open_label %>" data-label-close="<%= filters_close_label %>"><%= detailed_filters_open ? filters_close_label : filters_open_label %></span>
               <%= ui_icon(:chevron_down, class_name: "js-details-toggle-icon h-4 w-4 text-slate-600 transition-transform #{detailed_filters_open ? 'rotate-180' : ''}") %>
             </span>
           </button>
-          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
-        </div>
-        <% if detailed_filters_open %>
-          <p class="mt-1.5 ds-text-muted">
-            <%= active_filters.any? ? format(details_applied_summary, count: active_filters.size) : details_none_summary %>
-          </p>
-        <% end %>
-      </div>
-
-      <div data-details-panel class="rounded-xl border border-slate-100 bg-slate-50/40 p-3 sm:p-3.5 <%= detailed_filters_open ? '' : 'hidden' %>">
-        <div class="grid gap-2.5 sm:grid-cols-3">
-          <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
-          <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
-          <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
         </div>
 
-        <div class="mt-2.5">
-          <p class="ds-text-meta font-semibold"><%= applied_filters_label %></p>
-          <div class="mt-1.5 flex flex-wrap items-center gap-2">
+        <div data-details-panel class="mt-3 space-y-component <%= detailed_filters_open ? '' : 'hidden' %>">
+          <p class="ds-text-muted"><%= filters_hint %></p>
+          <div class="grid gap-2.5 sm:grid-cols-3">
+            <%= select_tag :category, options_for_select([[t("posts.index.category_placeholder"), ""]] + @categories.map { |c| [c, c] }, params[:category]), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_filter_input: "category" } %>
+            <%= text_field_tag :theme, params[:theme], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.theme_placeholder"), data: { search_filter_input: "theme" } %>
+            <%= text_field_tag :tag, params[:tag], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.tag_placeholder"), data: { search_filter_input: "tag" } %>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
             <% if active_filters.any? %>
               <% active_filters.each do |key, value| %>
                 <% clear_params = persisted_query.except(key) %>
-                <%= link_to posts_path(clear_params), class: "tap-target inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_clear_#{key}" } do %>
+                <%= link_to posts_path(clear_params), class: "tap-target ds-badge-active", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_clear_#{key}" } do %>
+                  <%= ui_icon(:check, class_name: "h-3.5 w-3.5") %>
                   <span><%= "#{filter_labels[key]}: #{value}" %></span>
-                  <span aria-hidden="true" class="text-slate-600">&times;</span>
+                  <span aria-hidden="true">&times;</span>
                 <% end %>
               <% end %>
             <% else %>
-              <span class="ds-text-muted"><%= no_filters_label %></span>
+              <span class="ds-badge-info"><%= no_filters_label %></span>
             <% end %>
+            <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
           </div>
         </div>
       </div>
-      <% unless detailed_filters_open %>
-        <div class="px-1">
-          <p class="ds-text-meta font-semibold"><%= active_filters.any? ? format(details_applied_summary, count: active_filters.size) : details_none_summary %></p>
-          <p class="ds-text-muted mt-1"><%= detail_collapsed_hint %></p>
-        </div>
-      <% end %>
     <% end %>
   </div>
 
@@ -130,34 +117,37 @@
 
             <p class="mt-2 ds-line-clamp-2 text-sm leading-6 text-slate-600"><%= truncate(post.description, length: 90) %></p>
 
-            <% if post.tags.any? %>
-              <div class="mt-2.5 flex flex-wrap items-center gap-1.5 text-[11px] text-slate-400">
-                <% visible_tags.each do |tag| %>
-                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-600", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
-                <% end %>
-                <% if hidden_tag_count.positive? %>
-                  <span class="inline-flex items-center rounded-full border border-slate-100 bg-slate-50 px-2 py-0.5 text-slate-400">+<%= hidden_tag_count %></span>
-                <% end %>
-              </div>
-            <% end %>
+            <div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-slate-700" aria-label="Post primary metadata">
+              <% if post.category.present? %>
+                <span class="ds-badge-inactive"><%= post.category %></span>
+              <% end %>
+              <span>
+                <%= t("posts.index.author_label") %>:
+                <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+              </span>
+            </div>
 
-            <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta" aria-label="Post metadata">
-              <div class="flex flex-wrap items-center gap-2">
-                <% if post.category.present? %>
-                  <span class="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600"><%= post.category %></span>
-                <% end %>
-                <% if post.tags.empty? %>
-                  <span><%= "#{t('posts.index.tag_placeholder')}: #{no_filters_label}" %></span>
-                <% end %>
-                <span>
-                  <%= t("posts.index.author_label") %>:
-                  <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 hover:text-slate-900", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-                </span>
-                <span><%= l(post.created_at.to_date) %></span>
-                <span class="inline-flex items-center gap-1">
-                  <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                  <span><%= localized_number(post.likes_count) %></span>
-                </span>
+            <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta text-slate-500" aria-label="Post secondary metadata">
+              <div class="flex flex-wrap items-center justify-between gap-2">
+                <div class="flex flex-wrap items-center gap-1.5">
+                  <% if post.tags.any? %>
+                    <% visible_tags.each do |tag| %>
+                      <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+                    <% end %>
+                    <% if hidden_tag_count.positive? %>
+                      <span class="ds-badge-info">+<%= hidden_tag_count %></span>
+                    <% end %>
+                  <% else %>
+                    <span><%= "#{t('posts.index.tag_placeholder')}: #{no_filters_label}" %></span>
+                  <% end %>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span><%= l(post.created_at.to_date) %></span>
+                  <span class="inline-flex items-center gap-1">
+                    <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                    <span><%= localized_number(post.likes_count) %></span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -170,13 +160,15 @@
       <% if filtered_results %>
         <p class="mt-2 text-sm font-semibold text-slate-700"><%= no_results_title %></p>
         <p class="mt-1 ds-text-support"><%= no_results_hint %></p>
-        <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
-          <%= link_to clear_all_label, root_path, class: "tap-target cta-secondary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
+        <div class="mt-4">
+          <%= link_to clear_all_label, root_path, class: "tap-target cta-primary", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
+        </div>
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-1">
           <% if params[:q].present? %>
-            <%= link_to remove_keyword_label, posts_path(persisted_query.except(:q)), class: "tap-target cta-tertiary", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_keyword" } %>
+            <%= link_to remove_keyword_label, posts_path(persisted_query.except(:q)), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_keyword" } %>
           <% end %>
-          <% unless detailed_filters_open %>
-            <%= link_to expand_details_label, posts_path(persisted_query.merge(details: "1")), class: "tap-target cta-tertiary", data: { ga_event: "post_search_details_toggle_click", ga_category: "post_search", ga_label: "index_empty_open_details" } %>
+          <% if first_active_filter_key.present? %>
+            <%= link_to remove_one_filter_label, posts_path(persisted_query.except(first_active_filter_key)), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_one_filter" } %>
           <% end %>
         </div>
       <% else %>
@@ -201,26 +193,56 @@
       const form = toggle.closest("form");
       const panel = form ? form.querySelector("[data-details-panel]") : null;
       const icon = toggle.querySelector(".js-details-toggle-icon");
-      const stateLabel = toggle.querySelector("[data-details-state-badge]");
+      const toggleLabel = toggle.querySelector("[data-details-toggle-label]");
       const stateInput = form ? form.querySelector("[data-details-state-input]") : null;
       if (!panel) return;
 
       const expanded = toggle.getAttribute("aria-expanded") == "true";
       const nextExpanded = !expanded;
-      toggle.setAttribute("aria-expanded", String(!expanded));
-      panel.classList.toggle("hidden", expanded);
-      if (icon) icon.classList.toggle("rotate-180", !expanded);
-      if (stateLabel) {
-        const shownLabel = stateLabel.dataset.labelShown || "Details shown";
-        const hiddenLabel = stateLabel.dataset.labelHidden || "Details hidden";
-        stateLabel.textContent = nextExpanded ? shownLabel : hiddenLabel;
-        stateLabel.classList.toggle("bg-emerald-100", nextExpanded);
-        stateLabel.classList.toggle("text-emerald-700", nextExpanded);
-        stateLabel.classList.toggle("bg-slate-200", !nextExpanded);
-        stateLabel.classList.toggle("text-slate-600", !nextExpanded);
+      toggle.setAttribute("aria-expanded", String(nextExpanded));
+      panel.classList.toggle("hidden", !nextExpanded);
+      if (icon) icon.classList.toggle("rotate-180", nextExpanded);
+      if (toggleLabel) {
+        const openLabel = toggleLabel.dataset.labelOpen || "Open filters";
+        const closeLabel = toggleLabel.dataset.labelClose || "Hide filters";
+        toggleLabel.textContent = nextExpanded ? closeLabel : openLabel;
       }
-      if (stateInput) stateInput.value = expanded ? "0" : "1";
+      if (stateInput) stateInput.value = nextExpanded ? "1" : "0";
     });
+
+    const syncMobileIndexCta = () => {
+      const cta = document.querySelector("[data-index-mobile-cta]");
+      const searchRoot = document.querySelector("[data-index-search-root]");
+      const form = document.querySelector("[data-search-form]");
+      if (!cta || !searchRoot || !form) return;
+
+      const keyword = (form.querySelector("[data-search-keyword-input]")?.value || "").trim();
+      const category = (form.querySelector("[name='category']")?.value || "").trim();
+      const theme = (form.querySelector("[name='theme']")?.value || "").trim();
+      const tag = (form.querySelector("[name='tag']")?.value || "").trim();
+      const hasSearchState = [keyword, category, theme, tag].some((value) => value.length > 0);
+
+      const rect = searchRoot.getBoundingClientRect();
+      const searchVisible = rect.top < window.innerHeight && rect.bottom > 64;
+      const shouldHide = searchVisible || hasSearchState;
+
+      cta.classList.toggle("translate-y-full", shouldHide);
+      cta.classList.toggle("opacity-0", shouldHide);
+      cta.classList.toggle("pointer-events-none", shouldHide);
+    };
+
+    document.addEventListener("scroll", syncMobileIndexCta, { passive: true });
+    window.addEventListener("resize", syncMobileIndexCta);
+    document.addEventListener("input", (event) => {
+      if (!event.target.closest("[data-search-form]")) return;
+      syncMobileIndexCta();
+    });
+    document.addEventListener("change", (event) => {
+      if (!event.target.closest("[data-search-form]")) return;
+      syncMobileIndexCta();
+    });
+    document.addEventListener("turbo:load", syncMobileIndexCta);
+    document.addEventListener("DOMContentLoaded", syncMobileIndexCta);
 
     document.addEventListener("submit", (event) => {
       const form = event.target.closest("[data-search-form]");
@@ -254,5 +276,7 @@
         filter_has_value: String((target.value || "").trim().length > 0)
       });
     });
+
+    window.setTimeout(syncMobileIndexCta, 0);
   }
 </script>

--- a/app/views/shared/_ad_slot.html.erb
+++ b/app/views/shared/_ad_slot.html.erb
@@ -1,13 +1,18 @@
 <% if adsense_enabled? && slot.present? %>
-  <div class="my-8 flex justify-center">
-    <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="<%= ENV["ADSENSE_CLIENT_ID"] %>"
-         data-ad-slot="<%= slot %>"
-         data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
-    <script>
-      (adsbygoogle = window.adsbygoogle || []).push({});
-    </script>
+  <div class="my-10">
+    <div class="ad-slot-surface">
+      <p class="ad-slot-label">Sponsored</p>
+      <div class="flex justify-center">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="<%= ENV["ADSENSE_CLIENT_ID"] %>"
+             data-ad-slot="<%= slot %>"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+      </div>
+      <script>
+        (adsbygoogle = window.adsbygoogle || []).push({});
+      </script>
+    </div>
   </div>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_with model: user, class: "space-y-form" do |f| %>
+<% field_error = ->(attr) { user.errors.full_messages_for(attr).first } %>
+<% input_class = ->(error) { "w-full rounded-lg border px-3 py-2 text-sm #{error.present? ? 'border-red-400 bg-red-50' : 'border-slate-300'}" } %>
+<% name_error = field_error.call(:name) %>
+<% bio_error = field_error.call(:bio) %>
+<% email_error = field_error.call(:email) %>
+
+<%= form_with model: user, class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
   <% if user.errors.any? %>
     <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
       <p class="mb-2 font-semibold"><%= t("users.form.error_summary") %></p>
@@ -12,18 +18,27 @@
 
   <div>
     <%= f.label :name, t("users.form.name_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-    <%= f.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("users.form.name_placeholder") %>
+    <%= f.text_field :name, class: input_class.call(name_error), placeholder: t("users.form.name_placeholder"), aria: { invalid: name_error.present? ? "true" : nil, describedby: "user_name_error" } %>
+    <% if name_error.present? %>
+      <p id="user_name_error" class="mt-1 text-xs font-medium text-red-700"><%= name_error %></p>
+    <% end %>
   </div>
 
   <div>
     <%= f.label :bio, t("users.form.bio_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-    <%= f.text_area :bio, rows: 5, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("users.form.bio_placeholder") %>
+    <%= f.text_area :bio, rows: 5, class: input_class.call(bio_error), placeholder: t("users.form.bio_placeholder"), aria: { invalid: bio_error.present? ? "true" : nil, describedby: "user_bio_error" } %>
+    <% if bio_error.present? %>
+      <p id="user_bio_error" class="mt-1 text-xs font-medium text-red-700"><%= bio_error %></p>
+    <% end %>
   </div>
 
   <div>
     <%= f.label :email, t("users.form.email_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-    <%= f.email_field :email, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: "you@example.com" %>
-    <p class="mt-1 ds-text-muted"><%= t("users.form.email_hint") %></p>
+    <%= f.email_field :email, class: input_class.call(email_error), placeholder: "you@example.com", aria: { invalid: email_error.present? ? "true" : nil, describedby: "user_email_hint user_email_error" } %>
+    <p id="user_email_hint" class="mt-1 ds-text-muted"><%= t("users.form.email_hint") %></p>
+    <% if email_error.present? %>
+      <p id="user_email_error" class="mt-1 text-xs font-medium text-red-700"><%= email_error %></p>
+    <% end %>
   </div>
 
   <div class="flex items-center gap-2">
@@ -33,3 +48,23 @@
 
   <%= f.submit submit_label, class: "tap-target cta-primary" %>
 <% end %>
+
+<script>
+  if (!window.__userFormErrorAutofocusInstalled) {
+    window.__userFormErrorAutofocusInstalled = true;
+
+    const focusFirstErrorField = () => {
+      const form = document.querySelector("[data-form-autofocus-errors]");
+      if (!form) return;
+      const firstInvalid = form.querySelector("[aria-invalid='true']");
+      if (!firstInvalid) return;
+      firstInvalid.focus();
+      if (typeof firstInvalid.scrollIntoView === "function") {
+        firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    };
+
+    document.addEventListener("turbo:load", focusFirstErrorField);
+    document.addEventListener("DOMContentLoaded", focusFirstErrorField);
+  }
+</script>

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -27,33 +27,66 @@
   - Utility actions (toggle, lightweight links, low emphasis controls).
 - `cta-compact`:
   - Small variants for dense UI areas (chips, inline controls).
+- Header rule:
+  - Keep exactly one primary CTA in the desktop header action row.
+  - Utility controls (language, preference toggles) must live in a separate utility group.
 
 ## Fixed Mobile Bar Rules
 - Use `mobile-sticky-bar` for all fixed bottom action bars.
 - When fixed bars overlap critical inputs (comment forms), hide the bar while input fields are focused.
 - Keep a minimum `44px` tap target (`tap-target`) on all touch controls.
+- If in-page CTA already owns the current task (for example, search submit), suppress competing fixed-bar CTA while that task UI is visible or active.
 
 ## Card Layout Rules
 - Information order:
-  - `Title -> Summary -> Tags -> Meta`
+  - `Title -> Summary -> Primary meta -> Secondary meta`
 - Card height rhythm:
   - Keep consistent thumbnail height (`h-40`/`h-44`) to avoid scroll jitter.
 - Tags:
   - Show max 2 tags and aggregate overflow as `+n`.
   - Use low-emphasis chip tone for tags to reduce visual noise.
 
+## Badge State Rules
+- `active`:
+  - Use `ds-badge-active` for currently applied filters or selected states.
+  - Include an additional signal beyond color (icon/checkmark/weight).
+- `inactive`:
+  - Use `ds-badge-inactive` for selectable but not selected options.
+- `informational`:
+  - Use `ds-badge-info` for passive metadata chips.
+
 ## States
 - Empty states must include:
   - Context sentence
-  - Next action CTA
+  - One primary next action CTA
 - Search zero-results must include:
-  - "Clear all" action
-  - At least one condition-relax action
+  - One emphasized first action
+  - Additional recovery actions as lower-emphasis links
 
 ## Accessibility Rules
 - All interactive controls must expose visible focus style (`:focus-visible`).
 - Announce asynchronous status changes (copy success/failure, menu open/close) through the live region.
 - Menus and toggles must keep `aria-expanded` synchronized with UI state.
+
+## Typography And Rhythm
+- Japanese UI optimization:
+  - Prefer narrower reading columns and slightly larger paragraph rhythm in `lang-ja`.
+  - Avoid over-compressing labels; prioritize scan speed over density.
+- Spacing hierarchy:
+  - `section > block > component` must use fixed rhythm scales (`space-y-section`, `space-y-block`, `space-y-component`).
+
+## Ads Placement
+- Wrap ad slots in a low-noise container (`ad-slot-surface`) with clear spacing from content groups.
+- Add a compact disclosure label (`ad-slot-label`) to separate ads from primary content.
+
+## Design Audit Workflow
+- Pull requests that modify UI must complete a design-system checklist in the PR template.
+- Reviewer must validate:
+  - CTA count and hierarchy per screen
+  - badge state semantics
+  - empty/zero/error states
+  - focus visibility and dynamic announcements
+  - mobile fixed-bar conflicts with core interactions
 
 ## New Screen Checklist
 - [ ] One primary CTA per section
@@ -63,3 +96,5 @@
 - [ ] Keyboard focus is visually clear on all controls
 - [ ] Screen reader status feedback exists for dynamic actions
 - [ ] Mobile fixed bars do not cover key inputs
+- [ ] Badge states use active/inactive/informational roles consistently
+- [ ] Section/block/component spacing rhythm is preserved


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/61

## 目的

  - posts/index と共通レイアウトを中心に、情報密度とCTA競合を整理し、判断コストを下げる。
  - docs/design_system.md の方針を実装クラス運用に接続し、今後の逸脱を減らす。

  ## 実装内容

  - ヘッダーの主従整理
      - 主CTAを1つ（投稿作成）に集約。プロフィールは低強度化、言語切替はユーティリティ化。
  - モバイル固定CTA競合解消
      - 一覧で検索UI可視時/検索状態時は固定CTAを自動抑制。
  - 検索UIの2段階分離
      - 即時検索（キーワード）と絞り込み（展開式）を分離。
  - カード情報階層の再配置
      - Title > Summary > Primary meta > Secondary meta に再編成。
  - タグ/フィルタ状態の規格化
      - active / inactive / informational の3状態クラス追加・適用。
  - 0件時アクション再設計
      - 第一候補をPrimary 1つにし、他を低強度リンク化。
  - 日本語可読性と余白リズム改善
      - lang-ja向け行長/行間/段落余白調整、section > block > component 余白ユーティリティ追加。
  - フォームエラー導線強化（usersフォーム）
      - フィールド直下エラー、aria-invalid、最初のエラー自動フォーカス追加。
  - 広告スロットの低ノイズ化
      - 境界ラベル・背景差・余白ルールを追加。
  - 監査フロー整備
      - デザイン監査ルールを文書化し、PRテンプレートに接続。

  ## 方法

  - ERBテンプレートで情報構造とCTA階層を再配置。
  - Tailwindユーティリティ/トークンを追加して状態表現と余白を統一。
  - 最小限のJSで検索トグルとモバイル固定CTA表示条件を制御。
  - ドキュメントとPRテンプレートを追加して運用フローを固定化。

  ## 変更箇所

  - application.css
  - application.html.erb
  - index.html.erb
  - _ad_slot.html.erb
  - _form.html.erb
  - design_system.md
  - pull_request_template.md

  ## まとめ

  - 一覧・ヘッダー・モバイル固定バーの主従関係を再定義し、1画面内の行動選択を単純化しました。
  - デザインシステムの定義を実装とPR運用に接続し、今後の一貫性を保ちやすい状態にしました。

  ## Testing

  - ruby -rerb -e "ERB.new(File.read(%q{app/views/layouts/application.html.erb})).src": OK
  - ruby -rerb -e "ERB.new(File.read(%q{app/views/posts/index.html.erb})).src": OK
  - ruby -rerb -e "ERB.new(File.read(%q{app/views/shared/_ad_slot.html.erb})).src": OK
  - ruby -rerb -e "ERB.new(File.read(%q{app/views/users/_form.html.erb})).src": OK
  - git diff --check: 問題なし（CRLF警告のみ）
  - Railsのテストスイート全体は未実行。