### PR TITLE
Implement UX Polish Roadmap: Optimization for Search, Post, and Comment Flows

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -16,9 +16,9 @@
     --ds-focus-border-color: rgb(37, 99, 235);
     --ds-text-main: rgb(15 23 42);
     --ds-text-body: rgb(51 65 85);
-    --ds-text-support: rgb(51 65 85);
-    --ds-text-meta: rgb(71 85 105);
-    --ds-text-muted: rgb(71 85 105);
+    --ds-text-support: rgb(30 41 59);
+    --ds-text-meta: rgb(51 65 85);
+    --ds-text-muted: rgb(51 65 85);
     --ds-safe-area-bottom: env(safe-area-inset-bottom, 0px);
     --ds-safe-area-top: env(safe-area-inset-top, 0px);
     --ds-motion-duration-fast: 160ms;
@@ -280,6 +280,14 @@
 
   .ds-section-card {
     @apply rounded-xl border border-slate-200 bg-white p-5 sm:p-6;
+  }
+
+  .ds-filter-shell {
+    @apply bg-slate-50/70;
+  }
+
+  .ds-filter-shell-collapsed {
+    @apply border-slate-200/80 bg-slate-50/35;
   }
 
   .cta-primary {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,6 +90,7 @@ module ApplicationHelper
     storage: [ "ssd", "hdd", "nas", "drive" ]
   }.freeze
   ITEM_GENERIC_BRAND_TOKENS = %w[desk setup monitor keyboard mouse chair table stand with for and the a an rgb].freeze
+  GENERIC_POST_TAGS = %w[desk setup workspace workstation minimal home office room pc].freeze
 
   def ga4_measurement_id
     ENV["GA4_MEASUREMENT_ID"].to_s.strip.presence
@@ -179,6 +180,25 @@ module ApplicationHelper
 
   def flash_visual(type)
     FLASH_VISUALS.fetch(type.to_s, FLASH_VISUALS.fetch("notice"))
+  end
+
+  def prioritized_post_tags(post, query:, category:, selected_tag:)
+    tags = post.tags.map(&:to_s).map(&:strip).reject(&:blank?)
+    return [] if tags.empty?
+
+    selected = selected_tag.to_s.downcase
+    category_down = category.to_s.downcase
+    query_tokens = query.to_s.downcase.split(/[\s,\/_-]+/).map(&:strip).reject(&:blank?).first(6)
+
+    tags.sort_by do |tag|
+      normalized = tag.downcase
+      score = 0
+      score += 8 if selected.present? && normalized == selected
+      score += 4 if category_down.present? && (normalized.include?(category_down) || category_down.include?(normalized))
+      score += 3 if query_tokens.any? { |token| normalized.include?(token) || token.include?(normalized) }
+      score -= 1 if GENERIC_POST_TAGS.include?(normalized)
+      [ -score, tag ]
+    end
   end
   def related_item_facts(item)
     name = item.name.to_s.strip

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,7 @@
           <div class="relative" data-desktop-utility-root>
             <button type="button" data-desktop-utility-toggle aria-expanded="false" aria-controls="desktop-utility-menu" class="tap-target cta-tertiary" data-ga-event="navigation_desktop_utility_toggle_click" data-ga-category="navigation" data-ga-label="desktop_utility_toggle">
               <span class="inline-flex items-center gap-1.5">
-                <span><%= I18n.locale.to_s == "ja" ? "その他" : "Utility" %></span>
+                <span><%= t("navigation.utility_menu", default: "Utility") %></span>
                 <%= ui_icon(:chevron_down, class_name: "h-4 w-4 text-slate-600") %>
               </span>
             </button>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -36,6 +36,7 @@
   details: params[:details].presence
 }.compact %>
 <% empty_primary_cta = I18n.locale.to_s == "ja" ? "\u6700\u521D\u306E\u6295\u7A3F\u3092\u4F5C\u6210" : "Create your first post" %>
+<% timeline_hint = t("posts.index.timeline_hint", default: "Start your timeline with one post.") %>
 
 <section class="space-y-section">
   <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-blue-900 to-cyan-800 px-5 py-6 text-white sm:px-6 sm:py-8">
@@ -47,8 +48,10 @@
       </p>
       <div class="mt-4 flex flex-wrap items-center gap-2">
         <a href="#index-search" class="tap-target cta-primary"><%= t("posts.index.search_button") %></a>
-        <%= link_to t("navigation.create_post"), new_post_path, class: "tap-target cta-tertiary cta-compact text-white hover:bg-white/20 hover:text-white" %>
       </div>
+      <p class="mt-2 ds-text-meta text-blue-100/90">
+        <%= link_to t("navigation.create_post"), new_post_path, class: "underline decoration-white/40 underline-offset-2 hover:text-white" %>
+      </p>
     </div>
   </div>
 
@@ -56,7 +59,7 @@
     <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
 
-      <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div class="sticky top-20 z-10 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:static" data-quick-search-shell>
         <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= quick_search_label %></p>
         <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
@@ -64,7 +67,7 @@
         </div>
       </div>
 
-      <div class="rounded-xl border border-slate-200 bg-slate-50/60 p-3 sm:p-4">
+      <div class="ds-filter-shell <%= detailed_filters_open ? '' : 'ds-filter-shell-collapsed' %> rounded-xl border border-slate-200 p-3 sm:p-4" data-details-shell>
         <div class="flex flex-wrap items-center justify-between gap-2">
           <div>
             <p class="text-sm font-semibold text-slate-800"><%= filters_title %></p>
@@ -111,8 +114,9 @@
   <% if @posts.any? %>
     <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <% @posts.each do |post| %>
-        <% visible_tags = post.tags.first(max_card_tags) %>
-        <% hidden_tag_count = [post.tags.size - visible_tags.size, 0].max %>
+        <% ranked_tags = prioritized_post_tags(post, query: params[:q], category: params[:category], selected_tag: params[:tag]) %>
+        <% visible_tags = ranked_tags.first(max_card_tags) %>
+        <% hidden_tag_count = [ranked_tags.size - visible_tags.size, 0].max %>
         <article class="ds-card ds-shadow-soft flex h-full flex-col overflow-hidden">
           <%= link_to post_path(post), class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
             <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton>
@@ -140,17 +144,17 @@
             </div>
 
             <div class="mt-auto border-t border-slate-100 pt-3" aria-label="Post metadata">
-              <div class="flex flex-wrap items-center justify-between gap-2 ds-text-meta text-slate-600">
-                <span class="inline-flex items-center gap-1.5">
+              <div class="space-y-1.5">
+                <p class="ds-text-meta inline-flex items-center gap-1.5 text-slate-600">
                   <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
                   <span><%= localized_number(post.likes_count) %></span>
-                  <span aria-hidden="true">•</span>
+                  <span aria-hidden="true">&bull;</span>
                   <span><%= l(post.created_at.to_date) %></span>
-                </span>
-                <span>
+                </p>
+                <p class="ds-text-meta text-slate-600">
                   <%= t("posts.index.author_label") %>:
                   <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
-                </span>
+                </p>
               </div>
             </div>
           </div>
@@ -177,7 +181,7 @@
       <% else %>
         <div class="mt-4 space-y-2">
           <%= link_to empty_primary_cta, new_post_path, class: "tap-target cta-primary" %>
-          <p class="ds-text-muted"><%= I18n.locale.to_s == "ja" ? "まず1件作成してタイムラインを始めましょう。" : "Start your timeline with a single post." %></p>
+          <p class="ds-text-muted"><%= timeline_hint %></p>
         </div>
       <% end %>
     </div>
@@ -219,12 +223,14 @@
       const icon = toggle.querySelector(".js-details-toggle-icon");
       const toggleLabel = toggle.querySelector("[data-details-toggle-label]");
       const stateInput = form ? form.querySelector("[data-details-state-input]") : null;
+      const detailsShell = form ? form.querySelector("[data-details-shell]") : null;
       if (!panel) return;
 
       const expanded = toggle.getAttribute("aria-expanded") == "true";
       const nextExpanded = !expanded;
       toggle.setAttribute("aria-expanded", String(nextExpanded));
       panel.classList.toggle("hidden", !nextExpanded);
+      if (detailsShell) detailsShell.classList.toggle("ds-filter-shell-collapsed", !nextExpanded);
       if (icon) icon.classList.toggle("rotate-180", nextExpanded);
       if (toggleLabel) {
         const openLabel = toggleLabel.dataset.labelOpen || "Open filters";

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -12,11 +12,14 @@
 <% related_items_owner_hint = t("posts.show.related_items_owner_hint", default: "Add related items to help readers compare your setup.") %>
 <% mobile_more_label = t("posts.show.mobile_more_label", default: "More actions") %>
 <% comments_count = @root_comments.sum { |comment| 1 + comment.replies.size } %>
-<% comments_count_label = I18n.locale.to_s == "ja" ? "コメント #{localized_number(comments_count)}件" : "#{localized_number(comments_count)} comments" %>
-<% more_actions_label = I18n.locale.to_s == "ja" ? "その他の操作" : "More actions" %>
-<% owner_action_heading = I18n.locale.to_s == "ja" ? "オーナー操作" : "Owner actions" %>
-<% danger_zone_label = I18n.locale.to_s == "ja" ? "削除操作" : "Danger zone" %>
-<% danger_zone_lead = I18n.locale.to_s == "ja" ? "投稿の削除は取り消せません。" : "Post deletion cannot be undone." %>
+<% comments_count_label = t("posts.show.comments_count_label", count: comments_count, localized_count: localized_number(comments_count), default: "#{localized_number(comments_count)} comments") %>
+<% more_actions_label = t("posts.show.more_actions", default: "More actions") %>
+<% owner_action_heading = t("posts.show.owner_actions", default: "Owner actions") %>
+<% danger_zone_label = t("posts.show.danger_zone", default: "Danger zone") %>
+<% danger_zone_lead = t("posts.show.danger_zone_lead", default: "Post deletion cannot be undone.") %>
+<% value_summary = truncate(@post.description.to_s.squish, length: 170) %>
+<% comment_required_label = t("posts.show.comments.required", default: "Required") %>
+<% comment_optional_label = t("posts.show.comments.optional", default: "Optional") %>
 
 <article class="space-y-content">
   <header class="space-y-4">
@@ -40,51 +43,8 @@
       <%= t("posts.show.posted_by") %>
       <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
     </p>
-
-    <div class="hidden sm:block">
-      <div class="relative flex flex-wrap items-center gap-2" data-desktop-post-actions-root>
-        <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-primary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like_primary" } do %>
-          <span class="inline-flex items-center gap-1.5">
-            <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.like") %></span>
-          </span>
-        <% end %>
-
-        <button type="button" data-desktop-post-actions-toggle aria-expanded="false" aria-controls="desktop-post-actions-menu" class="tap-target cta-secondary">
-          <span class="inline-flex items-center gap-1.5">
-            <%= ui_icon(:ellipsis_horizontal, class_name: "h-4 w-4") %>
-            <span><%= more_actions_label %></span>
-          </span>
-        </button>
-
-        <div id="desktop-post-actions-menu" data-desktop-post-actions-menu class="absolute left-0 top-full z-20 mt-2 hidden min-w-64 rounded-xl border border-slate-300 bg-white p-2 shadow-2xl ring-1 ring-slate-900/5">
-          <div class="grid gap-1">
-            <button type="button" data-desktop-actions-menu-item data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share") %></span>
-            </button>
-            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x_menu" } do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_x") %></span>
-            <% end %>
-            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads_menu" } do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_threads") %></span>
-            <% end %>
-            <button type="button" data-desktop-actions-menu-item data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
-            </button>
-            <% unless post_owner?(@post) %>
-              <button type="button" data-desktop-actions-menu-item data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report_menu" class="tap-target cta-warning cta-compact justify-start">
-                <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-                <span><%= t("posts.show.actions.report") %></span>
-              </button>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
+    <p class="ds-text-body ds-break-words max-w-3xl"><%= value_summary %></p>
+    <a href="#comments" class="tap-target cta-tertiary cta-compact"><%= t("posts.show.comments.title") %></a>
   </header>
 
   <div class="ds-media-frame ds-media-frame-main ds-media-skeleton" data-media-skeleton>
@@ -104,6 +64,56 @@
         <% end %>
       </div>
     <% end %>
+  </section>
+
+  <section class="ds-section-card hidden space-y-3 sm:block">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <h2 class="ds-heading-sm text-slate-900"><%= t("posts.show.actions.title", default: "Actions") %></h2>
+      <p class="ds-text-meta"><%= t("posts.show.actions.lead", default: "Like is primary. Share, copy, and report are in More actions.") %></p>
+    </div>
+
+    <div class="relative flex flex-wrap items-center gap-2" data-desktop-post-actions-root>
+      <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-primary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like_primary" } do %>
+        <span class="inline-flex items-center gap-1.5">
+          <%= ui_icon(:heart, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.actions.like") %></span>
+        </span>
+      <% end %>
+
+      <button type="button" data-desktop-post-actions-toggle aria-expanded="false" aria-controls="desktop-post-actions-menu" class="tap-target cta-secondary">
+        <span class="inline-flex items-center gap-1.5">
+          <%= ui_icon(:ellipsis_horizontal, class_name: "h-4 w-4") %>
+          <span><%= more_actions_label %></span>
+        </span>
+      </button>
+
+      <div id="desktop-post-actions-menu" data-desktop-post-actions-menu class="absolute left-0 top-full z-20 mt-2 hidden min-w-64 rounded-xl border border-slate-300 bg-white p-2 shadow-2xl ring-1 ring-slate-900/5">
+        <div class="grid gap-1">
+          <button type="button" data-desktop-actions-menu-item data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+            <%= ui_icon(:share, class_name: "h-4 w-4") %>
+            <span><%= t("posts.show.actions.share") %></span>
+          </button>
+          <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x_menu" } do %>
+            <%= ui_icon(:share, class_name: "h-4 w-4") %>
+            <span><%= t("posts.show.actions.share_x") %></span>
+          <% end %>
+          <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads_menu" } do %>
+            <%= ui_icon(:share, class_name: "h-4 w-4") %>
+            <span><%= t("posts.show.actions.share_threads") %></span>
+          <% end %>
+          <button type="button" data-desktop-actions-menu-item data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+            <%= ui_icon(:share, class_name: "h-4 w-4") %>
+            <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
+          </button>
+          <% unless post_owner?(@post) %>
+            <button type="button" data-desktop-actions-menu-item data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report_menu" class="tap-target cta-warning cta-compact justify-start">
+              <%= ui_icon(:flag, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.report") %></span>
+            </button>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </section>
 
   <section class="ds-section-card space-y-4">
@@ -227,17 +237,20 @@
       </div>
     <% end %>
 
-    <div class="ds-anchor-offset border-t border-slate-200 pt-4" id="comment-form">
+    <div class="ds-anchor-offset border-t border-slate-200 pt-4" id="comment-form" data-comment-form-root>
       <% if @reply_to_comment.present? %>
-        <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
-          <%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %>
-          <%= link_to t("posts.show.comments.cancel"), post_path(@post, anchor: "comments"), class: "ml-2 text-blue-600 underline" %>
+        <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800" data-reply-context>
+          <p>
+            <%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %>
+            <%= link_to t("posts.show.comments.cancel"), post_path(@post, anchor: "comments"), class: "ml-2 text-blue-600 underline" %>
+          </p>
+          <p class="mt-1 text-xs text-blue-700 ds-break-words"><%= truncate(@reply_to_comment.body.to_s.squish, length: 100) %></p>
         </div>
       <% end %>
 
       <%= form_with model: [@post, @comment], class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
         <% if @comment.errors.any? %>
-          <div class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700" role="alert">
+          <div id="comment-error-summary" class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700" role="alert" tabindex="-1">
             <p class="mb-2 font-semibold"><%= t("posts.form.error_summary", default: "Please fix the following errors.") %></p>
             <ul class="list-disc pl-5">
               <% @comment.errors.full_messages.each do |message| %>
@@ -249,28 +262,39 @@
 
         <% if owned_users.any? %>
           <div>
-            <%= f.label :user_id, t("posts.show.comments.comment_as_profile"), class: "mb-1 block text-sm font-medium" %>
-            <%= f.collection_select :user_id, owned_users, :id, :name, { include_blank: t("posts.show.comments.post_as_guest") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+            <%= f.label :user_id, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
+              <span><%= t("posts.show.comments.comment_as_profile") %></span>
+              <span class="ds-badge-info"><%= comment_optional_label %></span>
+            <% end %>
+            <%= f.collection_select :user_id, owned_users, :id, :name, { include_blank: t("posts.show.comments.post_as_guest") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { comment_input: "user_id" } %>
+            <p class="mt-1 ds-text-muted"><%= t("posts.show.comments.profile_help", default: "Optional: choose a profile, or post as guest.") %></p>
           </div>
         <% end %>
 
         <%= f.hidden_field :parent_comment_id, value: @reply_to_comment&.id %>
 
         <div>
-          <%= f.label :author_name, t("posts.show.comments.name"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.text_field :author_name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+          <%= f.label :author_name, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
+            <span><%= t("posts.show.comments.name") %></span>
+            <span class="ds-badge-active"><%= comment_required_label %></span>
+          <% end %>
+          <%= f.text_field :author_name, required: true, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.comments.name_example", default: "Example: Alex"), data: { comment_input: "author_name" } %>
         </div>
 
         <div>
-          <%= f.label :body, t("posts.show.comments.comment"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.text_area :body, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm" %>
+          <%= f.label :body, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
+            <span><%= t("posts.show.comments.comment") %></span>
+            <span class="ds-badge-active"><%= comment_required_label %></span>
+          <% end %>
+          <%= f.text_area :body, rows: 4, required: true, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm ds-break-words", placeholder: t("posts.show.comments.body_example", default: "What part of this setup stood out to you?"), data: { comment_input: "body" } %>
+          <p class="mt-1 ds-text-muted"><%= t("posts.show.comments.body_help", default: "Tip: include one concrete point to get a better reply.") %></p>
         </div>
 
         <% if recaptcha_enabled? %>
-          <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>"></div>
+          <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>" data-recaptcha-shell></div>
         <% end %>
 
-        <%= f.button type: :submit, class: "tap-target cta-primary" do %>
+        <%= f.button type: :submit, class: "tap-target cta-primary", data: { ga_event: "comment_submit_click", ga_category: "comments", ga_label: (@reply_to_comment.present? ? "reply_submit" : "root_submit") } do %>
           <span class="inline-flex items-center gap-1.5">
             <%= ui_icon(:chat, class_name: "h-4 w-4") %>
             <span><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span>
@@ -385,12 +409,12 @@
   <% end %>
 
   <div class="space-y-2">
-    <p class="ad-slot-divider"><%= I18n.locale.to_s == "ja" ? "関連スポンサー枠" : "Sponsored placement" %></p>
+    <p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p>
     <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
   </div>
 
   <div class="space-y-2">
-    <p class="ad-slot-divider"><%= I18n.locale.to_s == "ja" ? "関連スポンサー枠" : "Sponsored placement" %></p>
+    <p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p>
     <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %>
   </div>
 </article>
@@ -402,6 +426,7 @@
     const mobileMenuOpenMessage = "<%= j(mobile_menu_open_label) %>";
     const mobileMenuCloseMessage = "<%= j(mobile_menu_close_label) %>";
     let lastModalTrigger = null;
+    let commentFormStarted = false;
 
     const markLoadedMedia = (scope = document) => {
       scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
@@ -499,12 +524,21 @@
       const root = document.querySelector("[data-mobile-actions-root]");
       const menu = document.querySelector("[data-mobile-actions-menu]");
       const modal = document.querySelector("[data-report-modal][open]");
-      const commentForm = document.querySelector("#comment-form form");
+      const commentFormRoot = document.querySelector("[data-comment-form-root]");
+      const commentForm = commentFormRoot ? commentFormRoot.querySelector("form") : null;
+      const recaptchaShell = commentFormRoot ? commentFormRoot.querySelector("[data-recaptcha-shell]") : null;
       if (!root) return;
 
       const focusedOnComment = commentForm ? commentForm.contains(document.activeElement) : false;
+      const replyMode = Boolean(commentFormRoot && commentFormRoot.querySelector("[data-reply-context]"));
+      const recaptchaFocused = recaptchaShell ? recaptchaShell.contains(document.activeElement) : false;
+      const recaptchaVisible = (() => {
+        if (!recaptchaShell) return false;
+        const rect = recaptchaShell.getBoundingClientRect();
+        return rect.top < window.innerHeight && rect.bottom > 0;
+      })();
       const menuOpen = menu && !menu.classList.contains("hidden");
-      const shouldHide = focusedOnComment || keyboardOpen() || Boolean(modal);
+      const shouldHide = focusedOnComment || keyboardOpen() || Boolean(modal) || replyMode || recaptchaFocused || recaptchaVisible;
 
       root.classList.toggle("translate-y-full", shouldHide);
       root.classList.toggle("opacity-0", shouldHide);
@@ -607,8 +641,31 @@
       if (activeDialog) closeModal(activeDialog);
     });
 
-    document.addEventListener("focusin", syncMobileActionBar, true);
+    document.addEventListener("focusin", (event) => {
+      syncMobileActionBar();
+      const form = event.target.closest("#comment-form form");
+      if (!form || commentFormStarted || typeof window.gtag !== "function") return;
+
+      commentFormStarted = true;
+      window.gtag("event", "comment_form_start", {
+        event_category: "comments",
+        event_label: document.querySelector("[data-reply-context]") ? "reply_mode" : "new_comment"
+      });
+    }, true);
     document.addEventListener("focusout", () => window.setTimeout(syncMobileActionBar, 0), true);
+    document.addEventListener("submit", (event) => {
+      const form = event.target.closest("#comment-form form");
+      if (!form || typeof window.gtag !== "function") return;
+
+      const hasProfile = ((form.querySelector("[name='comment[user_id]']")?.value || "").trim().length > 0);
+      const bodyLength = (form.querySelector("[name='comment[body]']")?.value || "").trim().length;
+      window.gtag("event", "comment_submit_attempt", {
+        event_category: "comments",
+        event_label: document.querySelector("[data-reply-context]") ? "reply_mode" : "new_comment",
+        has_profile: hasProfile,
+        body_length: bodyLength
+      });
+    });
     window.addEventListener("resize", syncMobileActionBar);
     if (window.visualViewport) {
       window.visualViewport.addEventListener("resize", syncMobileActionBar);

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -145,6 +145,21 @@
   - Hypothesis
   - Affected KPI(s)
   - Expected direction and guardrail metric
+- Ship in small batches:
+  - One UX change should map to one primary KPI.
+  - Keep each rollout independently reversible.
+  - Compare against a 7-day baseline before the next batch.
+
+## UX Polish Mapping
+- Search hierarchy and filter contrast:
+  - KPI: search submit-to-result CTR
+  - Guardrail: filter abandonment rate
+- Detail first-view value emphasis:
+  - KPI: detail-to-comment scroll reach rate
+  - Guardrail: bounce rate on detail page
+- Comment form simplification and reply context:
+  - KPI: comment completion rate
+  - Guardrail: comment error re-submit rate
 
 ## Design Audit Workflow
 - Pull requests that modify UI must complete a design-system checklist in the PR template.


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/67

## 目的

  - UX Polish Roadmap の12項目を、既存デザインシステムを崩さずに実装し、一覧→詳細→コメント投稿の導線品質を上げる。

  ## 実装内容

  - [x] 検索エリア階層の明確化（Quick searchをモバイルで上段固定、詳細フィルターを折りたたみ時に低コントラスト化）
  - [x] ヒーローCTA競合の解消（Primaryを検索1つに固定、投稿作成は低強調リンク化）
  - [x] 一覧カードメタ情報の視線移動短縮（メタを2段に固定）
  - [x] タグ表示を意味優先化（prioritized_post_tags でカテゴリ/検索/選択タグ優先）
  - [x] 詳細のファーストビュー価値訴求（要約をタイトル直下、補助アクションを本文下へ移動）
  - [x] コメント入力離脱低減（必須/任意表示、入力例、エラーサマリー強化）
  - [x] 返信UI文脈強化（返信先の1行抜粋＋キャンセル導線を同視線上に配置）
  - [x] 空状態の次アクション整理（一覧空状態文言を「最初の一手」へ統一）
  - [x] 補助テキストのコントラスト改善（トークン値を1段階引き上げ）
  - [x] モバイル固定バー干渉再検証実装（キーボード/返信/reCAPTCHA/モーダル条件を統合）
  - [x] 日本語折り返し耐性調整（ds-break-words と既存 clamp 運用を該当箇所へ適用）
  - [x] KPI仮説と小刻み改善運用（ドキュメント追記＋コメント導線計測イベント追加）

  ## 方法

  - ERBの情報階層とCTA優先度を再配置。
  - ヘルパーでタグ優先度ロジックを実装。
  - CSSトークンとユーティリティを追加して視認性と状態差を調整。
  - JSでモバイル固定バー表示条件を画面状態ベースに統一。
  - KPI運用ルールを docs に追加し、コメント開始/送信試行を計測。

  ## 変更箇所

  - app/views/posts/index.html.erb:39
  - app/views/posts/show.html.erb:20
  - app/views/layouts/application.html.erb:71
  - app/helpers/application_helper.rb:185
  - app/assets/tailwind/application.css:19
  - docs/design_system.md:148

  ## まとめ

  - Roadmapの12項目は実装済みです。
  - 併せて、以前問題化していたUTF-8起因の不安定要素を避けるため、該当変更ファイルはUTF-8妥当性も確認済みです。

  ## Testing

  - UTF-8 check（対象変更ファイル）: OK
  - bundle exec ruby bin/rails tailwindcss:build: OK
  - bundle exec brakeman --no-pager --no-exit-on-warn: OK（既知のEOL Ruby警告のみ）
  - bundle exec ruby bin/rails test test/system: OK（0 runs / 0 failures）
  - bundle exec ruby bin/rails test: NG（PostgreSQL localhost:5432 接続不可のため実行継続不可）