### PR TITLE
UX/UI Robustness: Implementation of state UI rules, user onboarding, and experiment base

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] posts/show
 - [ ] layout/header/mobile bar
 - [ ] forms
+- [ ] onboarding/legal
 - [ ] other:
 
 ## Design System Audit
@@ -15,29 +16,37 @@
 - [ ] Card hierarchy follows `Title > Summary > Primary meta > Secondary meta`
 - [ ] Badge semantics are consistent (`active / inactive / informational`)
 - [ ] Empty/zero/error states have a single emphasized next action
+- [ ] Disabled states include explicit reason text
+- [ ] Loading/success/error states use shared UI rules
 - [ ] Focus-visible is clear on all interactive controls
 - [ ] Dynamic UI changes are announced where needed
 - [ ] Mobile tap target size is >=44px
 - [ ] Section/block/component spacing rhythm is preserved
 - [ ] Ads use `ad-slot-surface` and `ad-slot-label` rules
 
-## Required Audit Record
-- CTA count / hierarchy result:
-- Empty / zero state result:
-- Focus-visible result:
-- Mobile interference result:
+## Metrics Hypothesis
+- Primary KPI:
+- Expected direction:
+- Guardrail metric:
+- Event(s) to verify:
 
 ## Accessibility Notes
-- Keyboard flow checked:
-- Screen reader announcement impact:
-- Contrast/state distinction impact:
+- Keyboard flow checked (Tab/Shift+Tab/Esc):
+- Screen reader read order checked:
+- Error-field association checked:
+
+## Required Audit Record
+- CTA count / hierarchy result:
+- Empty / zero / error state result:
+- Loading / disabled reason result:
+- Mobile interference result:
 
 ## Testing
 - [ ] Manual verification on desktop
 - [ ] Manual verification on mobile viewport
+- [ ] Locale switch layout verification (ja/en)
 - [ ] Relevant automated tests updated/passed
 
 ## Screenshots / Recordings
 - Before:
 - After:
-

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -66,16 +66,20 @@
     scroll-behavior: smooth;
   }
 
-  a,
-  button,
   input,
   select,
   textarea {
     transition: box-shadow var(--ds-motion-duration-fast) ease,
                 border-color var(--ds-motion-duration-fast) ease,
                 background-color var(--ds-motion-duration-fast) ease,
-                color var(--ds-motion-duration-fast) ease,
-                transform var(--ds-motion-duration-fast) ease;
+                color var(--ds-motion-duration-fast) ease;
+  }
+
+  a,
+  button {
+    transition: box-shadow var(--ds-motion-duration-fast) ease,
+                background-color var(--ds-motion-duration-fast) ease,
+                color var(--ds-motion-duration-fast) ease;
   }
 
   a:focus-visible,
@@ -214,6 +218,21 @@
     @apply rounded-xl border border-slate-200 bg-white;
   }
 
+  .ds-card-interactive {
+    cursor: pointer;
+    outline: none;
+  }
+
+  .ds-card-interactive:hover {
+    border-color: rgb(148 163 184);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.09);
+  }
+
+  .ds-card-interactive:focus-visible {
+    box-shadow: var(--ds-focus-ring-shadow), 0 8px 24px rgba(15, 23, 42, 0.09);
+    border-color: rgb(59 130 246);
+  }
+
   .ds-badge {
     @apply inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs font-medium text-slate-600;
   }
@@ -324,6 +343,26 @@
     box-shadow: var(--ds-focus-ring-shadow);
   }
 
+  .cta-primary:disabled,
+  .cta-secondary:disabled,
+  .cta-tertiary:disabled,
+  .cta-warning:disabled,
+  .cta-danger:disabled,
+  .ds-button-disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+    transform: none !important;
+  }
+
+  .cta-primary:active,
+  .cta-secondary:active,
+  .cta-tertiary:active,
+  .cta-warning:active,
+  .cta-danger:active,
+  .ds-tap-active {
+    transform: scale(0.98);
+  }
+
   .mobile-sticky-bar {
     @apply fixed inset-x-0 bottom-0 z-50 border-t border-slate-200 bg-white/95 backdrop-blur;
     box-shadow: 0 -10px 24px rgba(15, 23, 42, 0.08);
@@ -331,15 +370,15 @@
   }
 
   .ad-slot-surface {
-    @apply rounded-xl border border-slate-200 bg-slate-50/70 px-4 py-4 sm:px-5 sm:py-5;
+    @apply rounded-xl border border-slate-300 bg-slate-50/75 px-4 py-5 sm:px-5 sm:py-5;
   }
 
   .ad-slot-label {
-    @apply mb-2 text-center text-[11px] font-semibold uppercase tracking-wide text-slate-500;
+    @apply mb-2 inline-flex items-center rounded-full border border-slate-300 bg-white px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-600;
   }
 
   .ad-slot-divider {
-    @apply mb-2 text-center text-xs font-medium text-slate-500;
+    @apply mb-2 text-center text-xs font-semibold text-slate-600;
   }
 
   .lang-ja .ds-reading-column {
@@ -385,6 +424,146 @@
     @apply border-slate-300 bg-white text-slate-800;
   }
 
+  .ds-char-counter {
+    @apply mt-1 text-xs text-slate-500;
+  }
+
+  .ds-char-counter-warning {
+    @apply font-semibold text-amber-700;
+  }
+
+  .ds-char-counter-error {
+    @apply font-semibold text-red-700;
+  }
+
+  .ds-disabled-reason {
+    @apply min-h-5 text-xs font-medium text-slate-600;
+  }
+
+  .ds-field-guide {
+    @apply mt-1 text-xs leading-5 text-slate-500;
+  }
+
+  .ds-loading-shell {
+    position: relative;
+  }
+
+  .ds-form-submitting {
+    opacity: 0.92;
+  }
+
+  .ds-skeleton-line,
+  .ds-skeleton-block {
+    @apply rounded bg-slate-200;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .ds-skeleton-line::after,
+  .ds-skeleton-block::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(110deg, transparent 20%, var(--ds-skeleton-shimmer) 45%, transparent 70%);
+    transform: translateX(-100%);
+    animation: ds-skeleton-shimmer 1.35s infinite linear;
+  }
+
+  .ds-skeleton-line {
+    height: 0.75rem;
+  }
+
+  .ds-skeleton-block {
+    height: 100%;
+    min-height: 7rem;
+  }
+
+  .ds-loading-inline {
+    @apply inline-flex items-center gap-1.5 text-xs font-semibold text-slate-600;
+  }
+
+  .ds-loading-dot {
+    @apply h-1.5 w-1.5 rounded-full bg-slate-400;
+    animation: ds-loading-pulse 950ms infinite ease-in-out;
+  }
+
+  .ds-loading-dot:nth-child(2) {
+    animation-delay: 120ms;
+  }
+
+  .ds-loading-dot:nth-child(3) {
+    animation-delay: 220ms;
+  }
+
+  .ds-image-fallback {
+    @apply absolute inset-0 flex flex-col items-center justify-center gap-2 bg-slate-900/58 px-3 text-center text-xs font-medium text-white;
+  }
+
+  .ds-image-fallback button {
+    @apply rounded-md border border-white/80 bg-white/10 px-2.5 py-1 text-xs font-semibold text-white hover:bg-white/20;
+  }
+
+  .ds-thumbnail-crop {
+    object-position: 50% 36%;
+  }
+
+  .ds-legal-links {
+    @apply flex flex-wrap items-center gap-3 text-xs text-slate-600;
+  }
+
+  .ds-legal-links a {
+    @apply underline decoration-slate-300 underline-offset-2 hover:text-slate-900;
+  }
+
+  .ds-trust-note {
+    @apply rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-900;
+  }
+
+  .ds-thread-root {
+    @apply relative rounded-xl border border-slate-200 bg-white p-4 shadow-sm;
+  }
+
+  .ds-thread-reply-wrap {
+    @apply mt-4 space-y-2 border-l-2 border-slate-200 pl-3;
+  }
+
+  .ds-thread-reply {
+    @apply rounded-md border border-slate-200 bg-slate-50 px-3 py-2;
+  }
+
+  .ds-reply-target-highlight {
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+    border-color: rgb(96 165 250);
+  }
+
+  .ds-cta-experiment[data-variant="control"] {
+    --ds-cta-accent: rgb(37 99 235);
+  }
+
+  .ds-cta-experiment[data-variant="high-contrast"] {
+    --ds-cta-accent: rgb(2 132 199);
+  }
+
+  .ds-cta-experiment[data-variant="compact"] {
+    --ds-cta-accent: rgb(29 78 216);
+  }
+
+  .ds-cta-experiment.cta-primary {
+    background-color: var(--ds-cta-accent);
+  }
+
+  [data-page-skeleton] {
+    display: none;
+  }
+
+  html.ds-page-loading [data-page-content] {
+    display: none !important;
+  }
+
+  html.ds-page-loading [data-page-skeleton] {
+    display: block;
+  }
+
   @keyframes ds-toast-in {
     from {
       opacity: 0;
@@ -399,6 +578,17 @@
   @keyframes ds-skeleton-shimmer {
     to {
       transform: translateX(100%);
+    }
+  }
+
+  @keyframes ds-loading-pulse {
+    0%, 80%, 100% {
+      opacity: 0.35;
+      transform: scale(0.8);
+    }
+    40% {
+      opacity: 1;
+      transform: scale(1);
     }
   }
 
@@ -420,7 +610,10 @@
 
   @media (prefers-reduced-motion: reduce) {
     .ds-toast,
-    .ds-media-skeleton::after {
+    .ds-media-skeleton::after,
+    .ds-skeleton-line::after,
+    .ds-skeleton-block::after,
+    .ds-loading-dot {
       animation: none !important;
     }
   }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,4 +7,7 @@ class PagesController < ApplicationController
 
   def cookie
   end
+
+  def onboarding
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,6 +9,10 @@ class PostsController < ApplicationController
   def index
     @posts = Post.visible.includes(:user, :items, desk_image_attachment: :blob).filtered(params)
     @categories = Post.visible.where.not(category: [ nil, "" ]).distinct.order(:category).pluck(:category)
+    @popular_tags = Post.visible.where.not(tag_list: [ nil, "" ]).pluck(:tag_list).flat_map { |list|
+      list.to_s.split(",").map(&:strip)
+    }.reject(&:blank?).tally.sort_by { |(_, count)| -count }.map(&:first).first(8)
+    @recent_posts = Post.visible.latest.limit(4)
   end
 
   def show
@@ -18,6 +22,7 @@ class PostsController < ApplicationController
     @comment = @post.comments.new(parent_comment: @reply_to_comment)
     @report = @post.reports.new
     @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
+    @back_to_index_path = sanitize_internal_back_path(params[:from])
   end
 
   def new
@@ -172,6 +177,20 @@ class PostsController < ApplicationController
     return @owned_users.first if selected_id.zero?
 
     @owned_users.find { |user| user.id == selected_id }
+  end
+
+  def sanitize_internal_back_path(raw_path)
+    value = raw_path.to_s
+    return if value.blank?
+    return unless value.start_with?("/")
+    return if value.start_with?("//")
+
+    uri = URI.parse(value)
+    return unless uri.host.nil? && uri.scheme.nil?
+
+    value
+  rescue URI::InvalidURIError
+    nil
   end
 
   def assign_owner_token(post)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,7 +19,7 @@ class ReportsController < ApplicationController
         redirect_to post_path(@post), notice: t("reports.flash.thanks")
       end
     else
-      redirect_to post_path(@post), alert: report.errors.full_messages.to_sentence
+      redirect_to post_path(@post), alert: t("reports.flash.submit_failed", default: "Report could not be submitted. Please retry.")
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -152,6 +152,10 @@ module ApplicationHelper
   end
 
   def optimized_post_image_tag(post, variant: :thumbnail, **options)
+    class_names = [ options[:class] ]
+    class_names << "ds-thumbnail-crop" if variant.to_sym == :thumbnail
+    options[:class] = class_names.compact.join(" ")
+
     image_tag(
       optimized_post_image_source(post, variant: variant),
       **default_image_tag_options(post, variant).merge(options)
@@ -176,6 +180,33 @@ module ApplicationHelper
 
   def localized_number(value)
     number_with_delimiter(value, locale: I18n.locale)
+  end
+
+  def formatted_date(value)
+    return "" if value.blank?
+
+    l(value.to_date, format: :default)
+  end
+
+  def formatted_datetime(value)
+    return "" if value.blank?
+
+    l(value, format: :short)
+  end
+
+  def timestamp_tag(value, style: :datetime, include_relative: false)
+    return "" if value.blank?
+
+    label = style == :date ? formatted_date(value) : formatted_datetime(value)
+    aria_label = if include_relative
+      distance = distance_of_time_in_words(value, Time.current)
+      relative = t("time.relative_ago", distance: distance, default: "#{distance} ago")
+      "#{label} (#{relative})"
+    else
+      label
+    end
+
+    content_tag(:time, label, datetime: value.to_time.iso8601, title: aria_label, "aria-label": aria_label)
   end
 
   def flash_visual(type)
@@ -425,11 +456,13 @@ module ApplicationHelper
 
   def default_image_tag_options(post, variant)
     width, height = POST_IMAGE_DIMENSIONS.fetch(variant, POST_IMAGE_DIMENSIONS[:main])
+    fallback_url = asset_path(FALLBACK_POST_IMAGE)
     base = {
       alt: post&.title.presence || t("images.desk_alt"),
       decoding: "async",
       width: width,
-      height: height
+      height: height,
+      data: { fallback_src: fallback_url }
     }
 
     if variant == :thumbnail

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "ui_state"

--- a/app/javascript/ui_state.js
+++ b/app/javascript/ui_state.js
@@ -1,0 +1,334 @@
+const UI_STATE_GUARD = "__deskTourUiStateInstalled";
+
+const INTERACTIVE_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "label",
+  "summary",
+  "[role='button']",
+  "[data-card-stop]",
+  "[data-open-report-modal]",
+  "[data-close-report-modal]",
+  "[data-copy-url]"
+].join(", ");
+
+const isBlank = (value) => value == null || String(value).trim().length === 0;
+
+const controlLabel = (field, form) => {
+  if (!field) return "";
+
+  const id = field.getAttribute("id");
+  if (id) {
+    const byFor = form.querySelector(`label[for='${id}']`);
+    if (byFor) return byFor.textContent.replace(/\s+/g, " ").trim();
+  }
+
+  const wrapperLabel = field.closest("label");
+  if (wrapperLabel) return wrapperLabel.textContent.replace(/\s+/g, " ").trim();
+
+  return field.getAttribute("name") || field.getAttribute("aria-label") || "field";
+};
+
+const bindCardNavigation = (scope = document) => {
+  scope.querySelectorAll("[data-card-href]").forEach((card) => {
+    if (card.dataset.cardNavigationBound === "1") return;
+    card.dataset.cardNavigationBound = "1";
+
+    if (!card.hasAttribute("tabindex")) card.setAttribute("tabindex", "0");
+    if (!card.hasAttribute("role")) card.setAttribute("role", "link");
+
+    const navigateToCard = () => {
+      const href = card.dataset.cardHref;
+      if (!href) return;
+      window.location.assign(href);
+    };
+
+    card.addEventListener("click", (event) => {
+      if (event.defaultPrevented) return;
+      if (event.target.closest(INTERACTIVE_SELECTOR)) return;
+      if (window.getSelection && String(window.getSelection()).trim().length > 0) return;
+      navigateToCard();
+    });
+
+    card.addEventListener("keydown", (event) => {
+      if (event.target !== card) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      navigateToCard();
+    });
+  });
+};
+
+const updateCharCounter = (field) => {
+  const max = Number(field.dataset.charCountMax || field.getAttribute("maxlength") || "0");
+  if (!Number.isFinite(max) || max <= 0) return;
+
+  const current = String(field.value || "").length;
+  const counterId = field.dataset.charCountTarget;
+  const counter = counterId ? document.getElementById(counterId) : null;
+  if (!counter) return;
+
+  counter.textContent = `${current} / ${max}`;
+  counter.classList.toggle("ds-char-counter-warning", current >= Math.floor(max * 0.85) && current <= max);
+  counter.classList.toggle("ds-char-counter-error", current > max);
+};
+
+const bindCharCounters = (scope = document) => {
+  scope.querySelectorAll("[data-char-count-max], [maxlength]").forEach((field) => {
+    if (field.dataset.charCounterBound === "1") {
+      updateCharCounter(field);
+      return;
+    }
+
+    field.dataset.charCounterBound = "1";
+    updateCharCounter(field);
+    field.addEventListener("input", () => updateCharCounter(field));
+    field.addEventListener("change", () => updateCharCounter(field));
+  });
+};
+
+const requiredFieldBlank = (field) => {
+  if (field.disabled) return false;
+
+  if (field.type === "checkbox" || field.type === "radio") {
+    if (!field.name) return !field.checked;
+    const group = field.form ? field.form.querySelectorAll(`[name='${field.name}']`) : [ field ];
+    return !Array.from(group).some((input) => input.checked);
+  }
+
+  return isBlank(field.value);
+};
+
+const updateFormState = (form) => {
+  const reasonNode = form.querySelector("[data-disabled-reason]");
+  const submitButtons = Array.from(form.querySelectorAll("button[type='submit'], input[type='submit']"));
+  const requiredFields = Array.from(form.querySelectorAll("[required]"));
+
+  const missingLabels = requiredFields
+    .filter(requiredFieldBlank)
+    .map((field) => controlLabel(field, form))
+    .filter((label) => label.length > 0)
+    .filter((label, index, list) => list.indexOf(label) === index);
+
+  const blocked = missingLabels.length > 0 || form.dataset.uiSubmitting === "true";
+
+  submitButtons.forEach((button) => {
+    button.disabled = blocked;
+    button.classList.toggle("ds-button-disabled", blocked);
+    button.setAttribute("aria-disabled", String(blocked));
+  });
+
+  if (!reasonNode) return;
+
+  if (form.dataset.uiSubmitting === "true") {
+    reasonNode.textContent = form.dataset.submittingReason || "Processing...";
+    return;
+  }
+
+  if (missingLabels.length > 0) {
+    const preview = missingLabels.slice(0, 3).join(", ");
+    const suffix = missingLabels.length > 3 ? "..." : "";
+    reasonNode.textContent = `${form.dataset.disabledReasonPrefix || "Complete required fields"}: ${preview}${suffix}`;
+  } else {
+    reasonNode.textContent = "";
+  }
+};
+
+const bindFormState = (scope = document) => {
+  scope.querySelectorAll("form[data-ui-form]").forEach((form) => {
+    if (form.dataset.uiFormBound === "1") {
+      updateFormState(form);
+      return;
+    }
+
+    form.dataset.uiFormBound = "1";
+
+    form.addEventListener("input", () => updateFormState(form));
+    form.addEventListener("change", () => updateFormState(form));
+
+    form.addEventListener("submit", (event) => {
+      updateFormState(form);
+      const submitButtons = Array.from(form.querySelectorAll("button[type='submit'], input[type='submit']"));
+      const blocked = submitButtons.some((button) => button.disabled);
+      if (blocked) {
+        event.preventDefault();
+        if (typeof window.dsNotify === "function") {
+          window.dsNotify(form.dataset.disabledSubmitNotice || "Please complete required fields.", "error");
+        }
+        return;
+      }
+
+      form.dataset.uiSubmitting = "true";
+      form.setAttribute("aria-busy", "true");
+      form.classList.add("ds-form-submitting");
+
+      const submitText = form.dataset.loadingLabel || "Processing...";
+      submitButtons.forEach((button) => {
+        if (!button.dataset.originalLabel) {
+          button.dataset.originalLabel = button.textContent.trim();
+        }
+
+        const labelNode = button.querySelector("[data-submit-label]");
+        if (labelNode) {
+          labelNode.textContent = submitText;
+        } else if (button.tagName === "BUTTON") {
+          button.textContent = submitText;
+        } else {
+          button.value = submitText;
+        }
+
+        button.disabled = true;
+      });
+
+      updateFormState(form);
+    });
+
+    updateFormState(form);
+  });
+};
+
+const renderImageFallback = (image, reason = "error") => {
+  if (!image) return;
+
+  const shell = image.closest("[data-image-shell]");
+  if (!shell) return;
+
+  const fallbackSrc = image.dataset.fallbackSrc;
+  if (isBlank(fallbackSrc)) return;
+
+  if (image.dataset.originalSrc == null) {
+    image.dataset.originalSrc = image.getAttribute("src") || "";
+  }
+
+  if (reason === "error" && image.dataset.fallbackApplied !== "1") {
+    image.dataset.fallbackApplied = "1";
+    image.src = fallbackSrc;
+  }
+
+  const fallbackNode = shell.querySelector("[data-image-fallback]");
+  if (fallbackNode) fallbackNode.classList.remove("hidden");
+};
+
+const bindImageFallback = (scope = document) => {
+  scope.querySelectorAll("img[data-fallback-src]").forEach((image) => {
+    if (image.dataset.fallbackBound === "1") return;
+    image.dataset.fallbackBound = "1";
+
+    image.addEventListener("error", () => {
+      renderImageFallback(image, "error");
+    });
+  });
+
+  scope.querySelectorAll("[data-image-retry]").forEach((button) => {
+    if (button.dataset.imageRetryBound === "1") return;
+    button.dataset.imageRetryBound = "1";
+
+    button.addEventListener("click", () => {
+      const shell = button.closest("[data-image-shell]");
+      const image = shell ? shell.querySelector("img[data-fallback-src]") : null;
+      if (!image) return;
+
+      const originalSrc = image.dataset.originalSrc || "";
+      if (isBlank(originalSrc)) return;
+
+      image.dataset.fallbackApplied = "0";
+      image.src = `${originalSrc}${originalSrc.includes("?") ? "&" : "?"}retry=${Date.now()}`;
+
+      const fallbackNode = shell.querySelector("[data-image-fallback]");
+      if (fallbackNode) fallbackNode.classList.add("hidden");
+    });
+  });
+};
+
+const bindLoadingSkeleton = (scope = document) => {
+  scope.querySelectorAll("[data-loading-state]").forEach((container) => {
+    if (container.dataset.loadingStateBound === "1") return;
+    container.dataset.loadingStateBound = "1";
+
+    const skeleton = container.querySelector("[data-loading-skeleton]");
+    const content = container.querySelector("[data-loading-content]");
+    if (!skeleton || !content) return;
+
+    container.addEventListener("ds:loading:start", () => {
+      skeleton.classList.remove("hidden");
+      content.classList.add("hidden");
+      container.setAttribute("aria-busy", "true");
+    });
+
+    container.addEventListener("ds:loading:stop", () => {
+      skeleton.classList.add("hidden");
+      content.classList.remove("hidden");
+      container.removeAttribute("aria-busy");
+    });
+  });
+};
+
+const bindTapFeedback = () => {
+  const selector = ".cta-primary, .cta-secondary, .cta-tertiary, .cta-warning, .cta-danger, [data-tap-feedback]";
+
+  const activate = (event) => {
+    const target = event.target.closest(selector);
+    if (!target) return;
+    target.classList.add("ds-tap-active");
+  };
+
+  const deactivate = () => {
+    document.querySelectorAll(".ds-tap-active").forEach((node) => node.classList.remove("ds-tap-active"));
+  };
+
+  document.addEventListener("pointerdown", activate, { passive: true });
+  document.addEventListener("pointerup", deactivate, { passive: true });
+  document.addEventListener("pointercancel", deactivate, { passive: true });
+  document.addEventListener("touchend", deactivate, { passive: true });
+};
+
+const showFlashToasts = (scope = document) => {
+  const flashNodes = scope.querySelectorAll("[data-flash-message]");
+  if (flashNodes.length === 0) return;
+
+  flashNodes.forEach((node) => {
+    if (node.dataset.toastDisplayed === "1") return;
+    node.dataset.toastDisplayed = "1";
+
+    const message = node.dataset.flashMessage;
+    const level = node.dataset.flashLevel || "info";
+    if (typeof window.dsNotify === "function") {
+      window.setTimeout(() => window.dsNotify(message, level), 90);
+    }
+  });
+};
+
+const initializeUiState = (scope = document) => {
+  bindCardNavigation(scope);
+  bindCharCounters(scope);
+  bindFormState(scope);
+  bindImageFallback(scope);
+  bindLoadingSkeleton(scope);
+  showFlashToasts(scope);
+};
+
+if (!window[UI_STATE_GUARD]) {
+  window[UI_STATE_GUARD] = true;
+
+  bindTapFeedback();
+
+  document.addEventListener("turbo:before-fetch-request", () => {
+    document.documentElement.classList.add("ds-page-loading");
+  });
+
+  document.addEventListener("turbo:fetch-request-error", () => {
+    document.documentElement.classList.remove("ds-page-loading");
+  });
+
+  document.addEventListener("turbo:load", () => {
+    document.documentElement.classList.remove("ds-page-loading");
+    initializeUiState(document);
+  });
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initializeUiState(document);
+  });
+}

--- a/app/mailers/comment_reply_mailer.rb
+++ b/app/mailers/comment_reply_mailer.rb
@@ -9,7 +9,7 @@ class CommentReplyMailer < ApplicationMailer
 
     mail(
       to: @recipient.email,
-      subject: "【DeskTour Studio】あなたのコメントに返信がありました"
+      subject: I18n.t("mailers.comment_reply.subject", default: "DeskTour Studio: You received a reply")
     )
   end
 end

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -35,7 +35,7 @@
               <td class="px-4 py-3"><%= Report.reason_label(report.reason) %></td>
               <td class="px-4 py-3"><%= report.reporter_user&.name.presence || "Anonymous" %></td>
               <td class="px-4 py-3"><%= truncate(report.details.to_s, length: 120) %></td>
-              <td class="px-4 py-3"><%= l(report.created_at, format: :short) %></td>
+              <td class="px-4 py-3"><%= timestamp_tag(report.created_at, style: :datetime) %></td>
               <td class="px-4 py-3">
                 <div class="flex flex-wrap gap-2">
                   <%= button_to "Restore", restore_post_admin_report_path(report), method: :patch, class: "tap-target cta-secondary cta-compact" %>
@@ -74,7 +74,7 @@
               <td class="px-4 py-3"><%= report.post&.title.presence || "(Deleted post)" %></td>
               <td class="px-4 py-3"><%= Report.reason_label(report.reason) %></td>
               <td class="px-4 py-3"><%= report_status_badge(report.status) %></td>
-              <td class="px-4 py-3"><%= report.reviewed_at.present? ? l(report.reviewed_at, format: :short) : "-" %></td>
+              <td class="px-4 py-3"><%= report.reviewed_at.present? ? timestamp_tag(report.reviewed_at, style: :datetime) : "-" %></td>
             </tr>
           <% end %>
         <% else %>

--- a/app/views/comment_reply_mailer/reply_notification.html.erb
+++ b/app/views/comment_reply_mailer/reply_notification.html.erb
@@ -1,16 +1,15 @@
-<p><%= @recipient.name.presence || "ユーザー" %> さん</p>
+<p><%= @recipient.name.presence || t("mailers.comment_reply.recipient_default", default: "there") %>,</p>
 
-<p>あなたのコメントに返信がありました。</p>
+<p><%= t("mailers.comment_reply.intro", default: "You received a new reply on DeskTour Studio.") %></p>
 
 <ul>
-  <li>投稿: <strong><%= @post.title %></strong></li>
-  <li>あなたのコメント: <%= @parent_comment.body %></li>
-  <li>返信コメント: <%= @reply_comment.body %></li>
+  <li><strong><%= t("mailers.comment_reply.post", default: "Post") %>:</strong> <%= @post.title %></li>
+  <li><strong><%= t("mailers.comment_reply.parent_comment", default: "Your comment") %>:</strong> <%= @parent_comment.body %></li>
+  <li><strong><%= t("mailers.comment_reply.reply_comment", default: "Reply") %>:</strong> <%= @reply_comment.body %></li>
 </ul>
 
 <p>
-  <a href="<%= @comment_url %>">返信コメントを確認する</a>
+  <a href="<%= @comment_url %>"><%= t("mailers.comment_reply.cta", default: "View the reply") %></a>
 </p>
 
-<hr>
-<p>DeskTour Studio</p>
+<p><%= t("mailers.comment_reply.footer", default: "DeskTour Studio") %></p>

--- a/app/views/comment_reply_mailer/reply_notification.text.erb
+++ b/app/views/comment_reply_mailer/reply_notification.text.erb
@@ -1,13 +1,12 @@
-<%= @recipient.name.presence || "ユーザー" %> さん
+<%= @recipient.name.presence || t("mailers.comment_reply.recipient_default", default: "there") %>,
 
-あなたのコメントに返信がありました。
+<%= t("mailers.comment_reply.intro", default: "You received a new reply on DeskTour Studio.") %>
 
-投稿: <%= @post.title %>
-あなたのコメント: <%= @parent_comment.body %>
-返信コメント: <%= @reply_comment.body %>
+<%= t("mailers.comment_reply.post", default: "Post") %>: <%= @post.title %>
+<%= t("mailers.comment_reply.parent_comment", default: "Your comment") %>: <%= @parent_comment.body %>
+<%= t("mailers.comment_reply.reply_comment", default: "Reply") %>: <%= @reply_comment.body %>
 
-以下のリンクから該当コメントへ直接移動できます。
+<%= t("mailers.comment_reply.cta", default: "View the reply") %>:
 <%= @comment_url %>
 
----
-DeskTour Studio
+<%= t("mailers.comment_reply.footer", default: "DeskTour Studio") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,7 +49,7 @@
     <% end %>
   </head>
 
-  <body class="lang-<%= I18n.locale %> min-h-screen bg-slate-50 text-slate-800">
+  <body class="lang-<%= I18n.locale %> min-h-screen bg-slate-50 text-slate-800" data-screen="<%= "#{controller_name}-#{action_name}" %>">
     <% tracked_events = analytics_events %>
     <% mobile_sticky_active = controller_name == "posts" && action_name.in?(%w[index show]) %>
     <% main_padding_class = mobile_sticky_active ? "pb-40 sm:pb-8" : "pb-10 sm:pb-8" %>
@@ -80,6 +80,7 @@
                 <% else %>
                   <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary w-full justify-start", data: { ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "desktop_header_create_profile" } %>
                 <% end %>
+                <%= link_to t("navigation.onboarding", default: "Getting started"), onboarding_path, class: "tap-target cta-tertiary w-full justify-start", data: { ga_event: "navigation_onboarding_click", ga_category: "navigation", ga_label: "desktop_header_onboarding" } %>
                 <div class="rounded-lg border border-slate-200 bg-slate-50 p-2">
                   <p class="mb-1 ds-text-meta font-semibold"><%= t("language.switch_aria") %></p>
                   <div class="inline-flex w-full items-center gap-1 rounded-full border border-slate-300 bg-white p-1 text-xs font-semibold text-slate-700" role="group" aria-label="<%= t('language.switch_aria') %>">
@@ -96,6 +97,11 @@
                       <% end %>
                     <% end %>
                   </div>
+                </div>
+                <div class="ds-legal-links border-t border-slate-200 pt-2">
+                  <%= link_to t("footer.terms"), terms_path %>
+                  <%= link_to t("footer.privacy_policy"), privacy_policy_path %>
+                  <%= link_to t("footer.cookie_policy"), cookie_policy_path %>
                 </div>
               </div>
             </div>
@@ -130,11 +136,28 @@
           <% else %>
             <%= link_to t("navigation.create_profile"), new_user_path, class: "tap-target cta-tertiary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_profile_create_click", ga_category: "navigation", ga_label: "mobile_header_create_profile" } %>
           <% end %>
+
+          <%= link_to t("navigation.onboarding", default: "Getting started"), onboarding_path, class: "tap-target cta-tertiary flex w-full items-center justify-center", data: { mobile_header_action: true, ga_event: "navigation_onboarding_click", ga_category: "navigation", ga_label: "mobile_header_onboarding" } %>
+
+          <div class="ds-legal-links border-t border-slate-200 pt-2">
+            <%= link_to t("footer.terms"), terms_path, data: { mobile_header_action: true } %>
+            <%= link_to t("footer.privacy_policy"), privacy_policy_path, data: { mobile_header_action: true } %>
+            <%= link_to t("footer.cookie_policy"), cookie_policy_path, data: { mobile_header_action: true } %>
+          </div>
         </div>
       </div>
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-4 pt-8 <%= main_padding_class %> sm:px-6">
+      <% if controller_name == "posts" && action_name.in?(%w[index show new]) %>
+        <div class="mb-4 ds-legal-links">
+          <span class="text-slate-500"><%= t("legal.quick_links", default: "Policies") %>:</span>
+          <%= link_to t("footer.terms"), terms_path %>
+          <%= link_to t("footer.privacy_policy"), privacy_policy_path %>
+          <%= link_to t("footer.cookie_policy"), cookie_policy_path %>
+        </div>
+      <% end %>
+
       <% flash.each do |type, message| %>
         <% next if type.to_s == "analytics_events" %>
         <% visual = flash_visual(type) %>
@@ -146,9 +169,17 @@
         else
           "border-emerald-300 bg-emerald-50 text-emerald-700"
         end %>
+        <% toast_level = case visual[:level]
+        when :error
+          "error"
+        when :warning
+          "info"
+        else
+          "success"
+        end %>
         <% role = visual[:level] == :error ? "alert" : "status" %>
         <% live = visual[:level] == :error ? "assertive" : "polite" %>
-        <div class="mb-4 rounded-lg border px-4 py-3 text-sm <%= tone %>" role="<%= role %>" aria-live="<%= live %>">
+        <div class="mb-4 rounded-lg border px-4 py-3 text-sm <%= tone %>" role="<%= role %>" aria-live="<%= live %>" data-flash-message="<%= message %>" data-flash-level="<%= toast_level %>">
           <div class="flex items-start gap-2">
             <%= status_badge(level: visual[:level], icon: visual[:icon], label: t(visual[:label_key])) %>
             <p class="pt-0.5"><%= message %></p>

--- a/app/views/pages/onboarding.html.erb
+++ b/app/views/pages/onboarding.html.erb
@@ -1,0 +1,54 @@
+<% content_for :title, t("onboarding.title", default: "Getting Started") %>
+<% content_for :description, t("onboarding.description", default: "A short guide to browse, post, and join conversations on DeskTour Studio.") %>
+
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
+  <header class="rounded-2xl bg-gradient-to-br from-slate-900 via-sky-900 to-cyan-700 px-6 py-7 text-white">
+    <h1 class="ds-heading-xl"><%= t("onboarding.heading", default: "Start in 3 steps") %></h1>
+    <p class="mt-2 ds-text-support max-w-2xl text-sky-100"><%= t("onboarding.lead", default: "If this is your first visit, follow this flow: browse setups, publish your own, and leave a comment.") %></p>
+  </header>
+
+  <ol class="space-y-3">
+    <li class="ds-card p-4 sm:p-5">
+      <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("onboarding.step", default: "Step") %> 1</p>
+      <h2 class="mt-1 ds-heading-md text-slate-900"><%= t("onboarding.browse_title", default: "Browse the gallery") %></h2>
+      <p class="mt-1 ds-text-support"><%= t("onboarding.browse_body", default: "Use keyword search and filters to find layouts, devices, and ideas.") %></p>
+      <div class="mt-3">
+        <%= render "shared/experiment_cta", href: root_path, label: t("onboarding.browse_cta", default: "Open gallery"), tone: "secondary", variant: "control" %>
+      </div>
+    </li>
+
+    <li class="ds-card p-4 sm:p-5">
+      <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("onboarding.step", default: "Step") %> 2</p>
+      <h2 class="mt-1 ds-heading-md text-slate-900"><%= t("onboarding.post_title", default: "Publish your setup") %></h2>
+      <p class="mt-1 ds-text-support"><%= t("onboarding.post_body", default: "Create a profile, add your photo, and share key details so others can learn from your workflow.") %></p>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <%= render "shared/experiment_cta", href: new_user_path, label: t("onboarding.create_profile", default: "Create profile"), tone: "secondary", variant: "compact" %>
+        <%= render "shared/experiment_cta", href: new_post_path, label: t("onboarding.create_post", default: "Create post"), tone: "primary", variant: "high-contrast" %>
+      </div>
+    </li>
+
+    <li class="ds-card p-4 sm:p-5">
+      <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("onboarding.step", default: "Step") %> 3</p>
+      <h2 class="mt-1 ds-heading-md text-slate-900"><%= t("onboarding.comment_title", default: "Join comments") %></h2>
+      <p class="mt-1 ds-text-support"><%= t("onboarding.comment_body", default: "Leave one concrete point when commenting to get better replies.") %></p>
+      <div class="mt-3">
+        <a href="<%= root_path %>#index-search" class="tap-target cta-secondary"><%= t("onboarding.find_post", default: "Find a post to comment" ) %></a>
+      </div>
+    </li>
+  </ol>
+
+  <div class="ds-legal-links border-t border-slate-200 pt-3">
+    <span class="text-slate-500"><%= t("legal.quick_links", default: "Policies") %>:</span>
+    <%= link_to t("footer.terms"), terms_path %>
+    <%= link_to t("footer.privacy_policy"), privacy_policy_path %>
+    <%= link_to t("footer.cookie_policy"), cookie_policy_path %>
+  </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <div class="space-y-3">
+    <div class="ds-skeleton-block rounded-2xl"></div>
+    <div class="ds-card p-5"><div class="ds-skeleton-line w-1/3"></div><div class="mt-3 ds-skeleton-line"></div><div class="mt-2 ds-skeleton-line w-5/6"></div></div>
+    <div class="ds-card p-5"><div class="ds-skeleton-line w-1/3"></div><div class="mt-3 ds-skeleton-line"></div><div class="mt-2 ds-skeleton-line w-5/6"></div></div>
+  </div>
+</section>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,11 +2,6 @@
 <% owned_users ||= [] %>
 <% category_suggestions ||= [] %>
 <% tag_suggestions ||= [] %>
-<% locale_ja = I18n.locale.to_s == "ja" %>
-<% required_section_label = locale_ja ? "必須の基本情報" : "Required basics" %>
-<% required_section_lead = locale_ja ? "まずは投稿の中心となる情報を入力します。" : "Start with the core information for your post." %>
-<% optional_section_label = locale_ja ? "任意の詳細情報" : "Optional details" %>
-<% optional_section_lead = locale_ja ? "カテゴリ・テーマ・タグを追加すると見つけやすくなります。" : "Add category, theme, and tags to improve discoverability." %>
 <% field_error = ->(attr) { post.errors.full_messages_for(attr).first } %>
 <% input_class = ->(error) { "w-full rounded-lg border px-3 py-2 text-sm #{error.present? ? 'border-red-400 bg-red-50' : 'border-slate-300'}" } %>
 <% title_error = field_error.call(:title) %>
@@ -19,40 +14,59 @@
 <% optional_panel_open = [category_error, theme_error, tag_list_error, post.category, post.theme, post.tag_list].any?(&:present?) %>
 <% items_panel_open = post.items.any? { |item| item.name.present? || item.affiliate_url.present? || item.errors.any? } %>
 
-<%= form_with model: post, class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
+<%= form_with model: post,
+              class: "space-y-form ds-loading-shell",
+              data: {
+                form_autofocus_errors: true,
+                ui_form: true,
+                loading_label: t("ui.processing", default: "Processing..."),
+                submitting_reason: t("ui.processing", default: "Processing..."),
+                disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"),
+                disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.")
+              } do |f| %>
   <% if post.errors.any? %>
-    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700" role="alert" aria-live="assertive">
-      <p class="mb-2 font-semibold"><%= t("posts.form.error_summary") %></p>
-      <ul class="list-disc pl-5">
-        <% if profile_error.present? %>
-          <li><a href="#post_user_id" class="underline"><%= profile_error %></a></li>
-        <% end %>
-        <% if title_error.present? %>
-          <li><a href="#post_title" class="underline"><%= title_error %></a></li>
-        <% end %>
-        <% if description_error.present? %>
-          <li><a href="#post_description" class="underline"><%= description_error %></a></li>
-        <% end %>
-        <% if image_error.present? %>
-          <li><a href="#post_desk_image" class="underline"><%= image_error %></a></li>
-        <% end %>
-        <% if category_error.present? %>
-          <li><a href="#post_category" class="underline"><%= category_error %></a></li>
-        <% end %>
-        <% if theme_error.present? %>
-          <li><a href="#post_theme" class="underline"><%= theme_error %></a></li>
-        <% end %>
-        <% if tag_list_error.present? %>
-          <li><a href="#post_tag_list" class="underline"><%= tag_list_error %></a></li>
-        <% end %>
-      </ul>
+    <div class="space-y-2">
+      <%= render "shared/feedback_panel",
+                 level: :error,
+                 title: t("posts.form.error_summary", default: "Please fix the following errors."),
+                 body: t("ui.error_with_recovery", default: "Please review the fields below, then retry. If the issue continues, go back and try again."),
+                 actions: [
+                   { label: t("ui.focus_first_error", default: "Go to first error"), href: "#post-form-fields" },
+                   { label: t("ui.back", default: "Back"), href: (request.referer.presence || root_path) }
+                 ] %>
+
+      <div class="rounded-lg border border-red-200 bg-white p-3 text-sm text-red-800" role="alert" aria-live="assertive">
+        <ul class="list-disc pl-5">
+          <% if profile_error.present? %>
+            <li><a href="#post_user_id" class="underline"><%= profile_error %></a></li>
+          <% end %>
+          <% if title_error.present? %>
+            <li><a href="#post_title" class="underline"><%= title_error %></a></li>
+          <% end %>
+          <% if description_error.present? %>
+            <li><a href="#post_description" class="underline"><%= description_error %></a></li>
+          <% end %>
+          <% if image_error.present? %>
+            <li><a href="#post_desk_image" class="underline"><%= image_error %></a></li>
+          <% end %>
+          <% if category_error.present? %>
+            <li><a href="#post_category" class="underline"><%= category_error %></a></li>
+          <% end %>
+          <% if theme_error.present? %>
+            <li><a href="#post_theme" class="underline"><%= theme_error %></a></li>
+          <% end %>
+          <% if tag_list_error.present? %>
+            <li><a href="#post_tag_list" class="underline"><%= tag_list_error %></a></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   <% end %>
 
-  <section class="space-y-4 rounded-xl border border-slate-200 bg-white p-4 sm:p-5">
+  <section id="post-form-fields" class="space-y-4 rounded-xl border border-slate-200 bg-white p-4 sm:p-5">
     <div>
-      <h2 class="ds-heading-md"><%= required_section_label %></h2>
-      <p class="mt-1 ds-text-support"><%= required_section_lead %></p>
+      <h2 class="ds-heading-md"><%= t("posts.form.required_section", default: "Required basics") %></h2>
+      <p class="mt-1 ds-text-support"><%= t("posts.form.required_section_lead", default: "Start with the core information for your post.") %></p>
     </div>
 
     <div class="grid gap-4 sm:grid-cols-2">
@@ -60,7 +74,7 @@
         <div class="sm:col-span-2">
           <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
           <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: input_class.call(profile_error), aria: { invalid: profile_error.present? ? "true" : nil, describedby: "post_user_id_help post_user_id_error" } %>
-          <p id="post_user_id_help" class="mt-1 ds-text-muted"><%= locale_ja ? "既定で使う投稿プロフィールを選択します。" : "Choose the profile used for this post." %></p>
+          <p id="post_user_id_help" class="ds-field-guide"><%= t("posts.form.profile_guide", default: "Choose which profile is shown as the author.") %></p>
           <% if profile_error.present? %>
             <p id="post_user_id_error" class="mt-1 text-xs font-medium text-red-700"><%= profile_error %></p>
           <% end %>
@@ -69,8 +83,15 @@
 
       <div class="sm:col-span-2">
         <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-        <%= f.text_field :title, class: input_class.call(title_error), placeholder: t("posts.form.title_placeholder"), aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_error" } %>
-        <p id="post_title_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: ブラックと木目で統一した作業デスク" : "Example: Black and walnut developer desk setup" %></p>
+        <%= f.text_field :title,
+                         required: true,
+                         maxlength: 120,
+                         class: input_class.call(title_error),
+                         placeholder: t("posts.form.title_placeholder"),
+                         aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_counter post_title_error" },
+                         data: { char_count_max: 120, char_count_target: "post_title_counter" } %>
+        <p id="post_title_help" class="ds-field-guide"><%= t("posts.form.title_guide", default: "Include setup style and one distinctive element. Max 120 characters.") %></p>
+        <p id="post_title_counter" class="ds-char-counter" aria-live="polite"></p>
         <% if title_error.present? %>
           <p id="post_title_error" class="mt-1 text-xs font-medium text-red-700"><%= title_error %></p>
         <% end %>
@@ -78,8 +99,16 @@
 
       <div class="sm:col-span-2">
         <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-        <%= f.text_area :description, rows: 7, class: input_class.call(description_error), placeholder: t("posts.form.description_placeholder"), aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_error" } %>
-        <p id="post_description_help" class="mt-1 ds-text-muted"><%= locale_ja ? "配置、利用デバイス、用途を3-5文で書くと伝わりやすくなります。" : "Describe layout, devices, and workflow in 3-5 sentences." %></p>
+        <%= f.text_area :description,
+                        rows: 7,
+                        required: true,
+                        maxlength: 2000,
+                        class: input_class.call(description_error),
+                        placeholder: t("posts.form.description_placeholder"),
+                        aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_counter post_description_error" },
+                        data: { char_count_max: 2000, char_count_target: "post_description_counter" } %>
+        <p id="post_description_help" class="ds-field-guide"><%= t("posts.form.description_guide", default: "Write 3-5 sentences about layout, devices, and workflow. Do not include private information.") %></p>
+        <p id="post_description_counter" class="ds-char-counter" aria-live="polite"></p>
         <% if description_error.present? %>
           <p id="post_description_error" class="mt-1 text-xs font-medium text-red-700"><%= description_error %></p>
         <% end %>
@@ -87,8 +116,8 @@
 
       <div class="sm:col-span-2">
         <%= f.label :desk_image, t("posts.form.image_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-        <%= f.file_field :desk_image, class: input_class.call(image_error), accept: "image/*", aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error" } %>
-        <p id="post_image_help" class="mt-1 ds-text-muted"><%= locale_ja ? "明るめの横長画像（1200px以上推奨）" : "Use a bright landscape image (1200px+ recommended)." %></p>
+        <%= f.file_field :desk_image, required: post.published?, class: input_class.call(image_error), accept: "image/*", aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error" } %>
+        <p id="post_image_help" class="ds-field-guide"><%= t("posts.form.image_guide", default: "Use a bright landscape image (1200px+ recommended).") %></p>
         <% if image_error.present? %>
           <p id="post_image_error" class="mt-1 text-xs font-medium text-red-700"><%= image_error %></p>
         <% end %>
@@ -99,8 +128,8 @@
   <details class="rounded-xl border border-slate-200 bg-slate-50 p-4 sm:p-5" <%= "open" if optional_panel_open %>>
     <summary class="cursor-pointer list-none">
       <div>
-        <h2 class="ds-heading-md"><%= optional_section_label %></h2>
-        <p class="mt-1 ds-text-support"><%= optional_section_lead %></p>
+        <h2 class="ds-heading-md"><%= t("posts.form.optional_section", default: "Optional details") %></h2>
+        <p class="mt-1 ds-text-support"><%= t("posts.form.optional_section_lead", default: "Add category, theme, and tags to improve discoverability.") %></p>
       </div>
     </summary>
 
@@ -108,7 +137,7 @@
       <div>
         <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :category, class: input_class.call(category_error), placeholder: t("posts.form.category_placeholder"), list: "post-category-options", aria: { invalid: category_error.present? ? "true" : nil, describedby: "post_category_help post_category_error" } %>
-        <p id="post_category_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: Engineering, Design, Writing" : "Example: Engineering, Design, Writing" %></p>
+        <p id="post_category_help" class="ds-field-guide"><%= t("posts.form.category_guide", default: "Examples: Engineering, Design, Writing.") %></p>
         <% if category_error.present? %>
           <p id="post_category_error" class="mt-1 text-xs font-medium text-red-700"><%= category_error %></p>
         <% end %>
@@ -117,7 +146,7 @@
       <div>
         <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
         <%= f.text_field :theme, class: input_class.call(theme_error), placeholder: t("posts.form.theme_placeholder"), aria: { invalid: theme_error.present? ? "true" : nil, describedby: "post_theme_help post_theme_error" } %>
-        <p id="post_theme_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: Dark, Minimal, Natural" : "Example: Dark, Minimal, Natural" %></p>
+        <p id="post_theme_help" class="ds-field-guide"><%= t("posts.form.theme_guide", default: "Examples: Dark, Minimal, Natural.") %></p>
         <% if theme_error.present? %>
           <p id="post_theme_error" class="mt-1 text-xs font-medium text-red-700"><%= theme_error %></p>
         <% end %>
@@ -125,8 +154,15 @@
 
       <div class="sm:col-span-2">
         <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-        <%= f.text_field :tag_list, class: input_class.call(tag_list_error), placeholder: t("posts.form.tags_placeholder"), list: "post-tag-options", aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_error" } %>
-        <p id="post_tag_list_help" class="mt-1 ds-text-muted"><%= locale_ja ? "例: mechanical keyboard, standing desk（カンマ区切り）" : "Example: mechanical keyboard, standing desk (comma-separated)" %></p>
+        <%= f.text_field :tag_list,
+                         maxlength: 220,
+                         class: input_class.call(tag_list_error),
+                         placeholder: t("posts.form.tags_placeholder"),
+                         list: "post-tag-options",
+                         aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_counter post_tag_list_error" },
+                         data: { char_count_max: 220, char_count_target: "post_tag_list_counter" } %>
+        <p id="post_tag_list_help" class="ds-field-guide"><%= t("posts.form.tags_guide", default: "Use up to 8 tags separated by commas. Avoid duplicates.") %></p>
+        <p id="post_tag_list_counter" class="ds-char-counter" aria-live="polite"></p>
         <% if tag_list_error.present? %>
           <p id="post_tag_list_error" class="mt-1 text-xs font-medium text-red-700"><%= tag_list_error %></p>
         <% end %>
@@ -142,12 +178,12 @@
           <div>
             <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
             <%= item_fields.text_field :name, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.item_name_placeholder") %>
-            <p class="mt-1 ds-text-muted"><%= locale_ja ? "例: HHKB Professional HYBRID Type-S" : "Example: HHKB Professional HYBRID Type-S" %></p>
+            <p class="ds-field-guide"><%= t("posts.form.item_name_guide", default: "Example: HHKB Professional HYBRID Type-S") %></p>
           </div>
           <div>
             <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium text-slate-700" %>
             <%= item_fields.url_field :affiliate_url, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.form.affiliate_url_placeholder") %>
-            <p class="mt-1 ds-text-muted"><%= locale_ja ? "例: https://www.amazon.co.jp/... または公式ストアURL" : "Example: https://www.amazon.com/... or official store URL" %></p>
+            <p class="ds-field-guide"><%= t("posts.form.affiliate_url_guide", default: "Use official product page or trusted store URL.") %></p>
           </div>
         </div>
       <% end %>
@@ -171,8 +207,25 @@
   <% end %>
 
   <div class="flex flex-wrap gap-3">
-    <%= f.submit submit_label, class: "tap-target cta-primary" %>
-    <%= f.submit t("posts.form.save_draft"), name: "save_as_draft", value: "1", class: "tap-target cta-secondary" %>
+    <%= f.button type: :submit, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "control", ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "publish_primary" } do %>
+      <span class="inline-flex items-center gap-1.5">
+        <%= ui_icon(:check_circle, class_name: "h-4 w-4") %>
+        <span data-submit-label><%= submit_label %></span>
+      </span>
+    <% end %>
+
+    <%= f.button type: :submit, name: "save_as_draft", value: "1", class: "tap-target cta-secondary", data: { ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "save_draft_secondary" } do %>
+      <span data-submit-label><%= t("posts.form.save_draft") %></span>
+    <% end %>
+  </div>
+
+  <p class="ds-disabled-reason" data-disabled-reason aria-live="polite"></p>
+
+  <div class="ds-legal-links border-t border-slate-200 pt-3">
+    <span class="text-slate-500"><%= t("legal.quick_links", default: "Policies") %>:</span>
+    <%= link_to t("footer.terms"), terms_path %>
+    <%= link_to t("footer.privacy_policy"), privacy_policy_path %>
+    <%= link_to t("footer.cookie_policy"), cookie_policy_path %>
   </div>
 <% end %>
 

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("posts.edit.title") %>
 <% content_for :description, t("posts.edit.description") %>
 
-<section class="mx-auto w-full max-w-3xl space-y-content">
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
     <div>
         <h1 class="ds-heading-xl"><%= t("posts.edit.heading") %></h1>
         <div class="mt-2 flex items-center gap-2 ds-text-support">
@@ -13,4 +13,8 @@
     <div class="ds-card p-6">
         <%= render "form", post: @post, owned_users: @owned_users, category_suggestions: @category_suggestions, tag_suggestions: @tag_suggestions %>
     </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :detail %>
 </section>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -8,19 +8,19 @@
 <% detailed_filters_open = params[:details] == "1" || active_filters.any? %>
 <% applied_filter_count = active_filters.size %>
 <% filtered_results = params[:q].present? || applied_filter_count.positive? %>
-<% no_filters_label = I18n.locale.to_s == "ja" ? "\u306A\u3057" : "None" %>
-<% quick_search_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u691C\u7D22" : "Quick search" %>
-<% filters_open_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u3092\u958B\u304F" : "Open filters" %>
-<% filters_close_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u3092\u9589\u3058\u308B" : "Hide filters" %>
-<% filters_title = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F" : "Refine results" %>
-<% filters_hint = I18n.locale.to_s == "ja" ? "\u5FC5\u8981\u306A\u3068\u304D\u3060\u3051\u30AB\u30C6\u30B4\u30EA\u30FC\u30FB\u30BF\u30B0\u3092\u8FFD\u52A0\u3057\u3066\u7D5E\u308A\u8FBC\u307F\u307E\u3059\u3002" : "Open only when you need category, theme, or tag filters." %>
-<% details_applied_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: %{count}\u4EF6" : "%{count} filters applied" %>
-<% details_none_summary = I18n.locale.to_s == "ja" ? "\u9069\u7528\u4E2D: \u306A\u3057" : "No filters applied" %>
-<% no_results_title = I18n.locale.to_s == "ja" ? "\u6761\u4EF6\u3092\u7DE9\u548C\u3057\u3066\u518D\u691C\u7D22\u3057\u307E\u3057\u3087\u3046" : "Try broader filters" %>
-<% no_results_hint = I18n.locale.to_s == "ja" ? "\u307E\u305A\u306F1\u3064\u3060\u3051\u6761\u4EF6\u3092\u5916\u3059\u3068\u3001\u65B0\u3057\u3044\u6295\u7A3F\u304C\u898B\u3064\u304B\u308A\u3084\u3059\u304F\u306A\u308A\u307E\u3059\u3002" : "Relax one condition first to discover more posts." %>
-<% clear_all_label = I18n.locale.to_s == "ja" ? "\u3059\u3079\u3066\u30AF\u30EA\u30A2" : "Clear all filters" %>
-<% remove_keyword_label = I18n.locale.to_s == "ja" ? "\u30AD\u30FC\u30EF\u30FC\u30C9\u3092\u5916\u3059" : "Remove keyword" %>
-<% remove_one_filter_label = I18n.locale.to_s == "ja" ? "\u7D5E\u308A\u8FBC\u307F\u30921\u3064\u5916\u3059" : "Remove one filter" %>
+<% no_filters_label = t("posts.index.no_filters", default: "None") %>
+<% quick_search_label = t("posts.index.quick_search", default: "Quick search") %>
+<% filters_open_label = t("posts.index.open_filters", default: "Open filters") %>
+<% filters_close_label = t("posts.index.close_filters", default: "Hide filters") %>
+<% filters_title = t("posts.index.filters_title", default: "Refine results") %>
+<% filters_hint = t("posts.index.filters_hint", default: "Open only when you need category, theme, or tag filters.") %>
+<% details_applied_summary = t("posts.index.filters_applied", default: "%{count} filters applied") %>
+<% details_none_summary = t("posts.index.filters_none", default: "No filters applied") %>
+<% no_results_title = t("posts.index.zero_title", default: "No matches found") %>
+<% no_results_hint = t("posts.index.zero_hint", default: "Try removing one condition first to discover more posts.") %>
+<% clear_all_label = t("posts.index.clear_all", default: "Clear all filters") %>
+<% remove_keyword_label = t("posts.index.remove_keyword", default: "Remove keyword") %>
+<% remove_one_filter_label = t("posts.index.remove_one_filter", default: "Remove one filter") %>
 <% max_card_tags = 2 %>
 <% filter_labels = {
   category: t("posts.index.category_placeholder"),
@@ -35,10 +35,11 @@
   tag: params[:tag].presence,
   details: params[:details].presence
 }.compact %>
-<% empty_primary_cta = I18n.locale.to_s == "ja" ? "\u6700\u521D\u306E\u6295\u7A3F\u3092\u4F5C\u6210" : "Create your first post" %>
+<% empty_primary_cta = t("posts.index.empty_primary", default: "Create your first post") %>
 <% timeline_hint = t("posts.index.timeline_hint", default: "Start your timeline with one post.") %>
+<% return_path = request.fullpath %>
 
-<section class="space-y-section">
+<section class="space-y-section" data-page-content>
   <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-blue-900 to-cyan-800 px-5 py-6 text-white sm:px-6 sm:py-8">
     <div class="absolute inset-0 bg-slate-950/20" aria-hidden="true"></div>
     <div class="relative max-w-3xl rounded-xl bg-slate-950/35 p-4 sm:p-5">
@@ -47,7 +48,8 @@
         <%= t("posts.index.hero_description") %>
       </p>
       <div class="mt-4 flex flex-wrap items-center gap-2">
-        <a href="#index-search" class="tap-target cta-primary"><%= t("posts.index.search_button") %></a>
+        <%= render "shared/experiment_cta", href: "#index-search", label: t("posts.index.search_button"), tone: "primary", variant: "control", html_options: { data: { ga_event: "post_index_search_jump_click", ga_category: "post_index", ga_label: "hero_search_jump" } } %>
+        <%= render "shared/experiment_cta", href: onboarding_path, label: t("navigation.onboarding", default: "Getting started"), tone: "secondary", variant: "compact", html_options: { data: { ga_event: "onboarding_open_click", ga_category: "onboarding", ga_label: "index_hero" } } %>
       </div>
       <p class="mt-2 ds-text-meta text-blue-100/90">
         <%= link_to t("navigation.create_post"), new_post_path, class: "underline decoration-white/40 underline-offset-2 hover:text-white" %>
@@ -56,13 +58,16 @@
   </div>
 
   <div id="index-search" class="ds-card p-4 sm:p-5" data-index-search-root>
-    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true } do %>
+    <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true, ui_form: true, disabled_reason_prefix: t("ui.search_hint", default: "Add one search condition"), disabled_submit_notice: t("ui.search_hint", default: "Add one search condition") } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
 
       <div class="sticky top-20 z-10 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:static" data-quick-search-shell>
         <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= quick_search_label %></p>
         <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
-          <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+          <div>
+            <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+            <p class="ds-field-guide"><%= t("posts.index.search_guide", default: "Search title, description, items, and tags.") %></p>
+          </div>
           <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-primary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
         </div>
       </div>
@@ -117,16 +122,21 @@
         <% ranked_tags = prioritized_post_tags(post, query: params[:q], category: params[:category], selected_tag: params[:tag]) %>
         <% visible_tags = ranked_tags.first(max_card_tags) %>
         <% hidden_tag_count = [ranked_tags.size - visible_tags.size, 0].max %>
-        <article class="ds-card ds-shadow-soft flex h-full flex-col overflow-hidden">
-          <%= link_to post_path(post), class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results" } do %>
-            <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton>
-              <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-full w-full object-cover") %>
+        <% card_url = post_path(post, from: return_path) %>
+        <article class="ds-card ds-shadow-soft ds-card-interactive flex h-full flex-col overflow-hidden" data-card-href="<%= card_url %>">
+          <%= link_to card_url, class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results", card_stop: true } do %>
+            <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton data-image-shell>
+              <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-full w-full object-cover", data: { fallback_src: asset_path(ApplicationHelper::FALLBACK_POST_IMAGE) }) %>
+              <div class="ds-image-fallback hidden" data-image-fallback>
+                <p><%= t("images.fallback_text", default: "Image is unavailable") %></p>
+                <button type="button" data-image-retry><%= t("images.retry", default: "Retry") %></button>
+              </div>
             </div>
           <% end %>
 
           <div class="flex h-full flex-col p-4">
             <h2 class="ds-heading-sm ds-line-clamp-2 ds-break-words text-slate-900">
-              <%= link_to post.title, post_path(post), class: "block leading-6 hover:text-blue-600", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click" } %>
+              <%= link_to post.title, card_url, class: "block leading-6 hover:text-blue-600", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click", card_stop: true } %>
             </h2>
 
             <p class="mt-2 ds-line-clamp-2 ds-text-support ds-break-words"><%= truncate(post.description, length: 100) %></p>
@@ -136,7 +146,7 @@
                 <span class="ds-badge-inactive"><%= post.category %></span>
               <% end %>
               <% visible_tags.each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card" } %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card", card_stop: true } %>
               <% end %>
               <% if hidden_tag_count.positive? %>
                 <span class="ds-badge-info">+<%= hidden_tag_count %></span>
@@ -149,11 +159,11 @@
                   <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
                   <span><%= localized_number(post.likes_count) %></span>
                   <span aria-hidden="true">&bull;</span>
-                  <span><%= l(post.created_at.to_date) %></span>
+                  <%= timestamp_tag(post.created_at, style: :date) %>
                 </p>
                 <p class="ds-text-meta text-slate-600">
                   <%= t("posts.index.author_label") %>:
-                  <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click" } %>
+                  <%= link_to post.user.name, user_path(post.user), class: "font-medium text-slate-700 underline-offset-2 hover:text-slate-900 hover:underline", data: { ga_event: "post_author_open", ga_category: "post_index", ga_label: "author_profile_click", card_stop: true } %>
                 </p>
               </div>
             </div>
@@ -167,8 +177,9 @@
       <% if filtered_results %>
         <p class="mt-2 text-sm font-semibold text-slate-700"><%= no_results_title %></p>
         <p class="mt-1 ds-text-support"><%= no_results_hint %></p>
-        <div class="mt-4">
+        <div class="mt-4 flex flex-wrap items-center justify-center gap-2">
           <%= link_to clear_all_label, posts_path, class: "tap-target cta-primary", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_clear_all" } %>
+          <%= link_to t("posts.index.zero_reset", default: "Reset conditions"), posts_path, class: "tap-target cta-secondary", data: { ga_event: "post_search_reset_click", ga_category: "post_search", ga_label: "index_empty_reset_conditions" } %>
         </div>
         <div class="mt-3 flex flex-wrap items-center justify-center gap-2">
           <% if params[:q].present? %>
@@ -178,6 +189,30 @@
             <%= link_to remove_one_filter_label, posts_path(persisted_query.except(first_active_filter_key)), class: "tap-target cta-tertiary cta-compact", data: { ga_event: "post_search_filter_clear_click", ga_category: "post_search", ga_label: "index_empty_remove_one_filter" } %>
           <% end %>
         </div>
+
+        <% if @popular_tags.any? %>
+          <div class="mx-auto mt-5 max-w-2xl">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.index.popular_tags", default: "Popular tags") %></p>
+            <div class="mt-2 flex flex-wrap items-center justify-center gap-2">
+              <% @popular_tags.each do |tag| %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: "1"), class: "tap-target ds-badge-inactive", data: { ga_event: "post_search_recovery_click", ga_category: "post_search", ga_label: "zero_state_popular_tag" } %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
+        <% if @recent_posts.any? %>
+          <div class="mx-auto mt-5 max-w-2xl text-left">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.index.recent_posts", default: "Recent posts") %></p>
+            <ul class="mt-2 space-y-1.5">
+              <% @recent_posts.each do |recent_post| %>
+                <li>
+                  <%= link_to recent_post.title, post_path(recent_post, from: return_path), class: "text-sm text-blue-700 underline-offset-2 hover:underline", data: { ga_event: "post_search_recovery_click", ga_category: "post_search", ga_label: "zero_state_recent_post" } %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
       <% else %>
         <div class="mt-4 space-y-2">
           <%= link_to empty_primary_cta, new_post_path, class: "tap-target cta-primary" %>
@@ -188,6 +223,10 @@
   <% end %>
 
   <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_INDEX_BOTTOM"] %>
+</section>
+
+<section class="hidden space-y-4" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :list %>
 </section>
 
 <script>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,15 +1,22 @@
 <% content_for :title, t("posts.new.title") %>
 <% content_for :description, t("posts.new.description") %>
 
-<section class="mx-auto w-full max-w-3xl space-y-content">
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
     <div>
         <h1 class="ds-heading-xl"><%= t("posts.new.heading") %></h1>
         <p class="mt-2 ds-text-support">
             <%= t("posts.new.lead") %>
+        </p>
+        <p class="mt-2 ds-text-muted">
+          <%= link_to t("navigation.onboarding", default: "Need a quick guide?"), onboarding_path, class: "underline decoration-slate-300 underline-offset-2 hover:text-slate-900" %>
         </p>
     </div>
 
     <div class="ds-card p-6">
         <%= render "form", post: @post, owned_users: @owned_users, submit_label: t("posts.form.publish"), category_suggestions: @category_suggestions, tag_suggestions: @tag_suggestions %>
     </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :detail %>
 </section>

--- a/app/views/posts/notifications.html.erb
+++ b/app/views/posts/notifications.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("posts.notifications.title") %>
 <% content_for :description, t("posts.notifications.description") %>
 
-<section class="mx-auto w-full max-w-3xl space-y-content">
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
   <header class="flex flex-wrap items-center justify-between gap-3">
     <div>
       <h1 class="ds-heading-xl"><%= t("posts.notifications.heading") %></h1>
@@ -23,7 +23,7 @@
           <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
             <p class="text-sm text-slate-800"><%= notification.message %></p>
             <p class="mt-1 ds-text-meta">
-              <%= l(notification.created_at, format: :short) %>
+              <%= timestamp_tag(notification.created_at, style: :datetime) %>
               <% if notification.read_at.present? %>
                 <span class="ml-2 inline-flex items-center gap-1 rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-emerald-700">
                   <%= ui_icon(:check_circle, class_name: "h-3.5 w-3.5") %>
@@ -46,4 +46,8 @@
       </div>
     <% end %>
   </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :comment %>
 </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,62 +1,45 @@
 <% content_for :title, @post.title %>
 <% content_for :description, truncate(@post.description, length: 120) %>
 <% content_for :og_image_url, og_image_url(@post) %>
-<% body_section_label = t("posts.show.overview_heading", default: "Overview") %>
-<% comments_lead_label = t("posts.show.comments_lead", default: "After reading the post and related items, join the conversation below.") %>
-<% comment_empty_cta = t("posts.show.comment_empty_cta", default: "Write the first comment") %>
-<% mobile_menu_open_label = t("navigation.menu_opened", default: "Action menu opened") %>
-<% mobile_menu_close_label = t("navigation.menu_closed", default: "Action menu closed") %>
-<% item_preview_label = t("posts.show.item_preview", default: "Item preview") %>
-<% item_price_unknown_label = t("posts.show.item_price_unknown", default: "Price: unavailable") %>
-<% item_link_missing_label = t("posts.show.item_link_missing", default: "Link not available") %>
-<% related_items_owner_hint = t("posts.show.related_items_owner_hint", default: "Add related items to help readers compare your setup.") %>
-<% mobile_more_label = t("posts.show.mobile_more_label", default: "More actions") %>
 <% comments_count = @root_comments.sum { |comment| 1 + comment.replies.size } %>
 <% comments_count_label = t("posts.show.comments_count_label", count: comments_count, localized_count: localized_number(comments_count), default: "#{localized_number(comments_count)} comments") %>
-<% more_actions_label = t("posts.show.more_actions", default: "More actions") %>
-<% owner_action_heading = t("posts.show.owner_actions", default: "Owner actions") %>
-<% danger_zone_label = t("posts.show.danger_zone", default: "Danger zone") %>
-<% danger_zone_lead = t("posts.show.danger_zone_lead", default: "Post deletion cannot be undone.") %>
-<% value_summary = truncate(@post.description.to_s.squish, length: 170) %>
-<% comment_required_label = t("posts.show.comments.required", default: "Required") %>
-<% comment_optional_label = t("posts.show.comments.optional", default: "Optional") %>
+<% share_url = post_share_url(@post) %>
+<% share_text = post_share_text(@post) %>
 
-<article class="space-y-content">
+<article class="space-y-content" data-page-content>
   <header class="space-y-4">
-    <div class="flex flex-wrap items-center gap-2 ds-text-meta text-slate-600">
-      <span><%= l(@post.created_at.to_date) %></span>
-      <% if @post.category.present? %>
-        <span class="ds-badge-inactive"><%= @post.category %></span>
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex flex-wrap items-center gap-2 ds-text-meta text-slate-600">
+        <%= timestamp_tag(@post.created_at, style: :date, include_relative: true) %>
+        <% if @post.category.present? %><span class="ds-badge-inactive"><%= @post.category %></span><% end %>
+        <% if @post.theme.present? %><span class="ds-badge-info"><%= @post.theme %></span><% end %>
+        <span class="inline-flex items-center gap-1"><%= ui_icon(:chat, class_name: "h-3.5 w-3.5") %><span><%= comments_count_label %></span></span>
+      </div>
+      <% if @back_to_index_path.present? %>
+        <%= link_to @back_to_index_path, class: "tap-target cta-secondary cta-compact" do %>
+          <%= ui_icon(:arrow_uturn_left, class_name: "h-4 w-4") %>
+          <span><%= t("posts.show.back_to_results", default: "Back to results") %></span>
+        <% end %>
       <% end %>
-      <% if @post.theme.present? %>
-        <span class="ds-badge-info"><%= @post.theme %></span>
-      <% end %>
-      <span class="inline-flex items-center gap-1">
-        <%= ui_icon(:chat, class_name: "h-3.5 w-3.5") %>
-        <span><%= comments_count_label %></span>
-      </span>
     </div>
 
     <h1 class="ds-heading-xl ds-break-words text-slate-900"><%= @post.title %></h1>
-
-    <p class="ds-text-support">
-      <%= t("posts.show.posted_by") %>
-      <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
-    </p>
-    <p class="ds-text-body ds-break-words max-w-3xl"><%= value_summary %></p>
+    <p class="ds-text-support"><%= t("posts.show.posted_by") %> <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %></p>
+    <p class="ds-text-body ds-break-words max-w-3xl"><%= truncate(@post.description.to_s.squish, length: 170) %></p>
     <a href="#comments" class="tap-target cta-tertiary cta-compact"><%= t("posts.show.comments.title") %></a>
   </header>
 
-  <div class="ds-media-frame ds-media-frame-main ds-media-skeleton" data-media-skeleton>
-    <%= optimized_post_image_tag(@post, variant: :main, class: "h-full w-full object-cover") %>
+  <div class="ds-media-frame ds-media-frame-main ds-media-skeleton" data-media-skeleton data-image-shell>
+    <%= optimized_post_image_tag(@post, variant: :main, class: "h-full w-full object-cover", data: { fallback_src: asset_path(ApplicationHelper::FALLBACK_POST_IMAGE) }) %>
+    <div class="ds-image-fallback hidden" data-image-fallback>
+      <p><%= t("images.fallback_text", default: "Image is unavailable") %></p>
+      <button type="button" data-image-retry><%= t("images.retry", default: "Retry") %></button>
+    </div>
   </div>
 
   <section class="ds-section-card space-y-4">
-    <h2 class="ds-heading-lg text-slate-900"><%= body_section_label %></h2>
-    <div class="max-w-3xl">
-      <p class="ds-text-body whitespace-pre-wrap ds-break-words"><%= @post.description %></p>
-    </div>
-
+    <h2 class="ds-heading-lg text-slate-900"><%= t("posts.show.overview_heading", default: "Overview") %></h2>
+    <p class="ds-text-body whitespace-pre-wrap ds-break-words max-w-3xl"><%= @post.description %></p>
     <% if @post.tags.any? %>
       <div class="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
         <% @post.tags.each do |tag| %>
@@ -69,103 +52,63 @@
   <section class="ds-section-card hidden space-y-3 sm:block">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <h2 class="ds-heading-sm text-slate-900"><%= t("posts.show.actions.title", default: "Actions") %></h2>
-      <p class="ds-text-meta"><%= t("posts.show.actions.lead", default: "Like is primary. Share, copy, and report are in More actions.") %></p>
+      <p class="ds-text-meta"><%= t("posts.show.actions.lead", default: "Like is primary. Share and report are in More actions.") %></p>
     </div>
 
     <div class="relative flex flex-wrap items-center gap-2" data-desktop-post-actions-root>
-      <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-primary", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "desktop_like_primary" } do %>
-        <span class="inline-flex items-center gap-1.5">
-          <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.like") %></span>
-        </span>
+      <%= button_to like_post_path(@post), method: :post, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "control" } do %>
+        <span class="inline-flex items-center gap-1.5"><%= ui_icon(:heart, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.like") %></span></span>
       <% end %>
 
-      <button type="button" data-desktop-post-actions-toggle aria-expanded="false" aria-controls="desktop-post-actions-menu" class="tap-target cta-secondary">
-        <span class="inline-flex items-center gap-1.5">
-          <%= ui_icon(:ellipsis_horizontal, class_name: "h-4 w-4") %>
-          <span><%= more_actions_label %></span>
-        </span>
+      <button type="button" data-desktop-post-actions-toggle aria-haspopup="menu" aria-expanded="false" aria-controls="desktop-post-actions-menu" class="tap-target cta-secondary">
+        <span class="inline-flex items-center gap-1.5"><%= ui_icon(:ellipsis_horizontal, class_name: "h-4 w-4") %><span><%= t("posts.show.more_actions", default: "More actions") %></span></span>
       </button>
 
-      <div id="desktop-post-actions-menu" data-desktop-post-actions-menu class="absolute left-0 top-full z-20 mt-2 hidden min-w-64 rounded-xl border border-slate-300 bg-white p-2 shadow-2xl ring-1 ring-slate-900/5">
+      <div id="desktop-post-actions-menu" role="menu" data-desktop-post-actions-menu class="absolute left-0 top-full z-20 mt-2 hidden min-w-64 rounded-xl border border-slate-300 bg-white p-2 shadow-2xl ring-1 ring-slate-900/5">
         <div class="grid gap-1">
-          <button type="button" data-desktop-actions-menu-item data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-            <%= ui_icon(:share, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.share") %></span>
-          </button>
-          <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "desktop_share_x_menu" } do %>
-            <%= ui_icon(:share, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.share_x") %></span>
-          <% end %>
-          <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "desktop_share_threads_menu" } do %>
-            <%= ui_icon(:share, class_name: "h-4 w-4") %>
-            <span><%= t("posts.show.actions.share_threads") %></span>
-          <% end %>
-          <button type="button" data-desktop-actions-menu-item data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="desktop_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-            <%= ui_icon(:share, class_name: "h-4 w-4") %>
-            <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
-          </button>
+          <button type="button" role="menuitem" data-desktop-actions-menu-item data-copy-url="<%= share_url %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"><%= ui_icon(:share, class_name: "h-4 w-4") %><span data-copy-label><%= t("posts.show.actions.copy_url") %></span></button>
+          <button type="button" role="menuitem" data-desktop-actions-menu-item data-native-share-url="<%= share_url %>" data-native-share-text="<%= share_text %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"><%= ui_icon(:share, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.share") %></span></button>
+          <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", role: "menuitem", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true } do %><%= ui_icon(:share, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.share_x") %></span><% end %>
+          <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", role: "menuitem", class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100", data: { desktop_actions_menu_item: true } do %><%= ui_icon(:share, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.share_threads") %></span><% end %>
           <% unless post_owner?(@post) %>
-            <button type="button" data-desktop-actions-menu-item data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="desktop_report_menu" class="tap-target cta-warning cta-compact justify-start">
-              <%= ui_icon(:flag, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.report") %></span>
-            </button>
+            <button type="button" role="menuitem" data-desktop-actions-menu-item data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target cta-warning cta-compact justify-start"><%= ui_icon(:flag, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.report") %></span></button>
           <% end %>
         </div>
       </div>
     </div>
-  </section>
 
+    <% unless post_owner?(@post) %><p class="ds-trust-note"><%= t("reports.trust_note", default: "Reports are reviewed by moderators. Typical response time: within 24 hours.") %></p><% end %>
+  </section>
   <section class="ds-section-card space-y-4">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <h2 class="ds-heading-lg text-slate-900"><%= t("posts.show.related_items") %></h2>
-      <span class="inline-flex items-center gap-1 ds-text-meta text-slate-600">
-        <%= ui_icon(:heart, class_name: "h-4 w-4") %>
-        <span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span>
-      </span>
+      <span class="inline-flex items-center gap-1 ds-text-meta text-slate-600"><%= ui_icon(:heart, class_name: "h-4 w-4") %><span><%= t("metrics.likes") %>: <%= localized_number(@post.likes_count) %></span></span>
     </div>
 
     <% if @post.items.any? %>
       <div class="space-y-3">
         <% @post.items.each do |item| %>
-          <% item_facts = related_item_facts(item) %>
-          <% fact_map = item_facts.index_by { |fact| fact[:key] } %>
-          <% labels = {
-            brand: t("posts.show.item_brand", default: "Brand"),
-            category: t("posts.show.item_category", default: "Category"),
-            price: t("posts.show.item_price", default: "Price"),
-            source: t("posts.show.item_source", default: "Source")
-          } %>
-
+          <% fact_map = related_item_facts(item).index_by { |fact| fact[:key] } %>
           <article class="rounded-lg border border-slate-200 bg-slate-50 p-3 sm:p-4">
             <div class="grid gap-3 sm:grid-cols-[88px_minmax(0,1fr)] sm:items-start">
               <div class="aspect-square rounded-md border border-slate-200 bg-white text-slate-400">
-                <div class="flex h-full items-center justify-center">
-                  <div class="text-center">
-                    <%= ui_icon(:information_circle, class_name: "mx-auto h-5 w-5") %>
-                    <p class="mt-1 text-[10px] font-medium"><%= item_preview_label %></p>
-                  </div>
-                </div>
+                <div class="flex h-full items-center justify-center"><div class="text-center"><%= ui_icon(:information_circle, class_name: "mx-auto h-5 w-5") %><p class="mt-1 text-[10px] font-medium"><%= t("posts.show.item_preview", default: "Item preview") %></p></div></div>
               </div>
-
               <div class="space-y-3">
                 <h3 class="ds-heading-sm ds-break-words text-slate-900"><%= item.name %></h3>
-
                 <dl class="grid gap-2 sm:grid-cols-2">
                   <% [ :brand, :category, :price, :source ].each do |key| %>
-                    <% fact = fact_map[key] %>
                     <div class="rounded-md border border-slate-200 bg-white px-2.5 py-2">
-                      <dt class="ds-text-meta font-semibold text-slate-500"><%= labels[key] %></dt>
-                      <dd class="mt-0.5 text-sm text-slate-700 ds-break-words"><%= fact&.dig(:value).presence || (key == :price ? item_price_unknown_label : "-") %></dd>
+                      <dt class="ds-text-meta font-semibold text-slate-500"><%= t("posts.show.item_#{key}", default: key.to_s.humanize) %></dt>
+                      <dd class="mt-0.5 text-sm text-slate-700 ds-break-words"><%= fact_map[key]&.dig(:value).presence || (key == :price ? t("posts.show.item_price_unknown", default: "Price: unavailable") : "-") %></dd>
                     </div>
                   <% end %>
                 </dl>
-
                 <div class="flex flex-wrap items-center gap-2">
                   <% if item.affiliate_url.present? %>
                     <%= link_to t("posts.show.open_product_page"), item.affiliate_url, class: "tap-target cta-secondary cta-compact", target: "_blank", rel: "nofollow sponsored noopener" %>
                   <% else %>
-                    <span class="ds-text-muted"><%= item_link_missing_label %></span>
+                    <span class="ds-text-muted"><%= t("posts.show.item_link_missing", default: "Link not available") %></span>
                   <% end %>
                 </div>
               </div>
@@ -176,196 +119,154 @@
     <% else %>
       <p class="ds-text-support"><%= t("posts.show.no_related_items") %></p>
       <% if post_owner?(@post) %>
-        <p class="ds-text-support"><%= related_items_owner_hint %></p>
-        <%= link_to edit_post_path(@post), class: "inline-flex tap-target cta-secondary cta-compact" do %>
-          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.edit") %></span>
-        <% end %>
+        <p class="ds-text-support"><%= t("posts.show.related_items_owner_hint", default: "Add related items to help readers compare your setup.") %></p>
+        <%= link_to edit_post_path(@post), class: "inline-flex tap-target cta-secondary cta-compact" do %><%= ui_icon(:pencil_square, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.edit") %></span><% end %>
       <% end %>
     <% end %>
   </section>
 
   <section id="comments" class="ds-anchor-offset space-y-form rounded-xl border border-slate-200 bg-white p-4 sm:p-6">
     <div class="flex flex-wrap items-center justify-between gap-3">
-      <div class="space-y-1">
-        <h2 class="inline-flex items-center gap-1.5 ds-heading-lg text-slate-900">
-          <%= ui_icon(:chat, class_name: "h-5 w-5") %>
-          <span><%= t("posts.show.comments.title") %></span>
-        </h2>
-        <p class="ds-text-meta"><%= comments_count_label %></p>
-      </div>
-      <a href="#comment-form" class="tap-target cta-primary cta-compact"><%= @root_comments.any? ? t("posts.show.comments.post_comment") : comment_empty_cta %></a>
+      <div class="space-y-1"><h2 class="inline-flex items-center gap-1.5 ds-heading-lg text-slate-900" id="comments-heading"><%= ui_icon(:chat, class_name: "h-5 w-5") %><span><%= t("posts.show.comments.title") %></span></h2><p class="ds-text-meta"><%= comments_count_label %></p></div>
+      <a href="#comment-form" class="tap-target cta-primary cta-compact"><%= @root_comments.any? ? t("posts.show.comments.post_comment") : t("posts.show.comment_empty_cta", default: "Write the first comment") %></a>
     </div>
-
-    <p class="ds-text-support"><%= comments_lead_label %></p>
+    <p class="ds-text-support"><%= t("posts.show.comments_lead", default: "After reading the post and related items, join the conversation below.") %></p>
 
     <% if @root_comments.any? %>
-      <div class="space-y-4" aria-live="polite">
-        <% @root_comments.each do |comment| %>
-          <article id="comment-<%= comment.id %>" class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <div class="flex items-center justify-between gap-3">
-              <p class="text-sm font-medium text-slate-800 ds-break-words"><%= comment.author_name %></p>
-            </div>
-            <p class="mt-0.5 ds-text-meta"><%= l(comment.created_at, format: :short) %></p>
-            <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= comment.body %></p>
-
-            <% if comment.replies.any? %>
-              <div class="mt-4 space-y-2 rounded-lg bg-slate-50 px-3 py-3 sm:pl-4 sm:pr-3">
-                <% comment.replies.each do |reply| %>
-                  <div id="comment-<%= reply.id %>" class="rounded-md border border-slate-100 bg-white/85 px-3 py-2">
-                    <p class="text-xs font-medium text-slate-700 ds-break-words"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
-                    <p class="mt-0.5 ds-text-meta"><%= l(reply.created_at, format: :short) %></p>
-                    <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= reply.body %></p>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
-
-            <div class="mt-3 border-t border-slate-100 pt-3">
-              <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700", data: { ga_event: "comment_reply_click", ga_category: "comments", ga_label: "reply_to_parent" } do %>
-                <%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %>
-                <span><%= t("posts.show.comments.reply") %></span>
+      <ol class="space-y-4" aria-live="polite" aria-labelledby="comments-heading">
+        <% @root_comments.each_with_index do |comment, index| %>
+          <li>
+            <article id="comment-<%= comment.id %>" class="ds-thread-root" aria-label="<%= t('posts.show.comments.thread_label', default: 'Comment thread %{position}', position: index + 1) %>">
+              <div class="flex items-center justify-between gap-3"><p class="text-sm font-medium text-slate-800 ds-break-words"><%= comment.author_name %></p></div>
+              <p class="mt-0.5 ds-text-meta"><%= timestamp_tag(comment.created_at, style: :datetime) %></p>
+              <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= comment.body %></p>
+              <% if comment.replies.any? %>
+                <div class="ds-thread-reply-wrap" aria-label="<%= t('posts.show.comments.replies', default: 'Replies') %>">
+                  <% comment.replies.each do |reply| %>
+                    <div id="comment-<%= reply.id %>" class="ds-thread-reply">
+                      <p class="text-xs font-medium text-slate-700 ds-break-words"><%= t("posts.show.comments.replied_by", name: reply.author_name) %></p>
+                      <p class="mt-0.5 ds-text-meta"><%= timestamp_tag(reply.created_at, style: :datetime) %></p>
+                      <p class="mt-1 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= reply.body %></p>
+                    </div>
+                  <% end %>
+                </div>
               <% end %>
-            </div>
-          </article>
+              <div class="mt-3 border-t border-slate-100 pt-3">
+                <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700" do %><%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %><span><%= t("posts.show.comments.reply") %></span><% end %>
+              </div>
+            </article>
+          </li>
         <% end %>
-      </div>
+      </ol>
     <% else %>
-      <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center">
-        <p class="ds-text-support"><%= t("posts.show.comments.empty_state") %></p>
-        <a href="#comment-form" class="mt-3 inline-flex tap-target cta-primary cta-compact"><%= comment_empty_cta %></a>
-      </div>
+      <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-center"><p class="ds-text-support"><%= t("posts.show.comments.empty_state") %></p><a href="#comment-form" class="mt-3 inline-flex tap-target cta-primary cta-compact"><%= t("posts.show.comment_empty_cta", default: "Write the first comment") %></a></div>
     <% end %>
-
     <div class="ds-anchor-offset border-t border-slate-200 pt-4" id="comment-form" data-comment-form-root>
       <% if @reply_to_comment.present? %>
         <div class="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800" data-reply-context>
-          <p>
-            <%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %>
-            <%= link_to t("posts.show.comments.cancel"), post_path(@post, anchor: "comments"), class: "ml-2 text-blue-600 underline" %>
-          </p>
+          <p><%= t("posts.show.comments.replying_to", name: @reply_to_comment.author_name) %> <%= link_to t("posts.show.comments.cancel"), post_path(@post, anchor: "comments"), class: "ml-2 text-blue-600 underline" %></p>
           <p class="mt-1 text-xs text-blue-700 ds-break-words"><%= truncate(@reply_to_comment.body.to_s.squish, length: 100) %></p>
         </div>
       <% end %>
 
-      <%= form_with model: [@post, @comment], class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
+      <%= form_with model: [@post, @comment], class: "space-y-form ds-loading-shell", data: { form_autofocus_errors: true, ui_form: true, loading_label: t("ui.processing", default: "Processing..."), submitting_reason: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
         <% if @comment.errors.any? %>
-          <div id="comment-error-summary" class="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700" role="alert" tabindex="-1">
-            <p class="mb-2 font-semibold"><%= t("posts.form.error_summary", default: "Please fix the following errors.") %></p>
-            <ul class="list-disc pl-5">
-              <% @comment.errors.full_messages.each do |message| %>
-                <li><%= message %></li>
-              <% end %>
-            </ul>
+          <div class="space-y-2">
+            <%= render "shared/feedback_panel", level: :error, title: t("posts.form.error_summary", default: "Please fix the following errors."), body: t("comments.form.error_recovery", default: "Please update the fields and retry."), actions: [{ label: t("ui.retry", default: "Retry"), href: "#comment-form" }, { label: t("ui.back", default: "Back"), href: post_path(@post, anchor: "comments") }] %>
+            <div id="comment-error-summary" class="rounded-lg border border-red-200 bg-white p-3 text-sm text-red-800" role="alert" tabindex="-1"><ul class="list-disc pl-5"><% @comment.errors.full_messages.each do |message| %><li><%= message %></li><% end %></ul></div>
           </div>
         <% end %>
 
         <% if owned_users.any? %>
           <div>
-            <%= f.label :user_id, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
-              <span><%= t("posts.show.comments.comment_as_profile") %></span>
-              <span class="ds-badge-info"><%= comment_optional_label %></span>
-            <% end %>
+            <%= f.label :user_id, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %><span><%= t("posts.show.comments.comment_as_profile") %></span><span class="ds-badge-info"><%= t("posts.show.comments.optional", default: "Optional") %></span><% end %>
             <%= f.collection_select :user_id, owned_users, :id, :name, { include_blank: t("posts.show.comments.post_as_guest") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { comment_input: "user_id" } %>
-            <p class="mt-1 ds-text-muted"><%= t("posts.show.comments.profile_help", default: "Optional: choose a profile, or post as guest.") %></p>
+            <p class="ds-field-guide"><%= t("posts.show.comments.profile_help", default: "Optional: choose a profile, or post as guest.") %></p>
           </div>
         <% end %>
 
         <%= f.hidden_field :parent_comment_id, value: @reply_to_comment&.id %>
 
         <div>
-          <%= f.label :author_name, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
-            <span><%= t("posts.show.comments.name") %></span>
-            <span class="ds-badge-active"><%= comment_required_label %></span>
-          <% end %>
-          <%= f.text_field :author_name, required: true, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.comments.name_example", default: "Example: Alex"), data: { comment_input: "author_name" } %>
+          <%= f.label :author_name, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %><span><%= t("posts.show.comments.name") %></span><span class="ds-badge-active"><%= t("posts.show.comments.required", default: "Required") %></span><% end %>
+          <%= f.text_field :author_name, required: true, maxlength: 40, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.comments.name_example", default: "Example: Alex"), data: { comment_input: "author_name", char_count_max: 40, char_count_target: "comment_name_counter" }, aria: { describedby: "comment_name_guide comment_name_counter" } %>
+          <p id="comment_name_guide" class="ds-field-guide"><%= t("comments.form.name_guide", default: "Shown publicly with your comment.") %></p>
+          <p id="comment_name_counter" class="ds-char-counter" aria-live="polite"></p>
         </div>
 
         <div>
-          <%= f.label :body, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %>
-            <span><%= t("posts.show.comments.comment") %></span>
-            <span class="ds-badge-active"><%= comment_required_label %></span>
-          <% end %>
-          <%= f.text_area :body, rows: 4, required: true, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm ds-break-words", placeholder: t("posts.show.comments.body_example", default: "What part of this setup stood out to you?"), data: { comment_input: "body" } %>
-          <p class="mt-1 ds-text-muted"><%= t("posts.show.comments.body_help", default: "Tip: include one concrete point to get a better reply.") %></p>
+          <%= f.label :body, class: "mb-1 inline-flex items-center gap-1.5 text-sm font-medium" do %><span><%= t("posts.show.comments.comment") %></span><span class="ds-badge-active"><%= t("posts.show.comments.required", default: "Required") %></span><% end %>
+          <%= f.text_area :body, rows: 4, required: true, maxlength: 500, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm ds-break-words", placeholder: t("posts.show.comments.body_example", default: "What part of this setup stood out to you?"), data: { comment_input: "body", char_count_max: 500, char_count_target: "comment_body_counter" }, aria: { describedby: "comment_body_help comment_body_counter" } %>
+          <p id="comment_body_help" class="ds-field-guide"><%= t("posts.show.comments.body_help", default: "Tip: include one concrete point to get a better reply.") %></p>
+          <p id="comment_body_counter" class="ds-char-counter" aria-live="polite"></p>
         </div>
 
-        <% if recaptcha_enabled? %>
-          <div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>" data-recaptcha-shell></div>
-        <% end %>
+        <% if recaptcha_enabled? %><div class="g-recaptcha" data-sitekey="<%= recaptcha_site_key %>" data-recaptcha-shell></div><% end %>
 
-        <%= f.button type: :submit, class: "tap-target cta-primary", data: { ga_event: "comment_submit_click", ga_category: "comments", ga_label: (@reply_to_comment.present? ? "reply_submit" : "root_submit") } do %>
-          <span class="inline-flex items-center gap-1.5">
-            <%= ui_icon(:chat, class_name: "h-4 w-4") %>
-            <span><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span>
-          </span>
-        <% end %>
+        <%= f.button type: :submit, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "compact" } do %><span class="inline-flex items-center gap-1.5"><%= ui_icon(:chat, class_name: "h-4 w-4") %><span data-submit-label><%= @reply_to_comment.present? ? t("posts.show.comments.reply") : t("posts.show.comments.post_comment") %></span></span><% end %>
+        <p class="ds-disabled-reason" data-disabled-reason aria-live="polite"></p>
       <% end %>
     </div>
+
+    <div class="ds-legal-links border-t border-slate-200 pt-3"><span class="text-slate-500"><%= t("legal.quick_links", default: "Policies") %>:</span><%= link_to t("footer.terms"), terms_path %><%= link_to t("footer.privacy_policy"), privacy_policy_path %><%= link_to t("footer.cookie_policy"), cookie_policy_path %></div>
   </section>
 
   <% if post_owner?(@post) %>
     <section class="ds-card space-y-4 p-4">
-      <h2 class="ds-heading-sm text-slate-900"><%= owner_action_heading %></h2>
+      <h2 class="ds-heading-sm text-slate-900"><%= t("posts.show.owner_actions", default: "Owner actions") %></h2>
       <div class="flex flex-wrap items-center gap-2">
-        <%= link_to edit_post_path(@post), class: "tap-target cta-secondary" do %>
-          <%= ui_icon(:pencil_square, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.edit") %></span>
-        <% end %>
-        <%= link_to notifications_post_path(@post), class: "tap-target cta-secondary" do %>
-          <%= ui_icon(:bell, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span>
-        <% end %>
+        <%= link_to edit_post_path(@post), class: "tap-target cta-secondary" do %><%= ui_icon(:pencil_square, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.edit") %></span><% end %>
+        <%= link_to notifications_post_path(@post), class: "tap-target cta-secondary" do %><%= ui_icon(:bell, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.notifications", count: localized_number(@unread_notifications_count)) %></span><% end %>
       </div>
-
       <div class="border-t border-red-100 pt-3">
-        <p class="ds-text-meta font-semibold text-red-700"><%= danger_zone_label %></p>
-        <p class="mt-1 ds-text-muted text-red-700"><%= danger_zone_lead %></p>
-        <%= button_to post_path(@post), method: :delete, form: { class: "mt-2 inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target cta-danger" do %>
-          <%= ui_icon(:trash, class_name: "h-4 w-4") %>
-          <span><%= t("posts.show.actions.delete") %></span>
-        <% end %>
+        <p class="ds-text-meta font-semibold text-red-700"><%= t("posts.show.danger_zone", default: "Danger zone") %></p>
+        <p class="mt-1 ds-text-muted text-red-700"><%= t("posts.show.danger_zone_lead", default: "Post deletion cannot be undone.") %></p>
+        <%= button_to post_path(@post), method: :delete, form: { class: "mt-2 inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target cta-danger" do %><%= ui_icon(:trash, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.delete") %></span><% end %>
       </div>
     </section>
+  <% end %>
+
+  <% unless post_owner?(@post) %>
+    <dialog id="report-modal-<%= @post.id %>" data-report-modal class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
+      <div class="border-b border-slate-200 px-4 py-3"><h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2><p class="mt-1 text-xs text-slate-600"><%= t("posts.show.report.description") %></p></div>
+      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4", data: { ui_form: true, loading_label: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
+        <% if owned_users.any? %><div><%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %><%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: true } %></div><% end %>
+        <div><%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %><%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: owned_users.any? ? nil : true } %><p class="ds-field-guide"><%= t("reports.reason_guide", default: "Select the closest reason so moderators can triage faster.") %></p></div>
+        <div><%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %><%= f.text_area :details, rows: 4, maxlength: 1000, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.report.details_placeholder"), data: { char_count_max: 1000, char_count_target: "report_details_counter" }, aria: { describedby: "report_details_guide report_details_counter" } %><p id="report_details_guide" class="ds-field-guide"><%= t("reports.details_guide", default: "Optional: include concise evidence. Avoid personal information.") %></p><p id="report_details_counter" class="ds-char-counter" aria-live="polite"></p></div>
+        <p class="ds-trust-note"><%= t("reports.trust_note", default: "Reports are reviewed by moderators. Typical response time: within 24 hours.") %></p>
+        <div class="flex justify-end gap-2 pt-2"><button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="tap-target cta-tertiary"><%= t("posts.show.report.cancel") %></button><%= f.button type: :submit, class: "tap-target cta-warning" do %><span data-submit-label><%= t("posts.show.report.submit") %></span><% end %></div>
+        <p class="ds-disabled-reason" data-disabled-reason aria-live="polite"></p>
+      <% end %>
+    </dialog>
   <% end %>
 
   <div class="mobile-sticky-bar transition-all duration-200 sm:hidden" data-mobile-actions-root>
     <div class="mx-auto w-full max-w-6xl px-4 pt-3">
       <div class="relative pb-1">
         <div class="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-1.5">
-          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-primary w-full justify-center", data: { ga_event: "post_action_like_click", ga_category: "post_actions", ga_label: "mobile_like_primary" } do %>
+          <%= button_to like_post_path(@post), method: :post, form: { class: "w-full" }, class: "tap-target cta-primary w-full justify-center ds-cta-experiment", data: { variant: "control" } do %>
             <span class="inline-flex items-center justify-center gap-1.5">
               <%= ui_icon(:heart, class_name: "h-4 w-4") %>
               <span><%= t("posts.show.actions.like") %></span>
             </span>
           <% end %>
-
-          <button type="button" data-mobile-actions-toggle aria-expanded="false" aria-controls="mobile-post-actions-menu" data-ga-event="post_action_more_menu_toggle" data-ga-category="post_actions" data-ga-label="mobile_more_toggle" class="ds-icon-button text-slate-600 hover:bg-slate-100 hover:text-slate-900">
+          <button type="button" data-mobile-actions-toggle aria-haspopup="menu" aria-expanded="false" aria-controls="mobile-post-actions-menu" class="ds-icon-button text-slate-600 hover:bg-slate-100 hover:text-slate-900">
             <%= ui_icon(:ellipsis_horizontal, class_name: "h-5 w-5") %>
-            <span class="sr-only"><%= mobile_more_label %></span>
+            <span class="sr-only"><%= t("posts.show.mobile_more_label", default: "More actions") %></span>
           </button>
         </div>
-
-        <div id="mobile-post-actions-menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-20 mb-2 hidden rounded-xl border border-slate-300 bg-white/98 p-2 shadow-2xl ring-1 ring-slate-900/5">
+        <div id="mobile-post-actions-menu" role="menu" data-mobile-actions-menu class="absolute inset-x-0 bottom-full z-20 mb-2 hidden rounded-xl border border-slate-300 bg-white/98 p-2 shadow-2xl ring-1 ring-slate-900/5">
           <div class="grid gap-1">
-            <button type="button" data-mobile-menu-action data-native-share-url="<%= post_share_url(@post) %>" data-native-share-text="<%= post_share_text(@post) %>" data-ga-event="post_action_share_primary_click" data-ga-category="post_actions" data-ga-label="mobile_share_primary_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share") %></span>
-            </button>
-            <%= link_to x_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_x_click", ga_category: "post_actions", ga_label: "mobile_share_x_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_x") %></span>
-            <% end %>
-            <%= link_to threads_share_url(@post), target: "_blank", rel: "noopener", data: { mobile_menu_action: true, ga_event: "post_action_share_threads_click", ga_category: "post_actions", ga_label: "mobile_share_threads_menu" }, class: "tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100" do %>
-              <%= ui_icon(:share, class_name: "h-4 w-4") %>
-              <span><%= t("posts.show.actions.share_threads") %></span>
-            <% end %>
-            <button type="button" data-mobile-menu-action data-copy-url="<%= post_share_url(@post) %>" data-ga-event="post_action_copy_url_click" data-ga-category="post_actions" data-ga-label="mobile_copy_url_menu" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+            <button type="button" role="menuitem" data-mobile-menu-action data-copy-url="<%= share_url %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
               <%= ui_icon(:share, class_name: "h-4 w-4") %>
               <span data-copy-label><%= t("posts.show.actions.copy_url") %></span>
             </button>
+            <button type="button" role="menuitem" data-mobile-menu-action data-native-share-url="<%= share_url %>" data-native-share-text="<%= share_text %>" class="tap-target inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-100">
+              <%= ui_icon(:share, class_name: "h-4 w-4") %>
+              <span><%= t("posts.show.actions.share") %></span>
+            </button>
             <% unless post_owner?(@post) %>
-              <button type="button" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" data-ga-event="post_action_report_click" data-ga-category="post_actions" data-ga-label="mobile_report_menu" class="tap-target cta-warning cta-compact justify-start">
+              <button type="button" role="menuitem" data-mobile-menu-action data-open-report-modal="report-modal-<%= @post.id %>" class="tap-target cta-warning cta-compact justify-start">
                 <%= ui_icon(:flag, class_name: "h-4 w-4") %>
                 <span><%= t("posts.show.actions.report") %></span>
               </button>
@@ -376,117 +277,55 @@
     </div>
   </div>
 
-  <% unless post_owner?(@post) %>
-    <dialog id="report-modal-<%= @post.id %>" data-report-modal class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
-      <div class="border-b border-slate-200 px-4 py-3">
-        <h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2>
-        <p class="mt-1 text-xs text-slate-600"><%= t("posts.show.report.description") %></p>
-      </div>
-      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4" do |f| %>
-        <% if owned_users.any? %>
-          <div>
-            <%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %>
-            <%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: true } %>
-          </div>
-        <% end %>
-
-        <div>
-          <%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: owned_users.any? ? nil : true } %>
-        </div>
-
-        <div>
-          <%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %>
-          <%= f.text_area :details, rows: 4, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.report.details_placeholder") %>
-        </div>
-
-        <div class="flex justify-end gap-2 pt-2">
-          <button type="button" data-close-report-modal="report-modal-<%= @post.id %>" class="tap-target cta-tertiary"><%= t("posts.show.report.cancel") %></button>
-          <%= f.submit t("posts.show.report.submit"), class: "tap-target cta-warning" %>
-        </div>
-      <% end %>
-    </dialog>
-  <% end %>
-
-  <div class="space-y-2">
-    <p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p>
-    <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %>
-  </div>
-
-  <div class="space-y-2">
-    <p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p>
-    <%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %>
-  </div>
+  <div class="space-y-2"><p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p><%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_BODY"] %></div>
+  <div class="space-y-2"><p class="ad-slot-divider"><%= t("ads.sponsored_placement", default: "Sponsored placement") %></p><%= render "shared/ad_slot", slot: ENV["ADSENSE_SLOT_POST_FOOTER"] %></div>
 </article>
+
+<section class="hidden" data-page-skeleton aria-hidden="true"><%= render "shared/screen_skeleton", variant: :detail %></section>
 
 <script>
   if (!window.__postShowUiBindingInstalled) {
     window.__postShowUiBindingInstalled = true;
-
-    const mobileMenuOpenMessage = "<%= j(mobile_menu_open_label) %>";
-    const mobileMenuCloseMessage = "<%= j(mobile_menu_close_label) %>";
+    const menuOpenMessage = "<%= j(t('navigation.menu_opened', default: 'Action menu opened')) %>";
+    const menuCloseMessage = "<%= j(t('navigation.menu_closed', default: 'Action menu closed')) %>";
     let lastModalTrigger = null;
-    let commentFormStarted = false;
 
     const markLoadedMedia = (scope = document) => {
       scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
         const image = frame.querySelector("img");
-        if (!image) {
+        if (!image || image.complete) {
           frame.classList.add("ds-media-loaded");
           return;
         }
-        if (image.complete) {
-          frame.classList.add("ds-media-loaded");
-          return;
-        }
-
         image.addEventListener("load", () => frame.classList.add("ds-media-loaded"), { once: true });
         image.addEventListener("error", () => frame.classList.add("ds-media-loaded"), { once: true });
       });
     };
 
-    const closeDesktopActionsMenu = (reason = "dismissed") => {
-      const menu = document.querySelector("[data-desktop-post-actions-menu]");
-      const toggle = document.querySelector("[data-desktop-post-actions-toggle]");
-      if (!menu || menu.classList.contains("hidden")) return;
-
-      menu.classList.add("hidden");
-      if (toggle) toggle.setAttribute("aria-expanded", "false");
-      if (typeof window.gtag === "function") {
-        window.gtag("event", "post_action_desktop_menu_close", {
-          event_category: "post_actions",
-          event_label: `desktop_menu_${reason}`
-        });
-      }
+    const highlightCommentFromHash = () => {
+      if (!window.location.hash.startsWith("#comment-")) return;
+      const target = document.querySelector(window.location.hash);
+      if (!target) return;
+      target.classList.add("ds-reply-target-highlight");
+      window.setTimeout(() => target.classList.remove("ds-reply-target-highlight"), 1600);
     };
 
-    const closeMobileActionsMenu = (reason = "dismissed") => {
-      const menu = document.querySelector("[data-mobile-actions-menu]");
-      const toggle = document.querySelector("[data-mobile-actions-toggle]");
+    const closeMenu = (menuSelector, toggleSelector, notify = false) => {
+      const menu = document.querySelector(menuSelector);
+      const toggle = document.querySelector(toggleSelector);
       if (!menu || menu.classList.contains("hidden")) return;
-
       menu.classList.add("hidden");
       if (toggle) toggle.setAttribute("aria-expanded", "false");
-      if (typeof window.dsNotify === "function") window.dsNotify(mobileMenuCloseMessage, "info");
-      if (typeof window.gtag === "function") {
-        window.gtag("event", "post_action_more_menu_close", {
-          event_category: "post_actions",
-          event_label: `mobile_more_menu_${reason}`
-        });
-      }
+      if (notify && typeof window.dsNotify === "function") window.dsNotify(menuCloseMessage, "info");
     };
 
     const openModal = (trigger, modalId) => {
       const dialog = document.getElementById(modalId);
       if (!dialog || typeof dialog.showModal !== "function") return;
-
       lastModalTrigger = trigger;
       dialog.showModal();
-
       const focusTarget = dialog.querySelector("[data-modal-initial-focus]") || dialog.querySelector("input, select, textarea, button");
-      if (focusTarget) {
-        window.setTimeout(() => focusTarget.focus(), 0);
-      }
+      if (focusTarget) window.setTimeout(() => focusTarget.focus(), 0);
     };
 
     const closeModal = (dialog) => {
@@ -498,27 +337,17 @@
     };
 
     const runNativeShare = (button) => {
-      if (!button) return;
-      const url = button.getAttribute("data-native-share-url");
-      const text = button.getAttribute("data-native-share-text");
+      const url = button?.getAttribute("data-native-share-url");
+      const text = button?.getAttribute("data-native-share-text");
       if (!url) return;
-
       if (navigator.share) {
-        navigator.share({ text, url }).catch(async (error) => {
-          if (error && error.name === "AbortError") return;
-          try {
-            await navigator.clipboard.writeText(url);
-          } catch (_) {}
-        });
+        navigator.share({ text, url }).catch(() => navigator.clipboard.writeText(url).catch(() => {}));
       } else {
         navigator.clipboard.writeText(url).catch(() => {});
       }
     };
 
-    const keyboardOpen = () => {
-      if (!window.visualViewport) return false;
-      return (window.innerHeight - window.visualViewport.height) > 130;
-    };
+    const keyboardOpen = () => window.visualViewport ? (window.innerHeight - window.visualViewport.height) > 130 : false;
 
     const syncMobileActionBar = () => {
       const root = document.querySelector("[data-mobile-actions-root]");
@@ -532,14 +361,13 @@
       const focusedOnComment = commentForm ? commentForm.contains(document.activeElement) : false;
       const replyMode = Boolean(commentFormRoot && commentFormRoot.querySelector("[data-reply-context]"));
       const recaptchaFocused = recaptchaShell ? recaptchaShell.contains(document.activeElement) : false;
-      const recaptchaVisible = (() => {
-        if (!recaptchaShell) return false;
+      const recaptchaVisible = recaptchaShell ? (() => {
         const rect = recaptchaShell.getBoundingClientRect();
         return rect.top < window.innerHeight && rect.bottom > 0;
-      })();
-      const menuOpen = menu && !menu.classList.contains("hidden");
-      const shouldHide = focusedOnComment || keyboardOpen() || Boolean(modal) || replyMode || recaptchaFocused || recaptchaVisible;
+      })() : false;
 
+      const shouldHide = focusedOnComment || keyboardOpen() || Boolean(modal) || replyMode || recaptchaFocused || recaptchaVisible;
+      const menuOpen = menu && !menu.classList.contains("hidden");
       root.classList.toggle("translate-y-full", shouldHide);
       root.classList.toggle("opacity-0", shouldHide);
       root.classList.toggle("pointer-events-none", shouldHide && !menuOpen);
@@ -549,33 +377,22 @@
       dialog.addEventListener("click", (event) => {
         if (event.target === dialog) closeModal(dialog);
       });
-      dialog.addEventListener("close", () => {
-        if (lastModalTrigger && typeof lastModalTrigger.focus === "function") {
-          window.setTimeout(() => lastModalTrigger.focus(), 0);
-        }
-        syncMobileActionBar();
-      });
-      dialog.addEventListener("cancel", () => {
-        if (lastModalTrigger && typeof lastModalTrigger.focus === "function") {
-          window.setTimeout(() => lastModalTrigger.focus(), 0);
-        }
-      });
+      dialog.addEventListener("close", syncMobileActionBar);
     });
 
     document.addEventListener("click", (event) => {
       const openButton = event.target.closest("[data-open-report-modal]");
       if (openButton) {
         openModal(openButton, openButton.getAttribute("data-open-report-modal"));
-        closeMobileActionsMenu("modal_open");
-        closeDesktopActionsMenu("modal_open");
+        closeMenu("[data-mobile-actions-menu]", "[data-mobile-actions-toggle]", true);
+        closeMenu("[data-desktop-post-actions-menu]", "[data-desktop-post-actions-toggle]");
         syncMobileActionBar();
         return;
       }
 
       const closeButton = event.target.closest("[data-close-report-modal]");
       if (closeButton) {
-        const dialog = document.getElementById(closeButton.getAttribute("data-close-report-modal"));
-        closeModal(dialog);
+        closeModal(document.getElementById(closeButton.getAttribute("data-close-report-modal")));
         return;
       }
 
@@ -583,7 +400,6 @@
       if (desktopToggle) {
         const menu = document.querySelector("[data-desktop-post-actions-menu]");
         if (!menu) return;
-
         const expanded = desktopToggle.getAttribute("aria-expanded") == "true";
         menu.classList.toggle("hidden", expanded);
         desktopToggle.setAttribute("aria-expanded", String(!expanded));
@@ -593,97 +409,61 @@
       const desktopAction = event.target.closest("[data-desktop-actions-menu-item]");
       if (desktopAction) {
         runNativeShare(desktopAction.closest("[data-native-share-url]") || desktopAction);
-        closeDesktopActionsMenu("action_selected");
+        closeMenu("[data-desktop-post-actions-menu]", "[data-desktop-post-actions-toggle]");
         return;
       }
 
-      const mobileActionsToggle = event.target.closest("[data-mobile-actions-toggle]");
-      if (mobileActionsToggle) {
+      const mobileToggle = event.target.closest("[data-mobile-actions-toggle]");
+      if (mobileToggle) {
         const menu = document.querySelector("[data-mobile-actions-menu]");
         if (!menu) return;
-
-        const expanded = mobileActionsToggle.getAttribute("aria-expanded") == "true";
+        const expanded = mobileToggle.getAttribute("aria-expanded") == "true";
         menu.classList.toggle("hidden", expanded);
-        mobileActionsToggle.setAttribute("aria-expanded", String(!expanded));
-        if (!expanded && typeof window.dsNotify === "function") window.dsNotify(mobileMenuOpenMessage, "info");
-        if (expanded && typeof window.dsNotify === "function") window.dsNotify(mobileMenuCloseMessage, "info");
+        mobileToggle.setAttribute("aria-expanded", String(!expanded));
+        if (!expanded && typeof window.dsNotify === "function") window.dsNotify(menuOpenMessage, "info");
+        if (expanded && typeof window.dsNotify === "function") window.dsNotify(menuCloseMessage, "info");
         syncMobileActionBar();
         return;
       }
 
       const shareButton = event.target.closest("[data-native-share-url]");
-      if (shareButton) {
-        runNativeShare(shareButton);
-      }
+      if (shareButton) runNativeShare(shareButton);
 
       const mobileMenuAction = event.target.closest("[data-mobile-menu-action]");
       if (mobileMenuAction) {
-        closeMobileActionsMenu("action_selected");
+        closeMenu("[data-mobile-actions-menu]", "[data-mobile-actions-toggle]", true);
         return;
       }
 
       const mobileMenu = document.querySelector("[data-mobile-actions-menu]");
       if (mobileMenu && !mobileMenu.classList.contains("hidden") && !event.target.closest("[data-mobile-actions-menu]") && !event.target.closest("[data-mobile-actions-toggle]")) {
-        closeMobileActionsMenu("outside_tap");
+        closeMenu("[data-mobile-actions-menu]", "[data-mobile-actions-toggle]", true);
       }
 
       const desktopMenu = document.querySelector("[data-desktop-post-actions-menu]");
       if (desktopMenu && !desktopMenu.classList.contains("hidden") && !event.target.closest("[data-desktop-post-actions-root]")) {
-        closeDesktopActionsMenu("outside_tap");
+        closeMenu("[data-desktop-post-actions-menu]", "[data-desktop-post-actions-toggle]");
       }
     });
 
     document.addEventListener("keydown", (event) => {
       if (event.key !== "Escape") return;
-      closeMobileActionsMenu("escape");
-      closeDesktopActionsMenu("escape");
+      closeMenu("[data-mobile-actions-menu]", "[data-mobile-actions-toggle]", true);
+      closeMenu("[data-desktop-post-actions-menu]", "[data-desktop-post-actions-toggle]");
       const activeDialog = document.querySelector("[data-report-modal][open]");
       if (activeDialog) closeModal(activeDialog);
     });
 
-    document.addEventListener("focusin", (event) => {
-      syncMobileActionBar();
-      const form = event.target.closest("#comment-form form");
-      if (!form || commentFormStarted || typeof window.gtag !== "function") return;
-
-      commentFormStarted = true;
-      window.gtag("event", "comment_form_start", {
-        event_category: "comments",
-        event_label: document.querySelector("[data-reply-context]") ? "reply_mode" : "new_comment"
-      });
-    }, true);
+    document.addEventListener("focusin", syncMobileActionBar, true);
     document.addEventListener("focusout", () => window.setTimeout(syncMobileActionBar, 0), true);
-    document.addEventListener("submit", (event) => {
-      const form = event.target.closest("#comment-form form");
-      if (!form || typeof window.gtag !== "function") return;
-
-      const hasProfile = ((form.querySelector("[name='comment[user_id]']")?.value || "").trim().length > 0);
-      const bodyLength = (form.querySelector("[name='comment[body]']")?.value || "").trim().length;
-      window.gtag("event", "comment_submit_attempt", {
-        event_category: "comments",
-        event_label: document.querySelector("[data-reply-context]") ? "reply_mode" : "new_comment",
-        has_profile: hasProfile,
-        body_length: bodyLength
-      });
-    });
     window.addEventListener("resize", syncMobileActionBar);
     if (window.visualViewport) {
       window.visualViewport.addEventListener("resize", syncMobileActionBar);
       window.visualViewport.addEventListener("scroll", syncMobileActionBar);
     }
 
-    document.addEventListener("turbo:load", () => {
-      markLoadedMedia();
-      syncMobileActionBar();
-    });
-    document.addEventListener("DOMContentLoaded", () => {
-      markLoadedMedia();
-      syncMobileActionBar();
-    });
-
-    window.setTimeout(() => {
-      markLoadedMedia();
-      syncMobileActionBar();
-    }, 0);
+    document.addEventListener("turbo:load", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); });
+    document.addEventListener("DOMContentLoaded", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); });
+    window.setTimeout(() => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); }, 0);
   }
 </script>

--- a/app/views/shared/_ad_slot.html.erb
+++ b/app/views/shared/_ad_slot.html.erb
@@ -1,8 +1,11 @@
 <% if adsense_enabled? && slot.present? %>
-  <div class="my-12 sm:my-14">
+  <div class="my-12 sm:my-14" role="complementary" aria-label="<%= t('ads.sponsored_placement', default: 'Sponsored placement') %>">
     <div class="ad-slot-surface">
-      <p class="ad-slot-label">Sponsored</p>
-      <div class="flex justify-center">
+      <div class="mb-3 flex items-center justify-between gap-3 border-b border-slate-200 pb-2">
+        <p class="ad-slot-label">Sponsored</p>
+        <p class="text-[11px] font-medium text-slate-500"><%= t("ads.not_content", default: "Advertisement") %></p>
+      </div>
+      <div class="flex justify-center rounded-lg border border-slate-200 bg-white px-2 py-3">
         <ins class="adsbygoogle"
              style="display:block"
              data-ad-client="<%= ENV["ADSENSE_CLIENT_ID"] %>"

--- a/app/views/shared/_experiment_cta.html.erb
+++ b/app/views/shared/_experiment_cta.html.erb
@@ -1,0 +1,14 @@
+<% href = local_assigns.fetch(:href) %>
+<% label = local_assigns.fetch(:label) %>
+<% variant = local_assigns.fetch(:variant, "control") %>
+<% tone = local_assigns.fetch(:tone, "primary") %>
+<% css = case tone.to_s
+when "secondary" then "cta-secondary"
+when "tertiary" then "cta-tertiary"
+else "cta-primary"
+end %>
+<% html_options = (local_assigns[:html_options] || {}).deep_dup %>
+<% html_options[:class] = ["tap-target", css, "ds-cta-experiment", html_options[:class]].compact.join(" ") %>
+<% html_options[:data] = { variant: variant }.merge(html_options[:data] || {}) %>
+
+<%= link_to label, href, html_options %>

--- a/app/views/shared/_feedback_panel.html.erb
+++ b/app/views/shared/_feedback_panel.html.erb
@@ -1,0 +1,43 @@
+<% level = (local_assigns[:level] || :info).to_sym %>
+<% title = local_assigns[:title] %>
+<% body = local_assigns[:body] %>
+<% actions = Array(local_assigns[:actions]) %>
+<% tone = case level
+when :error
+  "border-red-300 bg-red-50 text-red-800"
+when :warning
+  "border-amber-300 bg-amber-50 text-amber-900"
+when :success
+  "border-emerald-300 bg-emerald-50 text-emerald-800"
+else
+  "border-blue-300 bg-blue-50 text-blue-900"
+end %>
+<% icon = case level
+when :error then :x_circle
+when :warning then :exclamation_triangle
+when :success then :check_circle
+else :information_circle
+end %>
+
+<div class="rounded-lg border px-4 py-3 text-sm <%= tone %>" role="<%= level == :error ? 'alert' : 'status' %>" aria-live="<%= level == :error ? 'assertive' : 'polite' %>">
+  <div class="flex items-start gap-2">
+    <%= status_badge(level: level, icon: icon, label: title.presence || t("status_levels.#{level}", default: level.to_s.humanize)) %>
+    <div class="space-y-2">
+      <% if body.present? %>
+        <p class="pt-0.5"><%= body %></p>
+      <% end %>
+      <% if actions.any? %>
+        <div class="flex flex-wrap gap-2">
+          <% actions.each do |action| %>
+            <% next unless action.respond_to?(:[]) && action[:label].present? %>
+            <% if action[:href].present? %>
+              <%= link_to action[:label], action[:href], class: "tap-target cta-tertiary cta-compact", data: action[:data] || {} %>
+            <% elsif action[:button].present? %>
+              <button type="button" class="tap-target cta-tertiary cta-compact" <%= tag.attributes(action[:button]) %>><%= action[:label] %></button>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_screen_skeleton.html.erb
+++ b/app/views/shared/_screen_skeleton.html.erb
@@ -1,0 +1,37 @@
+<% variant = (local_assigns[:variant] || :list).to_sym %>
+
+<% if variant == :list %>
+  <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-hidden="true">
+    <% 6.times do %>
+      <article class="ds-card overflow-hidden p-0">
+        <div class="ds-skeleton-block aspect-[16/9]"></div>
+        <div class="space-y-2 p-4">
+          <div class="ds-skeleton-line w-5/6"></div>
+          <div class="ds-skeleton-line w-2/3"></div>
+          <div class="ds-skeleton-line w-1/2"></div>
+        </div>
+      </article>
+    <% end %>
+  </div>
+<% elsif variant == :detail %>
+  <div class="space-y-4" aria-hidden="true">
+    <div class="ds-skeleton-line h-8 w-2/3"></div>
+    <div class="ds-skeleton-line w-1/3"></div>
+    <div class="ds-skeleton-block aspect-[16/10] rounded-xl"></div>
+    <div class="ds-card p-4 space-y-2">
+      <div class="ds-skeleton-line"></div>
+      <div class="ds-skeleton-line"></div>
+      <div class="ds-skeleton-line w-4/5"></div>
+    </div>
+  </div>
+<% else %>
+  <div class="space-y-3" aria-hidden="true">
+    <% 3.times do %>
+      <article class="ds-card p-4 space-y-2">
+        <div class="ds-skeleton-line w-1/4"></div>
+        <div class="ds-skeleton-line w-2/3"></div>
+        <div class="ds-skeleton-line w-5/6"></div>
+      </article>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -4,21 +4,42 @@
 <% bio_error = field_error.call(:bio) %>
 <% email_error = field_error.call(:email) %>
 
-<%= form_with model: user, class: "space-y-form", data: { form_autofocus_errors: true } do |f| %>
+<%= form_with model: user,
+              class: "space-y-form ds-loading-shell",
+              data: {
+                form_autofocus_errors: true,
+                ui_form: true,
+                loading_label: t("ui.processing", default: "Processing..."),
+                submitting_reason: t("ui.processing", default: "Processing..."),
+                disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"),
+                disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.")
+              } do |f| %>
   <% if user.errors.any? %>
-    <div class="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
-      <p class="mb-2 font-semibold"><%= t("users.form.error_summary") %></p>
-      <ul class="list-disc pl-5">
-        <% user.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
+    <div class="space-y-2">
+      <%= render "shared/feedback_panel",
+                 level: :error,
+                 title: t("users.form.error_summary", default: "Please review the form fields."),
+                 body: t("ui.error_with_recovery", default: "Please review the fields below, then retry."),
+                 actions: [
+                   { label: t("ui.focus_first_error", default: "Go to first error"), href: "#user_name" },
+                   { label: t("ui.back", default: "Back"), href: (request.referer.presence || root_path) }
+                 ] %>
+
+      <div class="rounded-lg border border-red-200 bg-white p-3 text-sm text-red-800" role="alert" aria-live="assertive">
+        <ul class="list-disc pl-5">
+          <% user.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
     </div>
   <% end %>
 
   <div>
     <%= f.label :name, t("users.form.name_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-    <%= f.text_field :name, class: input_class.call(name_error), placeholder: t("users.form.name_placeholder"), aria: { invalid: name_error.present? ? "true" : nil, describedby: "user_name_error" } %>
+    <%= f.text_field :name, required: true, maxlength: 40, class: input_class.call(name_error), placeholder: t("users.form.name_placeholder"), aria: { invalid: name_error.present? ? "true" : nil, describedby: "user_name_guide user_name_counter user_name_error" }, data: { char_count_max: 40, char_count_target: "user_name_counter" } %>
+    <p id="user_name_guide" class="ds-field-guide"><%= t("users.form.name_guide", default: "Name shown on posts and comments. Avoid personal contact details.") %></p>
+    <p id="user_name_counter" class="ds-char-counter" aria-live="polite"></p>
     <% if name_error.present? %>
       <p id="user_name_error" class="mt-1 text-xs font-medium text-red-700"><%= name_error %></p>
     <% end %>
@@ -26,7 +47,9 @@
 
   <div>
     <%= f.label :bio, t("users.form.bio_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
-    <%= f.text_area :bio, rows: 5, class: input_class.call(bio_error), placeholder: t("users.form.bio_placeholder"), aria: { invalid: bio_error.present? ? "true" : nil, describedby: "user_bio_error" } %>
+    <%= f.text_area :bio, rows: 5, maxlength: 300, class: input_class.call(bio_error), placeholder: t("users.form.bio_placeholder"), aria: { invalid: bio_error.present? ? "true" : nil, describedby: "user_bio_guide user_bio_counter user_bio_error" }, data: { char_count_max: 300, char_count_target: "user_bio_counter" } %>
+    <p id="user_bio_guide" class="ds-field-guide"><%= t("users.form.bio_guide", default: "Share your workspace style and tools in 1-3 short sentences.") %></p>
+    <p id="user_bio_counter" class="ds-char-counter" aria-live="polite"></p>
     <% if bio_error.present? %>
       <p id="user_bio_error" class="mt-1 text-xs font-medium text-red-700"><%= bio_error %></p>
     <% end %>
@@ -35,7 +58,7 @@
   <div>
     <%= f.label :email, t("users.form.email_label"), class: "mb-1 block text-sm font-medium text-slate-800" %>
     <%= f.email_field :email, class: input_class.call(email_error), placeholder: "you@example.com", aria: { invalid: email_error.present? ? "true" : nil, describedby: "user_email_hint user_email_error" } %>
-    <p id="user_email_hint" class="mt-1 ds-text-muted"><%= t("users.form.email_hint") %></p>
+    <p id="user_email_hint" class="ds-field-guide"><%= t("users.form.email_hint") %></p>
     <% if email_error.present? %>
       <p id="user_email_error" class="mt-1 text-xs font-medium text-red-700"><%= email_error %></p>
     <% end %>
@@ -46,7 +69,14 @@
     <%= f.label :email_notifications_enabled, t("users.form.email_notifications"), class: "text-sm text-slate-700" %>
   </div>
 
-  <%= f.submit submit_label, class: "tap-target cta-primary" %>
+  <%= f.button type: :submit, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "compact", ga_event: "profile_form_submit_click", ga_category: "profile_form", ga_label: "submit_profile" } do %>
+    <span class="inline-flex items-center gap-1.5">
+      <%= ui_icon(:check_circle, class_name: "h-4 w-4") %>
+      <span data-submit-label><%= submit_label %></span>
+    </span>
+  <% end %>
+
+  <p class="ds-disabled-reason" data-disabled-reason aria-live="polite"></p>
 <% end %>
 
 <script>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("users.edit.title") %>
 <% content_for :description, t("users.edit.description") %>
 
-<section class="mx-auto w-full max-w-3xl space-y-content">
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
   <div>
     <h1 class="ds-heading-xl"><%= t("users.edit.heading") %></h1>
     <p class="mt-2 ds-text-support">
@@ -12,4 +12,8 @@
   <div class="ds-card p-6">
     <%= render "form", user: @user, submit_label: t("users.form.submit_update") %>
   </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :detail %>
 </section>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("users.new.title") %>
 <% content_for :description, t("users.new.description") %>
 
-<section class="mx-auto w-full max-w-3xl space-y-content">
+<section class="mx-auto w-full max-w-3xl space-y-content" data-page-content>
   <div>
     <h1 class="ds-heading-xl"><%= t("users.new.heading") %></h1>
     <p class="mt-2 ds-text-support">
@@ -12,4 +12,8 @@
   <div class="ds-card p-6">
     <%= render "form", user: @user, submit_label: t("users.form.submit_create") %>
   </div>
+</section>
+
+<section class="mx-auto hidden w-full max-w-3xl" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :detail %>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
 <% browse_gallery_label = locale_ja ? "投稿一覧を見る" : "Browse gallery" %>
 <% draft_hint = locale_ja ? "下書きは本人のみ表示されます。" : "Drafts are visible only to you." %>
 
-<section class="space-y-content">
+<section class="space-y-content" data-page-content>
   <header class="ds-card p-6">
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
@@ -51,7 +51,7 @@
               </div>
               <div class="mt-auto border-t border-slate-100 pt-3 ds-text-meta">
                 <div class="flex flex-wrap items-center gap-2">
-                  <span><%= l(post.created_at.to_date) %></span>
+                  <%= timestamp_tag(post.created_at, style: :date) %>
                   <span class="inline-flex items-center gap-1">
                     <%= ui_icon(:heart, class_name: "h-3.5 w-3.5") %>
                     <span><%= localized_number(post.likes_count) %></span>
@@ -89,7 +89,7 @@
               <h3 class="ds-line-clamp-2 text-base font-semibold text-slate-900"><%= post.title.presence || t("users.show.untitled_draft") %></h3>
               <p class="mt-2 ds-line-clamp-2 ds-text-support"><%= truncate(post.description.to_s, length: 120) %></p>
               <div class="mt-auto flex items-center justify-between border-t border-slate-200 pt-3">
-                <span class="ds-text-meta"><%= l(post.updated_at.to_date) %></span>
+                <%= timestamp_tag(post.updated_at, style: :date) %>
                 <%= link_to edit_post_path(post), class: "tap-target cta-secondary cta-compact" do %>
                   <%= ui_icon(:pencil_square, class_name: "h-3.5 w-3.5") %>
                   <span><%= t("users.show.continue_editing") %></span>
@@ -108,4 +108,8 @@
       <% end %>
     </section>
   <% end %>
+</section>
+
+<section class="hidden" data-page-skeleton aria-hidden="true">
+  <%= render "shared/screen_skeleton", variant: :list %>
 </section>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "ui_state"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,6 @@ Rails.application.routes.draw do
   get "privacy-policy", to: "pages#privacy", as: :privacy_policy
   get "terms", to: "pages#terms", as: :terms
   get "cookie-policy", to: "pages#cookie", as: :cookie_policy
+  get "getting-started", to: "pages#onboarding", as: :onboarding
   get "sitemap.xml", to: "sitemaps#show", defaults: { format: :xml }
 end

--- a/docs/dark_mode_audit.md
+++ b/docs/dark_mode_audit.md
@@ -1,0 +1,46 @@
+# Dark Mode Migration Inventory
+
+Date: 2026-03-02
+Owner: UI backlog implementation
+
+## Goal
+Complete pre-migration inventory for dark mode by identifying hard-coded colors and prioritizing token migration.
+
+## Priority Buckets
+- P0 (high-frequency UI): header, navigation CTA, post cards, form controls, flash/toast, comment threads.
+- P1 (medium-frequency UI): report modal, notifications page, profile screens, onboarding, ad wrappers.
+- P2 (low-frequency UI): admin panels, legal pages, email templates.
+
+## Current Status
+- Tokenized baseline exists in `app/assets/tailwind/application.css` (`--ds-*` variables for typography, spacing, focus, skeleton).
+- Hard-coded utility classes remain in ERB templates (`text-slate-*`, `bg-white`, `border-slate-*`, `text-blue-*`, etc.).
+- Third-party embeds (`g-recaptcha`, AdSense) are non-themable and require neutral containers.
+
+## Hard-coded Color Hotspots (Sample)
+- `app/views/posts/index.html.erb`
+- `app/views/posts/show.html.erb`
+- `app/views/posts/_form.html.erb`
+- `app/views/layouts/application.html.erb`
+- `app/views/users/_form.html.erb`
+
+## Migration Strategy
+1. Map semantic tokens for text/surface/border/interactive states:
+   - `--ds-surface-1`, `--ds-surface-2`, `--ds-border-1`, `--ds-border-2`
+   - `--ds-text-main`, `--ds-text-subtle`, `--ds-text-muted`
+   - `--ds-accent`, `--ds-accent-contrast`, `--ds-danger`, `--ds-warning`, `--ds-success`
+2. Replace repeated utility colors with component classes in P0 screens first.
+3. Keep contrast gate for both themes before enabling switch:
+   - Body text >= 4.5:1
+   - Meta/aux text >= 4.5:1
+   - CTA labels >= 4.5:1
+4. Add visual regression snapshots for `ja/en` in both light/dark.
+
+## Component Readiness
+- Ready: skeleton/toast/focus/tap/spacing tokens in Tailwind layer.
+- Partial: cards/forms/badges (token + hard-coded mixed).
+- Not-ready: legal/admin/email templates.
+
+## Next Implementation Batch
+- Batch A: header/nav, post index cards, post show sections.
+- Batch B: form screens + notifications + profile pages.
+- Batch C: legal/admin pages and email theming.

--- a/docs/design_review_checklist.md
+++ b/docs/design_review_checklist.md
@@ -1,0 +1,30 @@
+# Design Review Checklist
+
+## Cadence
+- Trigger: every new screen and every UI-affecting change.
+- Format: one checklist record per PR.
+- Required attendees: implementation owner + one reviewer.
+
+## Required Checks
+- CTA hierarchy: one primary action per section/screen context.
+- State design: loading, success, error, empty, zero-results, disabled reason.
+- Accessibility: keyboard flow, focus visibility, live region updates, heading structure.
+- Metrics hypothesis: expected KPI impact + guardrail metric.
+
+## Keyboard Completion Script
+1. Traverse with `Tab` and `Shift+Tab` from page top to bottom.
+2. Confirm visible `:focus-visible` on all interactive elements.
+3. Open/close menus and dialogs using keyboard only.
+4. Verify `Esc` closes layer and focus returns to trigger.
+5. Verify comment/report forms can be completed without pointer.
+
+## Accessibility Read Order Script
+1. Confirm one `h1` per page.
+2. Validate heading order (`h1 > h2 > h3`) without skips.
+3. Confirm error summaries are linked to relevant fields.
+4. Confirm card metadata order matches visual order.
+
+## PR Artifact Requirements
+- Before/after screenshots (desktop + mobile).
+- Checklist result notes for CTA/state/accessibility/metrics.
+- Manual verification notes for keyboard and locale switch.

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -120,6 +120,9 @@
 - Use explicit aspect-ratio wrappers for list/detail media (`ds-media-frame-*`).
 - Image containers should render skeleton placeholders (`ds-media-skeleton`) until `load/error`.
 - Keep width/height attributes on image tags to stabilize layout before decode.
+- Thumbnail crop strategy:
+  - Apply `ds-thumbnail-crop` with top bias (`object-position: 50% 36%`) to reduce face/subject clipping.
+  - Provide in-frame fallback message + retry control on image load failure.
 
 ## Dark Mode Readiness
 - Maintain colors through `--ds-*` tokens only; avoid hard-coded semantic colors in component markup.

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -15,4 +15,9 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     get cookie_policy_url
     assert_response :success
   end
+
+  test "should get onboarding" do
+    get onboarding_url
+    assert_response :success
+  end
 end

--- a/test/system/keyboard_flow_test.rb
+++ b/test/system/keyboard_flow_test.rb
@@ -1,0 +1,16 @@
+require "application_system_test_case"
+
+class KeyboardFlowTest < ApplicationSystemTestCase
+  fixtures :posts
+
+  test "post detail action menus can be opened and closed with keyboard" do
+    visit post_path(posts(:one))
+
+    toggle = find("[data-desktop-post-actions-toggle]", visible: :visible)
+    toggle.click
+    assert_selector("[data-desktop-post-actions-menu]", visible: :visible)
+
+    find("body").send_keys(:escape)
+    assert_selector("[data-desktop-post-actions-menu].hidden", visible: :all)
+  end
+end

--- a/test/system/locale_layout_regression_test.rb
+++ b/test/system/locale_layout_regression_test.rb
@@ -1,0 +1,26 @@
+require "application_system_test_case"
+
+class LocaleLayoutRegressionTest < ApplicationSystemTestCase
+  test "ja and en locale switch keeps layout within viewport" do
+    visit root_path(locale: :ja)
+    assert_text "DeskTour Studio"
+    assert no_horizontal_overflow?, "Expected no horizontal overflow in ja locale"
+
+    click_link "English"
+    assert_text I18n.t("navigation.create_post", locale: :en)
+    assert no_horizontal_overflow?, "Expected no horizontal overflow in en locale"
+  end
+
+  private
+
+  def no_horizontal_overflow?
+    page.evaluate_script(<<~JS)
+      (() => {
+        const width = document.documentElement.clientWidth;
+        const bodyWidth = document.body.scrollWidth;
+        const htmlWidth = document.documentElement.scrollWidth;
+        return Math.max(bodyWidth, htmlWidth) <= (width + 1);
+      })()
+    JS
+  end
+end


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/68

## 目的

  DeskTour Studio の残UX/UIバックログ（状態設計・入力支援・信頼性表現・計測運用・アクセシビリティ検証）を実装し、一覧/詳細/フォーム/周辺導線の体験品質を底上げすること。

  ## 実装内容

  - 画面別 Skeleton/Loading の共通化
  - エラー/成功フィードバックの統一（共通パネル + トースト）
  - フォーム入力補助強化（常設ガイド、文字数カウンタ、上限接近警告）
  - disabled状態の理由表示と送信制御
  - 一覧→詳細→戻る体験改善（from導線 + スクロール復元維持）
  - カード全体クリックの誤操作対策
  - タップ時フィードバック統一
  - 日付/数値表記の統一ヘルパー導入
  - 画像失敗時UI（フォールバック + 再試行）
  - 共有導線の優先順整理（Copy優先）
  - 法務導線露出強化（ヘッダー/初回接点）
  - 広告文脈分離の強化
  - コメントスレッド可読性ルール追加
  - 初回オンボーディング導線追加
  - 通報近傍の信頼性シグナル追加
  - A/B前提CTA部品化
  - ダークモード移行棚卸しドキュメント化
  - デザインレビュー定例チェックリスト運用化
  - 言語切替回帰/キーボード操作のsystem test追加

  ## 方法

  - 共通JS（ui_state.js）で状態管理・フォームUX・カード操作・画像フォールバックを横断適用
  - Tailwindユーティリティ層を拡張し、状態UI/タップ/スケルトン/補助文を共通クラス化
  - 画面実装は ERB 側に data-* を付与して既存構成を壊さず段階的に反映
  - 文言は既存i18nに文字化け箇所があるため t(..., default:) を併用して安全に適用
  - 運用面は docs と PR テンプレートを更新して再発防止を仕組み化

  ## 変更箇所

  - 共通UI基盤:
    [ui_state.js](C:\Users\hahib\ruby on rails\desktour_studio\app\javascript\ui_state.js)
    [application.css](C:\Users\hahib\ruby on rails\desktour_studio\app\assets\tailwind\application.css)
    [application_helper.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\helpers\application_helper.rb)
  - 画面改修:
    [application.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\layouts\application.html.erb)
    [index.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\index.html.erb)
    [show.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\show.html.erb)
    [_form.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts_form.html.erb)
    [users/_form.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\users_form.html.erb)
  - 新規導線/部品:
    [onboarding.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\pages\onboarding.html.erb)
    [_feedback_panel.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\shared_feedback_panel.html.erb)
    [_screen_skeleton.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\shared_screen_skeleton.html.erb)
    [_experiment_cta.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\shared_experiment_cta.html.erb)
  - ルーティング/コントローラ:
    [routes.rb](C:\Users\hahib\ruby on rails\desktour_studio\config\routes.rb)
    [posts_controller.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\controllers\posts_controller.rb)
    [reports_controller.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\controllers\reports_controller.rb)
    [pages_controller.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\controllers\pages_controller.rb)
  - ドキュメント/運用:
    [dark_mode_audit.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\dark_mode_audit.md)
    [design_review_checklist.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\design_review_checklist.md)
    [pull_request_template.md](C:\Users\hahib\ruby on rails\desktour_studio.github\pull_request_template.md)

  ## まとめ

  残バックログの主要項目は実装済みです。UI状態の統一、入力中予防、再探索支援、信頼性表現、法務導線、A/B運用土台、レ
  ビュー運用まで一通り反映し、今後の画面追加でも同じ基準で拡張できる状態にしました。

  ## Testing

  - 実行成功:
    ruby bin/rails test test/models test/controllers test/helpers test/jobs
    結果: 56 runs, 167 assertions, 0 failures, 0 errors
  - 実行成功（個別）:
    ruby bin/rails test test/controllers/posts_controller_test.rb test/controllers/comments_controller_test.rb test/
    controllers/pages_controller_test.rb test/controllers/locale_selection_test.rb test/helpers/
    application_helper_test.rb test/controllers/reports_controller_test.rb
  - 追加済みだが実行不可（環境制約）:
    test/system/locale_layout_regression_test.rb
    test/system/keyboard_flow_test.rb
    理由: Selenium Manager の権限エラー（chromedriver取得不可）