### PR TITLE
Improving UI/UX consistency and comprehensively strengthening the design system foundation

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -19,6 +19,12 @@
     --ds-text-support: rgb(51 65 85);
     --ds-text-meta: rgb(71 85 105);
     --ds-text-muted: rgb(71 85 105);
+    --ds-safe-area-bottom: env(safe-area-inset-bottom, 0px);
+    --ds-safe-area-top: env(safe-area-inset-top, 0px);
+    --ds-motion-duration-fast: 160ms;
+    --ds-motion-duration-normal: 220ms;
+    --ds-skeleton-base: rgb(226 232 240);
+    --ds-skeleton-shimmer: rgb(241 245 249);
   }
 
   html[lang="ja"] {
@@ -56,12 +62,20 @@
     color: var(--ds-text-main);
   }
 
+  html {
+    scroll-behavior: smooth;
+  }
+
   a,
   button,
   input,
   select,
   textarea {
-    transition: box-shadow 0.16s ease, border-color 0.16s ease;
+    transition: box-shadow var(--ds-motion-duration-fast) ease,
+                border-color var(--ds-motion-duration-fast) ease,
+                background-color var(--ds-motion-duration-fast) ease,
+                color var(--ds-motion-duration-fast) ease,
+                transform var(--ds-motion-duration-fast) ease;
   }
 
   a:focus-visible,
@@ -85,6 +99,20 @@
   h3 {
     letter-spacing: var(--ds-letter-spacing-heading);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    html {
+      scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+      animation-duration: 1ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 1ms !important;
+    }
+  }
 }
 
 @layer utilities {
@@ -98,6 +126,10 @@
 
   .ds-heading-md {
     @apply text-lg font-semibold;
+  }
+
+  .ds-heading-sm {
+    @apply text-base font-semibold;
   }
 
   .ds-text-body {
@@ -160,6 +192,19 @@
     line-clamp: 2;
   }
 
+  .ds-line-clamp-3 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+  }
+
+  .ds-break-words {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
   .tap-target {
     min-height: 44px;
     min-width: 44px;
@@ -187,6 +232,54 @@
 
   .ds-shadow-soft {
     box-shadow: 0 6px 24px rgba(15, 23, 42, 0.06);
+  }
+
+  .ds-icon-button {
+    @apply inline-flex items-center justify-center rounded-lg;
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .ds-anchor-offset {
+    scroll-margin-top: 6rem;
+  }
+
+  .ds-media-frame {
+    @apply relative overflow-hidden rounded-xl border border-slate-200 bg-slate-100;
+  }
+
+  .ds-media-frame img {
+    @apply h-full w-full object-cover;
+  }
+
+  .ds-media-frame-card {
+    aspect-ratio: 16 / 9;
+  }
+
+  .ds-media-frame-main {
+    aspect-ratio: 16 / 10;
+  }
+
+  .ds-media-skeleton {
+    position: relative;
+    background: var(--ds-skeleton-base);
+  }
+
+  .ds-media-skeleton::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(110deg, transparent 20%, var(--ds-skeleton-shimmer) 45%, transparent 70%);
+    transform: translateX(-100%);
+    animation: ds-skeleton-shimmer 1.4s infinite linear;
+  }
+
+  .ds-media-loaded::after {
+    display: none;
+  }
+
+  .ds-section-card {
+    @apply rounded-xl border border-slate-200 bg-white p-5 sm:p-6;
   }
 
   .cta-primary {
@@ -226,6 +319,7 @@
   .mobile-sticky-bar {
     @apply fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur;
     box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
+    padding-bottom: max(var(--ds-safe-area-bottom), 0px);
   }
 
   .ad-slot-surface {
@@ -234,6 +328,10 @@
 
   .ad-slot-label {
     @apply mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-slate-500;
+  }
+
+  .ad-slot-divider {
+    @apply mb-2 text-center text-xs font-medium text-slate-500;
   }
 
   .lang-ja .ds-reading-column {
@@ -253,6 +351,7 @@
     @apply inline-flex items-center justify-center whitespace-nowrap px-2.5 py-1;
     min-width: 5.25rem;
     max-width: 7.5rem;
+    min-height: 44px;
   }
 
   .ds-toast-region {
@@ -289,6 +388,12 @@
     }
   }
 
+  @keyframes ds-skeleton-shimmer {
+    to {
+      transform: translateX(100%);
+    }
+  }
+
   @media (max-width: 640px) {
     .tap-target {
       padding-top: 0.625rem;
@@ -302,6 +407,13 @@
 
     .ad-slot-surface {
       @apply py-5;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ds-toast,
+    .ds-media-skeleton::after {
+      animation: none !important;
     }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,11 @@ module ApplicationHelper
       format: :jpg
     }
   }.freeze
+  POST_IMAGE_DIMENSIONS = {
+    thumbnail: [ 640, 360 ],
+    main: [ 1200, 750 ],
+    og: [ 1200, 630 ]
+  }.freeze
 
   FALLBACK_POST_IMAGE = "default-desk.svg"
   FLASH_VISUALS = {
@@ -399,15 +404,18 @@ module ApplicationHelper
   end
 
   def default_image_tag_options(post, variant)
+    width, height = POST_IMAGE_DIMENSIONS.fetch(variant, POST_IMAGE_DIMENSIONS[:main])
     base = {
       alt: post&.title.presence || t("images.desk_alt"),
-      decoding: "async"
+      decoding: "async",
+      width: width,
+      height: height
     }
 
     if variant == :thumbnail
-      base.merge(loading: "lazy")
+      base.merge(loading: "lazy", sizes: "(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw")
     else
-      base.merge(loading: "eager", fetchpriority: "high")
+      base.merge(loading: "eager", fetchpriority: "high", sizes: "100vw")
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,28 +63,42 @@
           <span class="sr-only">Menu</span>
         </button>
 
-        <div class="ml-auto hidden flex-col items-end gap-1 sm:flex">
-          <div class="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-slate-50 p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
-            <%= link_to locale_switch_path(:ja), class: "ds-locale-pill rounded-full #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
-              <span><%= t("language.option_ja") %></span>
-              <% if locale_selected?(:ja) %>
-                <%= ui_icon(:check, class_name: "h-3 w-3") %>
-              <% end %>
-            <% end %>
-            <%= link_to locale_switch_path(:en), class: "ds-locale-pill rounded-full #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-white'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
-              <span><%= t("language.option_en") %></span>
-              <% if locale_selected?(:en) %>
-                <%= ui_icon(:check, class_name: "h-3 w-3") %>
-              <% end %>
-            <% end %>
-          </div>
-          <div class="flex items-center gap-2 text-sm font-medium tracking-nav">
-            <% if owned_users.any? %>
-              <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
-            <% else %>
-              <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
-            <% end %>
-            <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+        <div class="ml-auto hidden items-center gap-2 sm:flex">
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "desktop_header_create_post" } %>
+          <div class="relative" data-desktop-utility-root>
+            <button type="button" data-desktop-utility-toggle aria-expanded="false" aria-controls="desktop-utility-menu" class="tap-target cta-tertiary" data-ga-event="navigation_desktop_utility_toggle_click" data-ga-category="navigation" data-ga-label="desktop_utility_toggle">
+              <span class="inline-flex items-center gap-1.5">
+                <span><%= I18n.locale.to_s == "ja" ? "その他" : "Utility" %></span>
+                <%= ui_icon(:chevron_down, class_name: "h-4 w-4 text-slate-600") %>
+              </span>
+            </button>
+
+            <div id="desktop-utility-menu" data-desktop-utility-menu class="absolute right-0 top-full z-30 mt-2 hidden w-64 rounded-xl border border-slate-300 bg-white p-3 shadow-2xl ring-1 ring-slate-900/5">
+              <div class="space-y-2">
+                <% if owned_users.any? %>
+                  <%= link_to t("navigation.my_profile"), user_path(owned_users.first), class: "tap-target cta-tertiary w-full justify-start", data: { ga_event: "navigation_profile_click", ga_category: "navigation", ga_label: "desktop_header_my_profile" } %>
+                <% else %>
+                  <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary w-full justify-start", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
+                <% end %>
+                <div class="rounded-lg border border-slate-200 bg-slate-50 p-2">
+                  <p class="mb-1 ds-text-meta font-semibold"><%= t("language.switch_aria") %></p>
+                  <div class="inline-flex w-full items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
+                    <%= link_to locale_switch_path(:ja), class: "ds-locale-pill rounded-full #{locale_selected?(:ja) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
+                      <span><%= t("language.option_ja") %></span>
+                      <% if locale_selected?(:ja) %>
+                        <%= ui_icon(:check, class_name: "h-3 w-3") %>
+                      <% end %>
+                    <% end %>
+                    <%= link_to locale_switch_path(:en), class: "ds-locale-pill rounded-full #{locale_selected?(:en) ? 'bg-slate-900 text-white shadow-sm ring-1 ring-slate-900' : 'text-slate-700 hover:bg-slate-100'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
+                      <span><%= t("language.option_en") %></span>
+                      <% if locale_selected?(:en) %>
+                        <%= ui_icon(:check, class_name: "h-3 w-3") %>
+                      <% end %>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -146,8 +160,8 @@
 
     <% if controller_name == "posts" && action_name == "index" %>
       <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-index-mobile-cta>
-        <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
+        <div class="mx-auto w-full max-w-6xl px-4 pt-3">
+          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-primary flex w-full justify-center rounded-xl px-4", data: { ga_event: "navigation_post_create_click", ga_category: "navigation", ga_label: "mobile_create_post_bottom_bar" } %>
         </div>
       </div>
     <% end %>
@@ -209,6 +223,21 @@
           }
         };
 
+        const closeDesktopUtilityMenu = (reason = "dismissed") => {
+          const menu = document.querySelector("[data-desktop-utility-menu]");
+          const toggle = document.querySelector("[data-desktop-utility-toggle]");
+          if (!menu || menu.classList.contains("hidden")) return;
+
+          menu.classList.add("hidden");
+          if (toggle) toggle.setAttribute("aria-expanded", "false");
+          if (typeof window.gtag === "function") {
+            window.gtag("event", "navigation_desktop_utility_close", {
+              event_category: "navigation",
+              event_label: `desktop_utility_${reason}`
+            });
+          }
+        };
+
         document.addEventListener("click", (event) => {
           const toggle = event.target.closest("[data-mobile-header-toggle]");
           if (toggle) {
@@ -226,6 +255,20 @@
             return;
           }
 
+          const desktopToggle = event.target.closest("[data-desktop-utility-toggle]");
+          if (desktopToggle) {
+            const menu = document.querySelector("[data-desktop-utility-menu]");
+            if (!menu) return;
+            const expanded = desktopToggle.getAttribute("aria-expanded") == "true";
+            if (expanded) {
+              closeDesktopUtilityMenu("toggle");
+            } else {
+              desktopToggle.setAttribute("aria-expanded", "true");
+              menu.classList.remove("hidden");
+            }
+            return;
+          }
+
           const action = event.target.closest("[data-mobile-header-action]");
           if (action) {
             closeMobileHeaderMenu("menu_action");
@@ -234,13 +277,21 @@
 
           const root = document.querySelector("[data-mobile-header-root]");
           const menu = document.querySelector("[data-mobile-header-menu]");
-          if (!root || !menu || menu.classList.contains("hidden")) return;
-          if (!root.contains(event.target)) closeMobileHeaderMenu("outside_tap");
+          if (root && menu && !menu.classList.contains("hidden") && !root.contains(event.target)) {
+            closeMobileHeaderMenu("outside_tap");
+          }
+
+          const desktopRoot = document.querySelector("[data-desktop-utility-root]");
+          const desktopMenu = document.querySelector("[data-desktop-utility-menu]");
+          if (desktopRoot && desktopMenu && !desktopMenu.classList.contains("hidden") && !desktopRoot.contains(event.target)) {
+            closeDesktopUtilityMenu("outside_tap");
+          }
         });
 
         document.addEventListener("keydown", (event) => {
           if (event.key !== "Escape") return;
           closeMobileHeaderMenu("escape");
+          closeDesktopUtilityMenu("escape");
         });
       }
     </script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,18 +4,9 @@
 <% tag_suggestions ||= [] %>
 <% locale_ja = I18n.locale.to_s == "ja" %>
 <% required_section_label = locale_ja ? "必須の基本情報" : "Required basics" %>
-<% required_section_lead = locale_ja ? "まずは投稿内容の核となる情報を入力します。" : "Start with the core information for your post." %>
+<% required_section_lead = locale_ja ? "まずは投稿の中心となる情報を入力します。" : "Start with the core information for your post." %>
 <% optional_section_label = locale_ja ? "任意の詳細情報" : "Optional details" %>
-<% optional_section_lead = locale_ja ? "カテゴリ・テーマ・タグで見つけやすくできます。" : "Add category, theme, and tags to improve discoverability." %>
-<% profile_example = locale_ja ? "例: メインの投稿プロフィールを選択" : "Example: select your default posting profile" %>
-<% title_example = locale_ja ? "例: 木目とブラックで統一した開発デスク" : "Example: Black and walnut developer desk setup" %>
-<% description_example = locale_ja ? "例: デバイス構成、レイアウトの工夫、1日の使い方を3〜5文で。" : "Example: describe your devices, layout choices, and daily workflow in 3-5 sentences." %>
-<% image_example = locale_ja ? "推奨: 横長で明るい写真（1200px以上）" : "Recommended: bright landscape photo (1200px or wider)" %>
-<% category_example = locale_ja ? "例: Engineering, Design, Writing" : "Example: Engineering, Design, Writing" %>
-<% theme_example = locale_ja ? "例: Dark, Minimal, Natural" : "Example: Dark, Minimal, Natural" %>
-<% tags_example = locale_ja ? "例: mechanical keyboard, standing desk（カンマ区切り）" : "Example: mechanical keyboard, standing desk (comma-separated)" %>
-<% item_name_example = locale_ja ? "例: HHKB Professional HYBRID Type-S" : "Example: HHKB Professional HYBRID Type-S" %>
-<% item_url_example = locale_ja ? "例: https://www.amazon.co.jp/... または公式ストアURL" : "Example: https://www.amazon.com/... or the official store URL" %>
+<% optional_section_lead = locale_ja ? "カテゴリ・テーマ・タグを追加すると見つけやすくなります。" : "Add category, theme, and tags to improve discoverability." %>
 <% field_error = ->(attr) { post.errors.full_messages_for(attr).first } %>
 <% input_class = ->(error) { "w-full rounded-lg border px-3 py-2 text-sm #{error.present? ? 'border-red-400 bg-red-50' : 'border-slate-300'}" } %>
 <% title_error = field_error.call(:title) %>
@@ -30,11 +21,29 @@
 
 <%= form_with model: post, class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
   <% if post.errors.any? %>
-    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
+    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700" role="alert" aria-live="assertive">
       <p class="mb-2 font-semibold"><%= t("posts.form.error_summary") %></p>
       <ul class="list-disc pl-5">
-        <% post.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
+        <% if profile_error.present? %>
+          <li><a href="#post_user_id" class="underline"><%= profile_error %></a></li>
+        <% end %>
+        <% if title_error.present? %>
+          <li><a href="#post_title" class="underline"><%= title_error %></a></li>
+        <% end %>
+        <% if description_error.present? %>
+          <li><a href="#post_description" class="underline"><%= description_error %></a></li>
+        <% end %>
+        <% if image_error.present? %>
+          <li><a href="#post_desk_image" class="underline"><%= image_error %></a></li>
+        <% end %>
+        <% if category_error.present? %>
+          <li><a href="#post_category" class="underline"><%= category_error %></a></li>
+        <% end %>
+        <% if theme_error.present? %>
+          <li><a href="#post_theme" class="underline"><%= theme_error %></a></li>
+        <% end %>
+        <% if tag_list_error.present? %>
+          <li><a href="#post_tag_list" class="underline"><%= tag_list_error %></a></li>
         <% end %>
       </ul>
     </div>
@@ -51,7 +60,7 @@
         <div class="sm:col-span-2">
           <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
           <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: input_class.call(profile_error), aria: { invalid: profile_error.present? ? "true" : nil, describedby: "post_user_id_help post_user_id_error" } %>
-          <p id="post_user_id_help" class="mt-1 ds-text-muted"><%= profile_example %></p>
+          <p id="post_user_id_help" class="mt-1 ds-text-muted"><%= locale_ja ? "既定で使う投稿プロフィールを選択します。" : "Choose the profile used for this post." %></p>
           <% if profile_error.present? %>
             <p id="post_user_id_error" class="mt-1 text-xs font-medium text-red-700"><%= profile_error %></p>
           <% end %>
@@ -61,7 +70,7 @@
       <div class="sm:col-span-2">
         <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :title, class: input_class.call(title_error), placeholder: t("posts.form.title_placeholder"), aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_error" } %>
-        <p id="post_title_help" class="mt-1 ds-text-muted"><%= title_example %></p>
+        <p id="post_title_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: ブラックと木目で統一した作業デスク" : "Example: Black and walnut developer desk setup" %></p>
         <% if title_error.present? %>
           <p id="post_title_error" class="mt-1 text-xs font-medium text-red-700"><%= title_error %></p>
         <% end %>
@@ -70,7 +79,7 @@
       <div class="sm:col-span-2">
         <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_area :description, rows: 7, class: input_class.call(description_error), placeholder: t("posts.form.description_placeholder"), aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_error" } %>
-        <p id="post_description_help" class="mt-1 ds-text-muted"><%= description_example %></p>
+        <p id="post_description_help" class="mt-1 ds-text-muted"><%= locale_ja ? "配置、利用デバイス、用途を3-5文で書くと伝わりやすくなります。" : "Describe layout, devices, and workflow in 3-5 sentences." %></p>
         <% if description_error.present? %>
           <p id="post_description_error" class="mt-1 text-xs font-medium text-red-700"><%= description_error %></p>
         <% end %>
@@ -79,7 +88,7 @@
       <div class="sm:col-span-2">
         <%= f.label :desk_image, t("posts.form.image_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.file_field :desk_image, class: input_class.call(image_error), accept: "image/*", aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error" } %>
-        <p id="post_image_help" class="mt-1 ds-text-muted"><%= image_example %></p>
+        <p id="post_image_help" class="mt-1 ds-text-muted"><%= locale_ja ? "明るめの横長画像（1200px以上推奨）" : "Use a bright landscape image (1200px+ recommended)." %></p>
         <% if image_error.present? %>
           <p id="post_image_error" class="mt-1 text-xs font-medium text-red-700"><%= image_error %></p>
         <% end %>
@@ -99,7 +108,7 @@
       <div>
         <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :category, class: input_class.call(category_error), placeholder: t("posts.form.category_placeholder"), list: "post-category-options", aria: { invalid: category_error.present? ? "true" : nil, describedby: "post_category_help post_category_error" } %>
-        <p id="post_category_help" class="mt-1 ds-text-muted"><%= category_example %></p>
+        <p id="post_category_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: Engineering, Design, Writing" : "Example: Engineering, Design, Writing" %></p>
         <% if category_error.present? %>
           <p id="post_category_error" class="mt-1 text-xs font-medium text-red-700"><%= category_error %></p>
         <% end %>
@@ -108,7 +117,7 @@
       <div>
         <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :theme, class: input_class.call(theme_error), placeholder: t("posts.form.theme_placeholder"), aria: { invalid: theme_error.present? ? "true" : nil, describedby: "post_theme_help post_theme_error" } %>
-        <p id="post_theme_help" class="mt-1 ds-text-muted"><%= theme_example %></p>
+        <p id="post_theme_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: Dark, Minimal, Natural" : "Example: Dark, Minimal, Natural" %></p>
         <% if theme_error.present? %>
           <p id="post_theme_error" class="mt-1 text-xs font-medium text-red-700"><%= theme_error %></p>
         <% end %>
@@ -117,7 +126,7 @@
       <div class="sm:col-span-2">
         <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :tag_list, class: input_class.call(tag_list_error), placeholder: t("posts.form.tags_placeholder"), list: "post-tag-options", aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_error" } %>
-        <p id="post_tag_list_help" class="mt-1 ds-text-muted"><%= tags_example %></p>
+        <p id="post_tag_list_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: mechanical keyboard, standing desk（カンマ区切り）" : "Example: mechanical keyboard, standing desk (comma-separated)" %></p>
         <% if tag_list_error.present? %>
           <p id="post_tag_list_error" class="mt-1 text-xs font-medium text-red-700"><%= tag_list_error %></p>
         <% end %>
@@ -133,12 +142,12 @@
           <div>
             <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
             <%= item_fields.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.item_name_placeholder") %>
-            <p class="mt-1 ds-text-muted"><%= item_name_example %></p>
+            <p class="mt-1 ds-text-muted"><%= locale_ja ? "例: HHKB Professional HYBRID Type-S" : "Example: HHKB Professional HYBRID Type-S" %></p>
           </div>
           <div>
             <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
             <%= item_fields.url_field :affiliate_url, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.affiliate_url_placeholder") %>
-            <p class="mt-1 ds-text-muted"><%= item_url_example %></p>
+            <p class="mt-1 ds-text-muted"><%= locale_ja ? "例: https://www.amazon.co.jp/... または公式ストアURL" : "Example: https://www.amazon.com/... or official store URL" %></p>
           </div>
         </div>
       <% end %>
@@ -152,6 +161,7 @@
       <% end %>
     </datalist>
   <% end %>
+
   <% if tag_suggestions.any? %>
     <datalist id="post-tag-options">
       <% tag_suggestions.each do |tag| %>
@@ -161,7 +171,7 @@
   <% end %>
 
   <div class="flex flex-wrap gap-3">
-    <%= f.submit t("posts.form.publish"), class: "tap-target cta-primary" %>
+    <%= f.submit submit_label, class: "tap-target cta-primary" %>
     <%= f.submit t("posts.form.save_draft"), name: "save_as_draft", value: "1", class: "tap-target cta-secondary" %>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -35,21 +35,28 @@
   tag: params[:tag].presence,
   details: params[:details].presence
 }.compact %>
+<% empty_primary_cta = I18n.locale.to_s == "ja" ? "\u6700\u521D\u306E\u6295\u7A3F\u3092\u4F5C\u6210" : "Create your first post" %>
 
 <section class="space-y-section">
-  <div class="rounded-2xl bg-gradient-to-br from-slate-900 via-blue-800 to-cyan-700 px-6 py-6 text-white sm:py-8">
-    <h1 class="ds-heading-xl"><%= t("posts.index.hero_title") %></h1>
-    <p class="ds-text-support ds-reading-column mt-2 max-w-2xl text-blue-100">
-      <%= t("posts.index.hero_description") %>
-    </p>
-    <a href="#index-search" class="mt-4 inline-flex tap-target cta-secondary cta-compact"><%= t("posts.index.search_button") %></a>
+  <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-blue-900 to-cyan-800 px-5 py-6 text-white sm:px-6 sm:py-8">
+    <div class="absolute inset-0 bg-slate-950/20" aria-hidden="true"></div>
+    <div class="relative max-w-3xl rounded-xl bg-slate-950/35 p-4 sm:p-5">
+      <h1 class="ds-heading-xl"><%= t("posts.index.hero_title") %></h1>
+      <p class="ds-text-support ds-reading-column mt-2 max-w-2xl text-blue-100 ds-break-words">
+        <%= t("posts.index.hero_description") %>
+      </p>
+      <div class="mt-4 flex flex-wrap items-center gap-2">
+        <a href="#index-search" class="tap-target cta-primary"><%= t("posts.index.search_button") %></a>
+        <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-tertiary cta-compact text-white hover:bg-white/20 hover:text-white" %>
+      </div>
+    </div>
   </div>
 
-  <div id="index-search" class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 sm:p-5" data-index-search-root>
+  <div id="index-search" class="ds-card p-4 sm:p-5" data-index-search-root>
     <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
 
-      <div class="rounded-xl border border-slate-200 bg-white p-4">
+      <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
         <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= quick_search_label %></p>
         <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
@@ -86,7 +93,7 @@
           <% else %>
             <span class="ds-badge-info"><%= no_filters_label %></span>
           <% end %>
-          <%= link_to t("posts.index.reset_button"), root_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
+          <%= link_to t("posts.index.reset_button"), posts_path, class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_search_reset" } %>
         </div>
 
         <div data-details-panel class="mt-3 space-y-component <%= detailed_filters_open ? '' : 'hidden' %>">
@@ -101,54 +108,49 @@
     <% end %>
   </div>
 
-      <% if @posts.any? %>
+  <% if @posts.any? %>
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
         <% visible_tags = post.tags.first(max_card_tags) %>
         <% hidden_tag_count = [post.tags.size - visible_tags.size, 0].max %>
-        <article class="flex h-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-          <%= link_to post_path(post), class: "block", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
-            <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-40 w-full object-cover sm:h-44") %>
+        <article class="ds-card ds-shadow-soft flex h-full flex-col overflow-hidden">
+          <%= link_to post_path(post), class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
+            <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton>
+              <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-full w-full object-cover") %>
+            </div>
           <% end %>
 
           <div class="flex h-full flex-col p-4">
-            <h2 class="text-base font-semibold text-slate-900">
-              <%= link_to post.title, post_path(post), class: "ds-line-clamp-2 block leading-5 hover:text-blue-600", data: { ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
+            <h2 class="ds-heading-sm ds-line-clamp-2 ds-break-words text-slate-900">
+              <%= link_to post.title, post_path(post), class: "block leading-6 hover:text-blue-600", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
             </h2>
 
-            <p class="mt-2 ds-line-clamp-2 text-sm leading-6 text-slate-600"><%= truncate(post.description, length: 90) %></p>
+            <p class="mt-2 ds-line-clamp-2 ds-text-support ds-break-words"><%= truncate(post.description, length: 100) %></p>
 
-            <div class="mt-3 flex flex-wrap items-center gap-1.5" aria-label="Post tags">
-              <% if post.tags.any? %>
-                <% visible_tags.each do |tag| %>
-                  <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
-                <% end %>
-                <% if hidden_tag_count.positive? %>
-                  <span class="ds-badge-info">+<%= hidden_tag_count %></span>
-                <% end %>
-              <% else %>
-                <span class="ds-text-muted"><%= "#{t('posts.index.tag_placeholder')}: #{no_filters_label}" %></span>
+            <div class="mt-3 flex flex-wrap items-center gap-1.5" aria-label="Post classification">
+              <% if post.category.present? %>
+                <span class="ds-badge-inactive"><%= post.category %></span>
+              <% end %>
+              <% visible_tags.each do |tag| %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+              <% end %>
+              <% if hidden_tag_count.positive? %>
+                <span class="ds-badge-info">+<%= hidden_tag_count %></span>
               <% end %>
             </div>
 
-            <div class="mt-auto rounded-lg bg-slate-50/80 px-2.5 py-2 ds-text-meta text-slate-500" aria-label="Post metadata">
-              <div class="flex flex-wrap items-center justify-between gap-2">
-                <div class="flex flex-wrap items-center gap-2">
-                  <span>
-                    <%= t("posts.index.author_label") %>:
-                    <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-                  </span>
-                  <% if post.category.present? %>
-                    <span class="ds-badge-inactive"><%= post.category %></span>
-                  <% end %>
-                </div>
-                <div class="flex items-center gap-2">
+            <div class="mt-auto border-t border-slate-100 pt-3" aria-label="Post metadata">
+              <div class="flex flex-wrap items-center justify-between gap-2 ds-text-meta text-slate-600">
+                <span class="inline-flex items-center gap-1.5">
+                  <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
+                  <span><%= localized_number(post.likes_count) %></span>
+                  <span aria-hidden="true">•</span>
                   <span><%= l(post.created_at.to_date) %></span>
-                  <span class="inline-flex items-center gap-1">
-                    <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
-                    <span><%= localized_number(post.likes_count) %></span>
-                  </span>
-                </div>
+                </span>
+                <span>
+                  <%= t("posts.index.author_label") %>:
+                  <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+                </span>
               </div>
             </div>
           </div>
@@ -162,9 +164,9 @@
         <p class="mt-2 text-sm font-semibold text-slate-700"><%= no_results_title %></p>
         <p class="mt-1 ds-text-support"><%= no_results_hint %></p>
         <div class="mt-4">
-          <%= link_to clear_all_label, root_path, class: "tap-target cta-primary", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
+          <%= link_to clear_all_label, posts_path, class: "tap-target cta-primary", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
         </div>
-        <div class="mt-3 flex flex-wrap items-center justify-center gap-1">
+        <div class="mt-3 flex flex-wrap items-center justify-center gap-2">
           <% if params[:q].present? %>
             <%= link_to remove_keyword_label, posts_path(persisted_query.except(:q)), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_keyword" } %>
           <% end %>
@@ -173,8 +175,9 @@
           <% end %>
         </div>
       <% else %>
-        <div class="mt-4">
-          <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-secondary" %>
+        <div class="mt-4 space-y-2">
+          <%= link_to empty_primary_cta, new_post_path, class: "tap-target cta-primary" %>
+          <p class="ds-text-muted"><%= I18n.locale.to_s == "ja" ? "まず1件作成してタイムラインを始めましょう。" : "Start your timeline with a single post." %></p>
         </div>
       <% end %>
     </div>
@@ -186,6 +189,26 @@
 <script>
   if (!window.__postIndexSearchBindingInstalled) {
     window.__postIndexSearchBindingInstalled = true;
+    const LIST_SCROLL_KEY = "post_index_scroll_y";
+    const LIST_RESTORE_KEY = "post_index_restore";
+
+    const markLoadedMedia = (scope = document) => {
+      scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
+        const image = frame.querySelector("img");
+        if (!image) {
+          frame.classList.add("ds-media-loaded");
+          return;
+        }
+
+        if (image.complete) {
+          frame.classList.add("ds-media-loaded");
+          return;
+        }
+
+        image.addEventListener("load", () => frame.classList.add("ds-media-loaded"), { once: true });
+        image.addEventListener("error", () => frame.classList.add("ds-media-loaded"), { once: true });
+      });
+    };
 
     document.addEventListener("click", (event) => {
       const toggle = event.target.closest("[data-details-toggle]");
@@ -211,10 +234,18 @@
       if (stateInput) stateInput.value = nextExpanded ? "1" : "0";
     });
 
+    document.addEventListener("click", (event) => {
+      const link = event.target.closest("[data-post-card-link]");
+      if (!link) return;
+
+      sessionStorage.setItem(LIST_SCROLL_KEY, String(window.scrollY || window.pageYOffset || 0));
+      sessionStorage.setItem(LIST_RESTORE_KEY, "1");
+    });
+
     let lastScrollY = window.scrollY || window.pageYOffset || 0;
     const keyboardOpen = () => {
       if (!window.visualViewport) return false;
-      return (window.innerHeight - window.visualViewport.height) > 140;
+      return (window.innerHeight - window.visualViewport.height) > 130;
     };
 
     const syncMobileIndexCta = () => {
@@ -228,19 +259,29 @@
       const theme = (form.querySelector("[name='theme']")?.value || "").trim();
       const tag = (form.querySelector("[name='tag']")?.value || "").trim();
       const hasSearchState = [keyword, category, theme, tag].some((value) => value.length > 0);
-      const activeElement = document.activeElement;
-      const focusedInSearch = activeElement && searchRoot.contains(activeElement);
-      const currentY = window.scrollY || window.pageYOffset || 0;
-      const scrollingDown = currentY > (lastScrollY + 6);
+      const focusedInSearch = searchRoot.contains(document.activeElement);
+      const detailsOpen = form.querySelector("[data-details-state-input]")?.value === "1";
 
       const rect = searchRoot.getBoundingClientRect();
-      const searchVisible = rect.top < window.innerHeight && rect.bottom > 64;
-      const shouldHide = searchVisible || hasSearchState || focusedInSearch || keyboardOpen() || scrollingDown;
+      const searchVisible = rect.top < window.innerHeight && rect.bottom > 72;
+
+      const currentY = window.scrollY || window.pageYOffset || 0;
+      const scrollingDown = currentY > (lastScrollY + 6);
+      const shouldHide = keyboardOpen() || focusedInSearch || hasSearchState || searchVisible || (detailsOpen && searchVisible) || (scrollingDown && currentY > 72);
 
       cta.classList.toggle("translate-y-full", shouldHide);
       cta.classList.toggle("opacity-0", shouldHide);
       cta.classList.toggle("pointer-events-none", shouldHide);
       lastScrollY = currentY;
+    };
+
+    const restoreListPosition = () => {
+      if (sessionStorage.getItem(LIST_RESTORE_KEY) !== "1") return;
+      const storedY = Number(sessionStorage.getItem(LIST_SCROLL_KEY) || "0");
+      window.setTimeout(() => {
+        window.scrollTo({ top: Number.isFinite(storedY) ? storedY : 0, behavior: "auto" });
+        sessionStorage.setItem(LIST_RESTORE_KEY, "0");
+      }, 0);
     };
 
     document.addEventListener("scroll", syncMobileIndexCta, { passive: true });
@@ -249,23 +290,25 @@
       window.visualViewport.addEventListener("resize", syncMobileIndexCta);
       window.visualViewport.addEventListener("scroll", syncMobileIndexCta);
     }
+
     document.addEventListener("input", (event) => {
       if (!event.target.closest("[data-search-form]")) return;
       syncMobileIndexCta();
     });
+
     document.addEventListener("change", (event) => {
       if (!event.target.closest("[data-search-form]")) return;
       syncMobileIndexCta();
     });
+
     document.addEventListener("focusin", (event) => {
       if (!event.target.closest("[data-index-search-root]")) return;
       syncMobileIndexCta();
     }, true);
+
     document.addEventListener("focusout", () => {
       window.setTimeout(syncMobileIndexCta, 0);
     }, true);
-    document.addEventListener("turbo:load", syncMobileIndexCta);
-    document.addEventListener("DOMContentLoaded", syncMobileIndexCta);
 
     document.addEventListener("submit", (event) => {
       const form = event.target.closest("[data-search-form]");
@@ -300,6 +343,21 @@
       });
     });
 
-    window.setTimeout(syncMobileIndexCta, 0);
+    document.addEventListener("turbo:load", () => {
+      markLoadedMedia();
+      syncMobileIndexCta();
+      restoreListPosition();
+    });
+    document.addEventListener("DOMContentLoaded", () => {
+      markLoadedMedia();
+      syncMobileIndexCta();
+      restoreListPosition();
+    });
+
+    window.setTimeout(() => {
+      markLoadedMedia();
+      syncMobileIndexCta();
+      restoreListPosition();
+    }, 0);
   }
 </script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,57 +11,124 @@
 <% item_link_missing_label = t("posts.show.item_link_missing", default: "Link not available") %>
 <% related_items_owner_hint = t("posts.show.related_items_owner_hint", default: "Add related items to help readers compare your setup.") %>
 <% mobile_more_label = t("posts.show.mobile_more_label", default: "More actions") %>
+<% comments_count = @root_comments.sum { |comment| 1 + comment.replies.size } %>
+<% comments_count_label = I18n.locale.to_s == "ja" ? "コメント #{localized_number(comments_count)}件" : "#{localized_number(comments_count)} comments" %>
+<% more_actions_label = I18n.locale.to_s == "ja" ? "その他の操作" : "More actions" %>
+<% owner_action_heading = I18n.locale.to_s == "ja" ? "オーナー操作" : "Owner actions" %>
+<% danger_zone_label = I18n.locale.to_s == "ja" ? "削除操作" : "Danger zone" %>
+<% danger_zone_lead = I18n.locale.to_s == "ja" ? "投稿の削除は取り消せません。" : "Post deletion cannot be undone." %>
 
 <article class="space-y-content">
-  <header class="space-y-3">
-    <div class="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+  <header class="space-y-4">
+    <div class="flex flex-wrap items-center gap-2 ds-text-meta text-slate-600">
       <span><%= l(@post.created_at.to_date) %></span>
       <% if @post.category.present? %>
-        <span class="rounded-full bg-slate-100 px-2 py-1 text-slate-700"><%= @post.category %></span>
+        <span class="ds-badge-inactive"><%= @post.category %></span>
       <% end %>
       <% if @post.theme.present? %>
-        <span class="rounded-full bg-cyan-50 px-2 py-1 text-cyan-700"><%= @post.theme %></span>
+        <span class="ds-badge-info"><%= @post.theme %></span>
       <% end %>
+      <span class="inline-flex items-center gap-1">
+        <%= ui_icon(:chat, class_name: "h-3.5 w-3.5") %>
+        <span><%= comments_count_label %></span>
+      </span>
     </div>
-    <h1 class="text-2xl font-bold text-slate-900 sm:text-3xl"><%= @post.title %></h1>
-    <p class="text-sm text-slate-600">
+
+    <h1 class="ds-heading-xl ds-break-words text-slate-900"><%= @post.title %></h1>
+
+    <p class="ds-text-support">
       <%= t("posts.show.posted_by") %>
       <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
     </p>
+
+    <div class="hidden sm:block">
+      <div class="relative flex flex-wrap items-center gap-2" data-desktop-post-actions-root>
+        <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-primary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like_primary" } do %>
+          <span class="inline-flex items-center gap-1.5">
+            <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+            <span><%= t("posts.show.actions.like") %></span>
+          </span>
+        <% end %>
+
+        <button type="button" data-desktop-post-actions-toggle aria-expanded="false" aria-controls="desktop-post-actions-menu" class="tap-target cta-secondary">
+          <span class="inline-flex items-center gap-1.5">
+            <%= ui_icon(:ellipsis_horizontal, class_name: "h-4 w-4") %>
+            <span><%= more_actions_label %></span>
+          </span>
+        </button>
+
+        <div id="desktop-post-actions-menu" data-desktop-post-actions-menu class="absolute left-0 top-full z-20 mt-2 hidden min-w-64 rounded-xl border border-slate-300 bg-white p-2 shadow-2xl ring-1 ring-slate-900/5">
+          <div class="grid gap-1">
+            <button type="button" data-desktop-actions-menu-item data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share") %></span>
+            </button>
+            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x_menu" } do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_x") %></span>
+            <% end %>
+            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads_menu" } do %>
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share_threads") %></span>
+            <% end %>
+            <button type="button" data-desktop-actions-menu-item data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
+            </button>
+            <% unless post_owner?(@post) %>
+              <button type="button" data-desktop-actions-menu-item data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report_menu" class="tap-target cta-warning cta-compact justify-start">
+                <%= ui_icon(:flag, class_name: "h-4 w-4") %>
+                <span><%= t("posts.show.actions.report") %></span>
+              </button>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
   </header>
 
-  <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white">
-    <%= optimized_post_image_tag(@post, variant: :main, class: "w-full object-cover") %>
+  <div class="ds-media-frame ds-media-frame-main ds-media-skeleton" data-media-skeleton>
+    <%= optimized_post_image_tag(@post, variant: :main, class: "h-full w-full object-cover") %>
   </div>
 
-  <section class="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
-    <h2 class="text-lg font-semibold text-slate-900"><%= body_section_label %></h2>
-    <div class="mt-3 max-w-3xl">
-      <p class="whitespace-pre-wrap text-base leading-reading text-slate-700"><%= @post.description %></p>
+  <section class="ds-section-card space-y-4">
+    <h2 class="ds-heading-lg text-slate-900"><%= body_section_label %></h2>
+    <div class="max-w-3xl">
+      <p class="ds-text-body whitespace-pre-wrap ds-break-words"><%= @post.description %></p>
     </div>
+
     <% if @post.tags.any? %>
-      <div class="mt-4 flex flex-wrap gap-2 border-t border-slate-100 pt-4">
+      <div class="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
         <% @post.tags.each do |tag| %>
-          <%= link_to "##{tag}", posts_path(tag: tag), class: "ds-badge-info hover:bg-slate-100" %>
+          <%= link_to "##{tag}", posts_path(tag: tag), class: "tap-target ds-badge-info hover:bg-slate-100" %>
         <% end %>
       </div>
     <% end %>
   </section>
 
-  <section class="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
+  <section class="ds-section-card space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <h2 class="text-xl font-bold text-slate-900"><%= t("posts.show.related_items") %></h2>
-      <span class="inline-flex items-center gap-1 text-sm text-slate-600">
+      <h2 class="ds-heading-lg text-slate-900"><%= t("posts.show.related_items") %></h2>
+      <span class="inline-flex items-center gap-1 ds-text-meta text-slate-600">
         <%= ui_icon(:heart, class_name: "h-4 w-4") %>
         <span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span>
       </span>
     </div>
 
     <% if @post.items.any? %>
-      <div class="mt-4 space-y-3">
+      <div class="space-y-3">
         <% @post.items.each do |item| %>
+          <% item_facts = related_item_facts(item) %>
+          <% fact_map = item_facts.index_by { |fact| fact[:key] } %>
+          <% labels = {
+            brand: t("posts.show.item_brand", default: "Brand"),
+            category: t("posts.show.item_category", default: "Category"),
+            price: t("posts.show.item_price", default: "Price"),
+            source: t("posts.show.item_source", default: "Source")
+          } %>
+
           <article class="rounded-lg border border-slate-200 bg-slate-50 p-3 sm:p-4">
-            <div class="grid gap-3 sm:grid-cols-[88px_minmax(0,1fr)] sm:items-center">
+            <div class="grid gap-3 sm:grid-cols-[88px_minmax(0,1fr)] sm:items-start">
               <div class="aspect-square rounded-md border border-slate-200 bg-white text-slate-400">
                 <div class="flex h-full items-center justify-center">
                   <div class="text-center">
@@ -70,17 +137,21 @@
                   </div>
                 </div>
               </div>
-              <div class="space-y-2">
-                <p class="text-sm font-semibold text-slate-900"><%= item.name %></p>
-                <div class="flex flex-wrap items-center gap-2">
-                  <% item_facts = related_item_facts(item) %>
-                  <% if item_facts.any? %>
-                    <% item_facts.each do |fact| %>
-                      <span class="ds-badge-info"><%= "#{fact[:label]}: #{fact[:value]}" %></span>
-                    <% end %>
-                  <% else %>
-                    <span class="ds-text-meta"><%= item_price_unknown_label %></span>
+
+              <div class="space-y-3">
+                <h3 class="ds-heading-sm ds-break-words text-slate-900"><%= item.name %></h3>
+
+                <dl class="grid gap-2 sm:grid-cols-2">
+                  <% [ :brand, :category, :price, :source ].each do |key| %>
+                    <% fact = fact_map[key] %>
+                    <div class="rounded-md border border-slate-200 bg-white px-2.5 py-2">
+                      <dt class="ds-text-meta font-semibold text-slate-500"><%= labels[key] %></dt>
+                      <dd class="mt-0.5 text-sm text-slate-700 ds-break-words"><%= fact&.dig(:value).presence || (key == :price ? item_price_unknown_label : "-") %></dd>
+                    </div>
                   <% end %>
+                </dl>
+
+                <div class="flex flex-wrap items-center gap-2">
                   <% if item.affiliate_url.present? %>
                     <%= link_to t("posts.show.open_product_page"), item.affiliate_url, class: "tap-target cta-secondary cta-compact", target: "_blank", rel: "nofollow sponsored noopener" %>
                   <% else %>
@@ -93,10 +164,10 @@
         <% end %>
       </div>
     <% else %>
-      <p class="mt-3 text-sm text-slate-600"><%= t("posts.show.no_related_items") %></p>
+      <p class="ds-text-support"><%= t("posts.show.no_related_items") %></p>
       <% if post_owner?(@post) %>
-        <p class="mt-2 ds-text-support"><%= related_items_owner_hint %></p>
-        <%= link_to edit_post_path(@post), class: "mt-3 inline-flex tap-target cta-secondary cta-compact" do %>
+        <p class="ds-text-support"><%= related_items_owner_hint %></p>
+        <%= link_to edit_post_path(@post), class: "inline-flex tap-target cta-secondary cta-compact" do %>
           <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
           <span><%= t("posts.show.actions.edit") %></span>
         <% end %>
@@ -104,32 +175,37 @@
     <% end %>
   </section>
 
-  <section id="comments" class="space-y-form rounded-xl border border-slate-200 bg-white p-4 sm:p-6">
-    <div class="space-y-2">
-      <h2 class="inline-flex items-center gap-1.5 text-xl font-bold text-slate-900">
-        <%= ui_icon(:chat, class_name: "h-5 w-5") %>
-        <span><%= t("posts.show.comments.title") %></span>
-      </h2>
-      <p class="text-sm text-slate-600"><%= comments_lead_label %></p>
+  <section id="comments" class="ds-anchor-offset space-y-form rounded-xl border border-slate-200 bg-white p-4 sm:p-6">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="space-y-1">
+        <h2 class="inline-flex items-center gap-1.5 ds-heading-lg text-slate-900">
+          <%= ui_icon(:chat, class_name: "h-5 w-5") %>
+          <span><%= t("posts.show.comments.title") %></span>
+        </h2>
+        <p class="ds-text-meta"><%= comments_count_label %></p>
+      </div>
+      <a href="#comment-form" class="tap-target cta-primary cta-compact"><%= @root_comments.any? ? t("posts.show.comments.post_comment") : comment_empty_cta %></a>
     </div>
 
+    <p class="ds-text-support"><%= comments_lead_label %></p>
+
     <% if @root_comments.any? %>
-      <div class="space-y-5">
+      <div class="space-y-4" aria-live="polite">
         <% @root_comments.each do |comment| %>
           <article id="comment-<%= comment.id %>" class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <div class="flex items-center justify-between gap-3">
-              <p class="text-sm font-medium text-slate-800"><%= comment.author_name %></p>
+              <p class="text-sm font-medium text-slate-800 ds-break-words"><%= comment.author_name %></p>
             </div>
-            <p class="mt-0.5 text-xs text-slate-600"><%= l(comment.created_at, format: :short) %></p>
-            <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= comment.body %></p>
+            <p class="mt-0.5 ds-text-meta"><%= l(comment.created_at, format: :short) %></p>
+            <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= comment.body %></p>
 
             <% if comment.replies.any? %>
               <div class="mt-4 space-y-2 rounded-lg bg-slate-50 px-3 py-3 sm:pl-4 sm:pr-3">
                 <% comment.replies.each do |reply| %>
-                  <div id="comment-<%= reply.id %>" class="rounded-md bg-white/85 px-3 py-2">
-                    <p class="text-xs font-medium text-slate-700"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
-                    <p class="mt-0.5 text-xs text-slate-600"><%= l(reply.created_at, format: :short) %></p>
-                    <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700"><%= reply.body %></p>
+                  <div id="comment-<%= reply.id %>" class="rounded-md border border-slate-100 bg-white/85 px-3 py-2">
+                    <p class="text-xs font-medium text-slate-700 ds-break-words"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
+                    <p class="mt-0.5 ds-text-meta"><%= l(reply.created_at, format: :short) %></p>
+                    <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= reply.body %></p>
                   </div>
                 <% end %>
               </div>
@@ -147,11 +223,11 @@
     <% else %>
       <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center">
         <p class="ds-text-support"><%= t("posts.show.comments.empty_state") %></p>
-        <a href="#comment-form" class="mt-3 inline-flex tap-target cta-secondary cta-compact"><%= comment_empty_cta %></a>
+        <a href="#comment-form" class="mt-3 inline-flex tap-target cta-primary cta-compact"><%= comment_empty_cta %></a>
       </div>
     <% end %>
 
-    <div class="border-t border-slate-200 pt-4" id="comment-form">
+    <div class="ds-anchor-offset border-t border-slate-200 pt-4" id="comment-form">
       <% if @reply_to_comment.present? %>
         <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
           <%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %>
@@ -159,9 +235,10 @@
         </div>
       <% end %>
 
-      <%= form_with model: [@post, @comment], class: "space-y-form" do |f| %>
+      <%= form_with model: [@post, @comment], class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
         <% if @comment.errors.any? %>
-          <div class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700">
+          <div class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700" role="alert">
+            <p class="mb-2 font-semibold"><%= t("posts.form.error_summary", default: "Please fix the following errors.") %></p>
             <ul class="list-disc pl-5">
               <% @comment.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
@@ -183,14 +260,17 @@
           <%= f.label :author_name, t("posts.show.comments.name"), class: "mb-1 block text-sm font-medium" %>
           <%= f.text_field :author_name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
         </div>
+
         <div>
           <%= f.label :body, t("posts.show.comments.comment"), class: "mb-1 block text-sm font-medium" %>
           <%= f.text_area :body, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
         </div>
+
         <% if recaptcha_enabled? %>
           <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
         <% end %>
-        <%= f.button type: :submit, class: "tap-target cta-secondary" do %>
+
+        <%= f.button type: :submit, class: "tap-target cta-primary" do %>
           <span class="inline-flex items-center gap-1.5">
             <%= ui_icon(:chat, class_name: "h-4 w-4") %>
             <span><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span>
@@ -200,35 +280,33 @@
     </div>
   </section>
 
-  <div class="hidden flex-wrap items-center gap-3 sm:flex">
-    <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-secondary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like" } do %>
-      <span class="inline-flex items-center gap-1.5">
-        <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.like") %></span>
-      </span>
-    <% end %>
-    <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target cta-secondary", data: { ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x" } do %>
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.share_x") %></span>
-    <% end %>
-    <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target cta-secondary", data: { ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads" } do %>
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span><%= t("posts.show.actions.share_threads") %></span>
-    <% end %>
-    <button type="button" data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url" class="tap-target cta-secondary">
-      <%= ui_icon(:share, class_name: "h-4 w-4") %>
-      <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
-    </button>
-    <% unless post_owner?(@post) %>
-      <button type="button" data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report" class="tap-target cta-warning cta-compact">
-        <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.report") %></span>
-      </button>
-    <% end %>
-  </div>
+  <% if post_owner?(@post) %>
+    <section class="ds-card space-y-4 p-4">
+      <h2 class="ds-heading-sm text-slate-900"><%= owner_action_heading %></h2>
+      <div class="flex flex-wrap items-center gap-2">
+        <%= link_to edit_post_path(@post), class: "tap-target cta-secondary" do %>
+          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.actions.edit") %></span>
+        <% end %>
+        <%= link_to notifications_post_path(@post), class: "tap-target cta-secondary" do %>
+          <%= ui_icon(:bell, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span>
+        <% end %>
+      </div>
+
+      <div class="border-t border-red-100 pt-3">
+        <p class="ds-text-meta font-semibold text-red-700"><%= danger_zone_label %></p>
+        <p class="mt-1 ds-text-muted text-red-700"><%= danger_zone_lead %></p>
+        <%= button_to post_path(@post), method: :delete, form: { class: "mt-2 inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target cta-danger" do %>
+          <%= ui_icon(:trash, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.actions.delete") %></span>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
 
   <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-mobile-actions-root>
-    <div class="mx-auto w-full max-w-6xl px-4 pt-3" style="padding-bottom: max(env(safe-area-inset-bottom), 0.75rem);">
+    <div class="mx-auto w-full max-w-6xl px-4 pt-3">
       <div class="relative pb-1">
         <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
           <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-primary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
@@ -237,7 +315,8 @@
               <span><%= t("posts.show.actions.like") %></span>
             </span>
           <% end %>
-          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="tap-target inline-flex items-center justify-center rounded-lg px-2.5 py-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+
+          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="ds-icon-button text-slate-600 hover:bg-slate-100 hover:text-slate-900">
             <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
             <span class="sr-only"><%= mobile_more_label %></span>
           </button>
@@ -273,25 +352,8 @@
     </div>
   </div>
 
-  <% if post_owner?(@post) %>
-    <div class="flex flex-wrap items-center gap-3 rounded-xl border border-blue-100 bg-blue-50 p-4">
-      <%= link_to edit_post_path(@post), class: "tap-target cta-secondary" do %>
-        <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.edit") %></span>
-      <% end %>
-      <%= link_to notifications_post_path(@post), class: "tap-target cta-secondary" do %>
-        <%= ui_icon(:bell, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span>
-      <% end %>
-      <%= button_to post_path(@post), method: :delete, form: { class: "inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target cta-danger" do %>
-        <%= ui_icon(:trash, class_name: "h-4 w-4") %>
-        <span><%= t("posts.show.actions.delete") %></span>
-      <% end %>
-    </div>
-  <% end %>
-
   <% unless post_owner?(@post) %>
-    <dialog id="report-modal-<%= @post.id %>" class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
+    <dialog id="report-modal-<%= @post.id %>" data-report-modal class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
       <div class="border-b border-slate-200 px-4 py-3">
         <h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2>
         <p class="mt-1 text-xs text-slate-600"><%= t("posts.show.report.description") %></p>
@@ -300,13 +362,13 @@
         <% if owned_users.any? %>
           <div>
             <%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %>
-            <%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+            <%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: true } %>
           </div>
         <% end %>
 
         <div>
           <%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+          <%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: owned_users.any? ? nil : true } %>
         </div>
 
         <div>
@@ -322,14 +384,56 @@
     </dialog>
   <% end %>
 
-  <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
+  <div class="space-y-2">
+    <p class="ad-slot-divider"><%= I18n.locale.to_s == "ja" ? "関連スポンサー枠" : "Sponsored placement" %></p>
+    <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
+  </div>
 
-  <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %>
+  <div class="space-y-2">
+    <p class="ad-slot-divider"><%= I18n.locale.to_s == "ja" ? "関連スポンサー枠" : "Sponsored placement" %></p>
+    <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %>
+  </div>
 </article>
 
 <script>
-  if (!window.__reportModalBindingInstalled) {
-    window.__reportModalBindingInstalled = true;
+  if (!window.__postShowUiBindingInstalled) {
+    window.__postShowUiBindingInstalled = true;
+
+    const mobileMenuOpenMessage = "<%= j(mobile_menu_open_label) %>";
+    const mobileMenuCloseMessage = "<%= j(mobile_menu_close_label) %>";
+    let lastModalTrigger = null;
+
+    const markLoadedMedia = (scope = document) => {
+      scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
+        const image = frame.querySelector("img");
+        if (!image) {
+          frame.classList.add("ds-media-loaded");
+          return;
+        }
+        if (image.complete) {
+          frame.classList.add("ds-media-loaded");
+          return;
+        }
+
+        image.addEventListener("load", () => frame.classList.add("ds-media-loaded"), { once: true });
+        image.addEventListener("error", () => frame.classList.add("ds-media-loaded"), { once: true });
+      });
+    };
+
+    const closeDesktopActionsMenu = (reason = "dismissed") => {
+      const menu = document.querySelector("[data-desktop-post-actions-menu]");
+      const toggle = document.querySelector("[data-desktop-post-actions-toggle]");
+      if (!menu || menu.classList.contains("hidden")) return;
+
+      menu.classList.add("hidden");
+      if (toggle) toggle.setAttribute("aria-expanded", "false");
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "post_action_desktop_menu_close", {
+          event_category: "post_actions",
+          event_label: `desktop_menu_${reason}`
+        });
+      }
+    };
 
     const closeMobileActionsMenu = (reason = "dismissed") => {
       const menu = document.querySelector("[data-mobile-actions-menu]");
@@ -338,7 +442,7 @@
 
       menu.classList.add("hidden");
       if (toggle) toggle.setAttribute("aria-expanded", "false");
-      if (typeof window.dsNotify === "function") window.dsNotify("<%= j(mobile_menu_close_label) %>", "info");
+      if (typeof window.dsNotify === "function") window.dsNotify(mobileMenuCloseMessage, "info");
       if (typeof window.gtag === "function") {
         window.gtag("event", "post_action_more_menu_close", {
           event_category: "post_actions",
@@ -347,21 +451,115 @@
       }
     };
 
+    const openModal = (trigger, modalId) => {
+      const dialog = document.getElementById(modalId);
+      if (!dialog || typeof dialog.showModal !== "function") return;
+
+      lastModalTrigger = trigger;
+      dialog.showModal();
+
+      const focusTarget = dialog.querySelector("[data-modal-initial-focus]") || dialog.querySelector("input, select, textarea, button");
+      if (focusTarget) {
+        window.setTimeout(() => focusTarget.focus(), 0);
+      }
+    };
+
+    const closeModal = (dialog) => {
+      if (!dialog || typeof dialog.close !== "function") return;
+      dialog.close();
+      if (lastModalTrigger && typeof lastModalTrigger.focus === "function") {
+        window.setTimeout(() => lastModalTrigger.focus(), 0);
+      }
+    };
+
+    const runNativeShare = (button) => {
+      if (!button) return;
+      const url = button.getAttribute("data-native-share-url");
+      const text = button.getAttribute("data-native-share-text");
+      if (!url) return;
+
+      if (navigator.share) {
+        navigator.share({ text, url }).catch(async (error) => {
+          if (error && error.name === "AbortError") return;
+          try {
+            await navigator.clipboard.writeText(url);
+          } catch (_) {}
+        });
+      } else {
+        navigator.clipboard.writeText(url).catch(() => {});
+      }
+    };
+
+    const keyboardOpen = () => {
+      if (!window.visualViewport) return false;
+      return (window.innerHeight - window.visualViewport.height) > 130;
+    };
+
+    const syncMobileActionBar = () => {
+      const root = document.querySelector("[data-mobile-actions-root]");
+      const menu = document.querySelector("[data-mobile-actions-menu]");
+      const modal = document.querySelector("[data-report-modal][open]");
+      const commentForm = document.querySelector("#comment-form form");
+      if (!root) return;
+
+      const focusedOnComment = commentForm ? commentForm.contains(document.activeElement) : false;
+      const menuOpen = menu && !menu.classList.contains("hidden");
+      const shouldHide = focusedOnComment || keyboardOpen() || Boolean(modal);
+
+      root.classList.toggle("translate-y-full", shouldHide);
+      root.classList.toggle("opacity-0", shouldHide);
+      root.classList.toggle("pointer-events-none", shouldHide && !menuOpen);
+    };
+
+    document.querySelectorAll("[data-report-modal]").forEach((dialog) => {
+      dialog.addEventListener("click", (event) => {
+        if (event.target === dialog) closeModal(dialog);
+      });
+      dialog.addEventListener("close", () => {
+        if (lastModalTrigger && typeof lastModalTrigger.focus === "function") {
+          window.setTimeout(() => lastModalTrigger.focus(), 0);
+        }
+        syncMobileActionBar();
+      });
+      dialog.addEventListener("cancel", () => {
+        if (lastModalTrigger && typeof lastModalTrigger.focus === "function") {
+          window.setTimeout(() => lastModalTrigger.focus(), 0);
+        }
+      });
+    });
+
     document.addEventListener("click", (event) => {
       const openButton = event.target.closest("[data-open-report-modal]");
       if (openButton) {
-        const modalId = openButton.getAttribute("data-open-report-modal");
-        const dialog = document.getElementById(modalId);
-        if (dialog && typeof dialog.showModal === "function") dialog.showModal();
+        openModal(openButton, openButton.getAttribute("data-open-report-modal"));
         closeMobileActionsMenu("modal_open");
+        closeDesktopActionsMenu("modal_open");
+        syncMobileActionBar();
         return;
       }
 
       const closeButton = event.target.closest("[data-close-report-modal]");
       if (closeButton) {
-        const modalId = closeButton.getAttribute("data-close-report-modal");
-        const dialog = document.getElementById(modalId);
-        if (dialog && typeof dialog.close === "function") dialog.close();
+        const dialog = document.getElementById(closeButton.getAttribute("data-close-report-modal"));
+        closeModal(dialog);
+        return;
+      }
+
+      const desktopToggle = event.target.closest("[data-desktop-post-actions-toggle]");
+      if (desktopToggle) {
+        const menu = document.querySelector("[data-desktop-post-actions-menu]");
+        if (!menu) return;
+
+        const expanded = desktopToggle.getAttribute("aria-expanded") == "true";
+        menu.classList.toggle("hidden", expanded);
+        desktopToggle.setAttribute("aria-expanded", String(!expanded));
+        return;
+      }
+
+      const desktopAction = event.target.closest("[data-desktop-actions-menu-item]");
+      if (desktopAction) {
+        runNativeShare(desktopAction.closest("[data-native-share-url]") || desktopAction);
+        closeDesktopActionsMenu("action_selected");
         return;
       }
 
@@ -369,81 +567,66 @@
       if (mobileActionsToggle) {
         const menu = document.querySelector("[data-mobile-actions-menu]");
         if (!menu) return;
+
         const expanded = mobileActionsToggle.getAttribute("aria-expanded") == "true";
         menu.classList.toggle("hidden", expanded);
         mobileActionsToggle.setAttribute("aria-expanded", String(!expanded));
-        if (!expanded && typeof window.dsNotify === "function") window.dsNotify("<%= j(mobile_menu_open_label) %>", "info");
-        if (expanded && typeof window.dsNotify === "function") window.dsNotify("<%= j(mobile_menu_close_label) %>", "info");
+        if (!expanded && typeof window.dsNotify === "function") window.dsNotify(mobileMenuOpenMessage, "info");
+        if (expanded && typeof window.dsNotify === "function") window.dsNotify(mobileMenuCloseMessage, "info");
+        syncMobileActionBar();
         return;
       }
 
-      const mobileActionsMenu = document.querySelector("[data-mobile-actions-menu]");
       const shareButton = event.target.closest("[data-native-share-url]");
-      if (mobileActionsMenu && !mobileActionsMenu.classList.contains("hidden")) {
-        const isMenuAction = event.target.closest("[data-mobile-menu-action]");
-        const isInsideMenu = event.target.closest("[data-mobile-actions-menu]");
-        if (isMenuAction) {
-          if (shareButton) {
-            const url = shareButton.getAttribute("data-native-share-url");
-            const text = shareButton.getAttribute("data-native-share-text");
-
-            if (navigator.share) {
-              navigator.share({ text, url }).catch(async (error) => {
-                if (error && error.name === "AbortError") return;
-                try {
-                  await navigator.clipboard.writeText(url);
-                } catch (_) {}
-              });
-            } else {
-              navigator.clipboard.writeText(url).catch(() => {});
-            }
-          }
-          closeMobileActionsMenu("action_selected");
-          return;
-        }
-        if (!isInsideMenu) closeMobileActionsMenu("outside_tap");
+      if (shareButton) {
+        runNativeShare(shareButton);
       }
 
-      if (shareButton) {
-        const url = shareButton.getAttribute("data-native-share-url");
-        const text = shareButton.getAttribute("data-native-share-text");
+      const mobileMenuAction = event.target.closest("[data-mobile-menu-action]");
+      if (mobileMenuAction) {
+        closeMobileActionsMenu("action_selected");
+        return;
+      }
 
-        if (navigator.share) {
-          navigator.share({ text, url }).catch(async (error) => {
-            if (error && error.name === "AbortError") return;
-            try {
-              await navigator.clipboard.writeText(url);
-            } catch (_) {}
-          });
-        } else {
-          navigator.clipboard.writeText(url).catch(() => {});
-        }
+      const mobileMenu = document.querySelector("[data-mobile-actions-menu]");
+      if (mobileMenu && !mobileMenu.classList.contains("hidden") && !event.target.closest("[data-mobile-actions-menu]") && !event.target.closest("[data-mobile-actions-toggle]")) {
+        closeMobileActionsMenu("outside_tap");
+      }
+
+      const desktopMenu = document.querySelector("[data-desktop-post-actions-menu]");
+      if (desktopMenu && !desktopMenu.classList.contains("hidden") && !event.target.closest("[data-desktop-post-actions-root]")) {
+        closeDesktopActionsMenu("outside_tap");
       }
     });
 
     document.addEventListener("keydown", (event) => {
       if (event.key !== "Escape") return;
       closeMobileActionsMenu("escape");
+      closeDesktopActionsMenu("escape");
+      const activeDialog = document.querySelector("[data-report-modal][open]");
+      if (activeDialog) closeModal(activeDialog);
     });
 
-    const mobileActionsRoot = document.querySelector("[data-mobile-actions-root]");
-    const commentForm = document.querySelector("#comment-form form");
-    if (mobileActionsRoot && commentForm) {
-      const setMobileBarVisibility = () => {
-        const activeElement = document.activeElement;
-        const shouldHide = activeElement && commentForm.contains(activeElement);
-        mobileActionsRoot.classList.toggle("translate-y-full", shouldHide);
-        mobileActionsRoot.classList.toggle("opacity-0", shouldHide);
-        mobileActionsRoot.classList.toggle("pointer-events-none", shouldHide);
-      };
-
-      document.addEventListener("focusin", setMobileBarVisibility, true);
-      document.addEventListener("focusout", () => {
-        window.setTimeout(setMobileBarVisibility, 0);
-      }, true);
-      commentForm.addEventListener("submit", () => {
-        mobileActionsRoot.classList.remove("translate-y-full", "opacity-0", "pointer-events-none");
-      });
+    document.addEventListener("focusin", syncMobileActionBar, true);
+    document.addEventListener("focusout", () => window.setTimeout(syncMobileActionBar, 0), true);
+    window.addEventListener("resize", syncMobileActionBar);
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", syncMobileActionBar);
+      window.visualViewport.addEventListener("scroll", syncMobileActionBar);
     }
+
+    document.addEventListener("turbo:load", () => {
+      markLoadedMedia();
+      syncMobileActionBar();
+    });
+    document.addEventListener("DOMContentLoaded", () => {
+      markLoadedMedia();
+      syncMobileActionBar();
+    });
+
+    window.setTimeout(() => {
+      markLoadedMedia();
+      syncMobileActionBar();
+    }, 0);
   }
 </script>

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -67,6 +67,12 @@
 - All interactive controls must expose visible focus style (`:focus-visible`).
 - Announce asynchronous status changes (copy success/failure, menu open/close) through the live region.
 - Menus and toggles must keep `aria-expanded` synchronized with UI state.
+- Modal/menu behavior must be consistent:
+  - Initial focus lands on the first actionable control.
+  - `Esc` closes the layer.
+  - Focus returns to the trigger after close.
+- Anchor targets under sticky headers must use `scroll-margin-top` (`ds-anchor-offset`).
+- Respect `prefers-reduced-motion`: disable non-essential animation and smooth scrolling.
 
 ## Typography And Rhythm
 - Japanese UI optimization:
@@ -78,6 +84,67 @@
 ## Ads Placement
 - Wrap ad slots in a low-noise container (`ad-slot-surface`) with clear spacing from content groups.
 - Add a compact disclosure label (`ad-slot-label`) to separate ads from primary content.
+- Add a context separator before ad groups (`ad-slot-divider`) when placed between reading/comment sections.
+
+## Responsive Density Rules
+- Define information density by breakpoint:
+  - Mobile: prioritize one-line metadata rows and collapsed secondary controls.
+  - Tablet: allow 2-column cards and compact chips.
+  - Desktop: expose utility menus and additional metadata only when they do not compete with the primary CTA.
+- Prevent overflow in mixed Japanese/English labels with `ds-break-words` and explicit line-clamp rules.
+
+## Component State Matrix
+- Every interactive component must define and visually test:
+  - `default`
+  - `hover`
+  - `focus-visible`
+  - `disabled`
+  - `loading`
+- Components covered:
+  - `cta-*`
+  - `ds-badge-*`
+  - form controls (`input/select/textarea`)
+  - menus/dialog triggers
+
+## Contrast Audit Flow
+- Use WCAG 2.2 contrast checks as a required pre-merge gate for:
+  - Body text
+  - Meta text
+  - CTA labels
+  - Badge text and borders
+- Keep contrast checks in PR artifacts:
+  - Screenshot set (default + focus-visible + disabled)
+  - Measured contrast values and pass/fail notes
+
+## Media Loading And CLS
+- Use explicit aspect-ratio wrappers for list/detail media (`ds-media-frame-*`).
+- Image containers should render skeleton placeholders (`ds-media-skeleton`) until `load/error`.
+- Keep width/height attributes on image tags to stabilize layout before decode.
+
+## Dark Mode Readiness
+- Maintain colors through `--ds-*` tokens only; avoid hard-coded semantic colors in component markup.
+- Before dark mode rollout, classify:
+  - Directly tokenized components (ready)
+  - Mixed token/hard-coded components (needs migration)
+  - Third-party embeds (non-themable constraints)
+- Define minimum contrast targets per theme variant before enabling user toggle.
+
+## Alt Text Guidelines
+- Post images: descriptive, content-bearing alt text (setup context + key visual trait).
+- Decorative icons: `aria-hidden="true"` and no redundant alt text.
+- Informational icons inside controls: text label must remain understandable without icon.
+
+## KPI-Driven Iteration Loop
+- Track UI changes against measurable outcomes:
+  - Search zero-result rate
+  - Card-to-detail click-through rate
+  - Comment completion rate
+  - Share/copy action rate
+  - Back-navigation recovery success (list position restore)
+- PRs that change conversion-critical UI must include:
+  - Hypothesis
+  - Affected KPI(s)
+  - Expected direction and guardrail metric
 
 ## Design Audit Workflow
 - Pull requests that modify UI must complete a design-system checklist in the PR template.


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/65

## 目的

  UIシステム定義（CTA階層、カード規則、モバイル固定バー規則、アクセシビリティ）と主要画面実装のズレを解消し、検索→閲覧→行動の完了率向上につなげる。

  ## 実装内容

  - 一覧 (posts/index) のCTA階層を再整理し、主行動を明確化。
  - 一覧カードの情報密度を最適化（カテゴリ/タグ/メタ整理、ノイズ削減）。
  - ヒーロー可読性を改善（オーバーレイ追加、コントラスト安定化）。
  - 詳細 (posts/show) の情報階層を再設計（本文→コメント導線を強調）。
  - 詳細アクションを再編（主行動1つ + その他メニュー）。
  - オーナー操作を通常操作と破壊的操作に分離。
  - モバイル固定バーの表示/非表示条件を再調整（入力・キーボード・モーダル考慮）。
  - ヘッダーを「主CTA1つ + Utilityメニュー」に圧縮。
  - 空状態の次アクション文言と導線を統一。
  - タップターゲット 44px を強化（タグ、言語切替、アイコンボタン）。
  - posts/show のタイポをトークン寄せ。
  - 検索リセットを posts_path に統一。
  - カードを ds-card / ds-shadow-soft に寄せて再利用性向上。
  - フォームエラー表示を強化（要約、項目リンク、初回エラーへフォーカス）。
  - モーダル/メニューのアクセシビリティ挙動を統一（初期フォーカス、Esc、フォーカス戻し）。
  - 画像のCLS対策（アスペクト比フレーム、width/height、スケルトン）。
  - 長文折り返しルールを追加（ds-break-words、line-clamp）。
  - 一覧→詳細→一覧のスクロール復帰を実装。
  - Reduce Motion対応を追加。
  - デザインシステム文書に監査/KPI/ダークモード準備/状態行列を追記。

  ## 方法

  - 共通CSSトークンとユーティリティを先に拡張し、各画面へ適用。
  - レイアウト（ヘッダー・固定バー）と画面（index/show/form）を段階的に再構成。
  - 画面内JSで状態制御（メニュー、モーダル、固定バー、スクロール復帰）を統一。
  - 画像ヘルパーに寸法/sizesを追加してレイアウト安定化。
  - 静的検証（Tailwind build / Brakeman）で回帰確認。


  - app/assets/tailwind/application.css
  - app/helpers/application_helper.rb
  - app/views/layouts/application.html.erb
  - app/views/posts/index.html.erb
  - app/views/posts/show.html.erb
  - app/views/posts/_form.html.erb
  - docs/design_system.md

  ## まとめ

  主要画面と共通レイヤーをデザインシステム準拠へ寄せ、CTA優先度、情報階層、アクセシビリティ、一貫した操作体験を強化した。
  実装対象に含まれる運用系項目（監査/KPI/ダークモード準備）は docs/design_system.md に規約として反映済み。

  ## Testing

  - ruby bin/rails tailwindcss:build
      - 成功
  - brakeman --no-pager --no-exit-on-warn
      - 成功（Errors: 0、EOLRuby 警告のみ）
  - RAILS_ENV=test DATABASE_URL=postgresql://localhost:5432/desktour_studio_test ruby bin/rails test test:system
      - Tailwindビルドは成功
      - PostgreSQL接続不可（::1:5432）で失敗（環境要因）