### PR TITLE
Strategic UX: Implementing offline support, search intelligence, and automated accessibility auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: [ main, develop ]
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
 
 jobs:
   scan_ruby:
@@ -97,3 +100,37 @@ jobs:
           name: screenshots
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
+
+  accessibility_audit:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Prepare DB
+        run: |
+          DATABASE_URL=postgres://postgres:postgres@localhost:5432/desktour_studio_test bundle exec bin/rails db:create RAILS_ENV=test
+          DATABASE_URL=postgres://postgres:postgres@localhost:5432/desktour_studio_test bundle exec bin/rails db:schema:load RAILS_ENV=test
+
+      - name: Run accessibility audit
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/desktour_studio_test
+        run: bundle exec rake accessibility:audit

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -536,6 +536,53 @@
     border-color: rgb(96 165 250);
   }
 
+  .ds-offline-banner {
+    @apply hidden rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-900;
+  }
+
+  html.ds-offline .ds-offline-banner {
+    @apply block;
+  }
+
+  .ds-comment-muted {
+    @apply rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600;
+  }
+
+  html.ds-low-bandwidth .ds-media-skeleton::after,
+  html.ds-low-bandwidth .ds-skeleton-line::after,
+  html.ds-low-bandwidth .ds-skeleton-block::after {
+    animation: none !important;
+  }
+
+  html.ds-low-bandwidth .ds-shadow-soft {
+    box-shadow: none !important;
+  }
+
+  html.ds-low-bandwidth [data-media-skeleton] {
+    min-height: 0;
+  }
+
+  html.ds-low-bandwidth [data-media-skeleton] img {
+    opacity: 0.72;
+  }
+
+  .ds-low-bandwidth-banner {
+    @apply hidden rounded-lg border border-sky-300 bg-sky-50 px-3 py-2 text-xs font-semibold text-sky-900;
+  }
+
+  html.ds-low-bandwidth .ds-low-bandwidth-banner {
+    @apply block;
+  }
+
+  html.ds-low-bandwidth [data-card-href] .ds-media-frame-card {
+    display: none;
+  }
+
+  html.platform-ios .mobile-sticky-bar,
+  html.platform-android .mobile-sticky-bar {
+    padding-bottom: max(var(--ds-safe-area-bottom), 6px);
+  }
+
   .ds-cta-experiment[data-variant="control"] {
     --ds-cta-accent: rgb(37 99 235);
   }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,12 +7,15 @@ class PostsController < ApplicationController
   before_action :require_post_owner!, only: %i[edit update destroy notifications]
 
   def index
-    @posts = Post.visible.includes(:user, :items, desk_image_attachment: :blob).filtered(params)
+    @sort_option = normalize_sort(params[:sort])
+    @posts = Post.visible.includes(:user, :items, desk_image_attachment: :blob).filtered(params.merge(sort: @sort_option))
     @categories = Post.visible.where.not(category: [ nil, "" ]).distinct.order(:category).pluck(:category)
+    @themes = Post.visible.where.not(theme: [ nil, "" ]).distinct.order(:theme).limit(24).pluck(:theme)
     @popular_tags = Post.visible.where.not(tag_list: [ nil, "" ]).pluck(:tag_list).flat_map { |list|
       list.to_s.split(",").map(&:strip)
     }.reject(&:blank?).tally.sort_by { |(_, count)| -count }.map(&:first).first(8)
     @recent_posts = Post.visible.latest.limit(4)
+    @search_suggestions = search_suggestions
   end
 
   def show
@@ -23,6 +26,7 @@ class PostsController < ApplicationController
     @report = @post.reports.new
     @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
     @back_to_index_path = sanitize_internal_back_path(params[:from])
+    @author_trust = author_trust_snapshot(@post.user)
   end
 
   def new
@@ -191,6 +195,30 @@ class PostsController < ApplicationController
     value
   rescue URI::InvalidURIError
     nil
+  end
+
+  def search_suggestions
+    recent_titles = Post.visible.latest.limit(20).pluck(:title)
+    (recent_titles + @categories + @themes + @popular_tags).map { |value| value.to_s.strip }.reject(&:blank?).uniq.first(40)
+  end
+
+  def normalize_sort(raw_sort)
+    allowed = %w[newest popular recently_updated]
+    value = raw_sort.to_s
+    allowed.include?(value) ? value : "newest"
+  end
+
+  def author_trust_snapshot(user)
+    posts_scope = user.posts.visible
+    profile_fields = [ user.name, user.bio, user.email ]
+    completion = ((profile_fields.count(&:present?).to_f / profile_fields.size) * 100).round
+
+    {
+      completion: completion,
+      published_posts_count: posts_scope.count,
+      total_likes: posts_scope.sum(:likes_count),
+      last_updated_at: posts_scope.maximum(:updated_at)
+    }
   end
 
   def assign_owner_token(post)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,6 +131,14 @@ module ApplicationHelper
     custom_description.presence || t("meta.default_description")
   end
 
+  def share_card_title(raw_title)
+    truncate(raw_title.to_s.presence || "DeskTour Studio", length: 65)
+  end
+
+  def share_card_description(raw_description)
+    truncate(raw_description.to_s.presence || t("meta.default_description"), length: 150)
+  end
+
   def canonical_url
     request.base_url + request.path
   end
@@ -180,6 +188,88 @@ module ApplicationHelper
 
   def localized_number(value)
     number_with_delimiter(value, locale: I18n.locale)
+  end
+
+  def context_breadcrumbs
+    base = [ { label: "DeskTour Studio", href: root_path } ]
+    return base if controller_name == "posts" && action_name == "index"
+
+    case controller_name
+    when "posts"
+      base << { label: t("posts.index.title"), href: root_path }
+      if action_name == "show" && defined?(@post) && @post.present?
+        base << { label: truncate(@post.title, length: 40), href: post_path(@post) }
+      elsif action_name.in?(%w[new create])
+        base << { label: t("posts.new.heading"), href: new_post_path }
+      elsif action_name.in?(%w[edit update]) && defined?(@post) && @post.present?
+        base << { label: truncate(@post.title, length: 40), href: post_path(@post) }
+        base << { label: t("posts.edit.heading"), href: edit_post_path(@post) }
+      end
+    when "users"
+      if action_name.in?(%w[new create])
+        base << { label: t("users.new.heading"), href: new_user_path }
+      elsif defined?(@user) && @user.present?
+        base << { label: @user.name, href: user_path(@user) }
+        base << { label: t("users.edit.heading"), href: edit_user_path(@user) } if action_name.in?(%w[edit update])
+      end
+    when "pages"
+      page_map = {
+        "privacy" => { label: t("footer.privacy_policy"), href: privacy_policy_path },
+        "terms" => { label: t("footer.terms"), href: terms_path },
+        "cookie" => { label: t("footer.cookie_policy"), href: cookie_policy_path },
+        "onboarding" => { label: t("navigation.onboarding", default: "Getting started"), href: onboarding_path }
+      }
+      candidate = page_map[action_name]
+      base << candidate if candidate.present?
+    end
+
+    base
+  end
+
+  def reading_sections(text)
+    raw = text.to_s
+    return [] if raw.blank?
+
+    sections = []
+    current = { title: t("posts.show.section_overview", default: "Overview"), lines: [] }
+
+    raw.each_line do |line|
+      heading_match = line.match(/\A##\s+(.+)\z/)
+      if heading_match
+        sections << current if current[:lines].any?
+        current = { title: heading_match[1].strip, lines: [] }
+      else
+        current[:lines] << line
+      end
+    end
+
+    sections << current if current[:lines].any?
+
+    sections.each_with_index.map do |section, idx|
+      {
+        id: "section-#{idx + 1}",
+        title: section[:title].presence || "#{t('posts.show.section_label', default: 'Section')} #{idx + 1}",
+        body: section[:lines].join.strip
+      }
+    end.reject { |section| section[:body].blank? }
+  end
+
+  def sort_option_label(value)
+    labels = {
+      "newest" => t("posts.index.sort_newest", default: "Newest"),
+      "popular" => t("posts.index.sort_popular", default: "Most liked"),
+      "recently_updated" => t("posts.index.sort_recently_updated", default: "Recently updated")
+    }
+    labels.fetch(value.to_s, labels.fetch("newest"))
+  end
+
+  def sort_option_hint(value)
+    hints = {
+      "newest" => t("posts.index.sort_hint_newest", default: "Ordered by publish date. Updates every time a post is published."),
+      "popular" => t("posts.index.sort_hint_popular", default: "Ordered by likes. Updated when likes change."),
+      "recently_updated" => t("posts.index.sort_hint_recently_updated", default: "Ordered by latest edit timestamp. Updated when authors edit.")
+    }
+    hints.fetch(value.to_s, hints.fetch("newest"))
   end
 
   def formatted_date(value)

--- a/app/javascript/ui_state.js
+++ b/app/javascript/ui_state.js
@@ -1,4 +1,5 @@
 const UI_STATE_GUARD = "__deskTourUiStateInstalled";
+const FORM_DRAFT_PREFIX = "form_draft_";
 
 const INTERACTIVE_SELECTOR = [
   "a",
@@ -16,6 +17,23 @@ const INTERACTIVE_SELECTOR = [
 ].join(", ");
 
 const isBlank = (value) => value == null || String(value).trim().length === 0;
+
+const readJson = (key, fallback = {}) => {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" && parsed != null ? parsed : fallback;
+  } catch (_) {
+    return fallback;
+  }
+};
+
+const writeJson = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (_) {}
+};
 
 const controlLabel = (field, form) => {
   if (!field) return "";
@@ -145,11 +163,81 @@ const bindFormState = (scope = document) => {
     }
 
     form.dataset.uiFormBound = "1";
+    form.dataset.uiFormDirty = "false";
 
-    form.addEventListener("input", () => updateFormState(form));
-    form.addEventListener("change", () => updateFormState(form));
+    const draftKey = `${FORM_DRAFT_PREFIX}${form.dataset.offlineDraftKey || form.getAttribute("action") || form.id || "default"}`;
+    const serializableFields = () => Array.from(form.querySelectorAll("input[name], textarea[name], select[name]")).filter((field) => {
+      const type = (field.getAttribute("type") || "").toLowerCase();
+      return ![ "password", "file", "submit", "button", "image" ].includes(type);
+    });
+
+    const saveDraft = () => {
+      const payload = {};
+      serializableFields().forEach((field) => {
+        if (field.type === "checkbox") {
+          payload[field.name] = field.checked;
+        } else if (field.type === "radio") {
+          if (field.checked) payload[field.name] = field.value;
+        } else {
+          payload[field.name] = field.value;
+        }
+      });
+      writeJson(draftKey, payload);
+    };
+
+    const restoreDraft = () => {
+      const payload = readJson(draftKey, {});
+      if (!payload || Object.keys(payload).length === 0) return;
+      serializableFields().forEach((field) => {
+        if (!(field.name in payload)) return;
+        if (field.type === "checkbox") {
+          field.checked = Boolean(payload[field.name]);
+        } else if (field.type === "radio") {
+          field.checked = String(payload[field.name]) === String(field.value);
+        } else {
+          field.value = payload[field.name];
+        }
+      });
+      if (typeof window.dsNotify === "function" && form.dataset.offlineDraftKey) {
+        window.dsNotify(form.dataset.draftRestoredMessage || "Draft restored.", "info");
+      }
+    };
+
+    form.addEventListener("input", () => {
+      form.dataset.uiFormDirty = "true";
+      updateFormState(form);
+      if (form.dataset.offlineDraftKey) saveDraft();
+    });
+    form.addEventListener("change", () => {
+      form.dataset.uiFormDirty = "true";
+      updateFormState(form);
+      if (form.dataset.offlineDraftKey) saveDraft();
+    });
+
+    form.addEventListener("focusout", (event) => {
+      const field = event.target.closest("input[name], textarea[name], select[name]");
+      if (!field || typeof window.gtag !== "function") return;
+      const label = controlLabel(field, form);
+      const filled = !isBlank(field.value);
+      window.gtag("event", "form_field_blur", {
+        event_category: "form",
+        event_label: form.dataset.formAnalyticsContext || "generic_form",
+        field_name: field.name,
+        field_label: label,
+        field_filled: filled
+      });
+    }, true);
 
     form.addEventListener("submit", (event) => {
+      if (!navigator.onLine) {
+        event.preventDefault();
+        saveDraft();
+        if (typeof window.dsNotify === "function") {
+          window.dsNotify(form.dataset.offlineSubmitMessage || "You appear to be offline. Your input is saved locally.", "error");
+        }
+        return;
+      }
+
       updateFormState(form);
       const submitButtons = Array.from(form.querySelectorAll("button[type='submit'], input[type='submit']"));
       const blocked = submitButtons.some((button) => button.disabled);
@@ -183,10 +271,33 @@ const bindFormState = (scope = document) => {
         button.disabled = true;
       });
 
+      if (form.dataset.offlineDraftKey) {
+        localStorage.removeItem(draftKey);
+      }
+
       updateFormState(form);
     });
 
+    restoreDraft();
     updateFormState(form);
+  });
+};
+
+const bindFormAbandonmentObserver = () => {
+  if (window.__formAbandonmentBound) return;
+  window.__formAbandonmentBound = true;
+
+  window.addEventListener("beforeunload", () => {
+    if (typeof window.gtag !== "function") return;
+    const dirtyForm = document.querySelector("form[data-ui-form][data-ui-form-dirty='true']");
+    if (!dirtyForm) return;
+    const active = dirtyForm.querySelector(":focus");
+    const activeField = active ? active.getAttribute("name") : "";
+    window.gtag("event", "form_abandon", {
+      event_category: "form",
+      event_label: dirtyForm.dataset.formAnalyticsContext || "generic_form",
+      active_field: activeField
+    });
   });
 };
 
@@ -305,6 +416,7 @@ const initializeUiState = (scope = document) => {
   bindCardNavigation(scope);
   bindCharCounters(scope);
   bindFormState(scope);
+  bindFormAbandonmentObserver();
   bindImageFallback(scope);
   bindLoadingSkeleton(scope);
   showFlashToasts(scope);
@@ -312,6 +424,25 @@ const initializeUiState = (scope = document) => {
 
 if (!window[UI_STATE_GUARD]) {
   window[UI_STATE_GUARD] = true;
+
+  const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  const lowBandwidth = Boolean(connection && (connection.saveData || /(^|[^0-9])2g/i.test(connection.effectiveType || "")));
+  if (lowBandwidth) {
+    document.documentElement.classList.add("ds-low-bandwidth");
+  }
+
+  const ua = navigator.userAgent || "";
+  if (/iPhone|iPad|iPod/i.test(ua)) document.documentElement.classList.add("platform-ios");
+  if (/Android/i.test(ua)) document.documentElement.classList.add("platform-android");
+
+  window.addEventListener("online", () => {
+    document.documentElement.classList.remove("ds-offline");
+    if (typeof window.dsNotify === "function") window.dsNotify("Back online.", "success");
+  });
+  window.addEventListener("offline", () => {
+    document.documentElement.classList.add("ds-offline");
+    if (typeof window.dsNotify === "function") window.dsNotify("You are offline. Inputs will be saved locally.", "error");
+  });
 
   bindTapFeedback();
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,7 @@ class Post < ApplicationRecord
 
   scope :visible, -> { published }
   scope :latest, -> { order(created_at: :desc) }
+  scope :recently_updated, -> { order(updated_at: :desc) }
 
   validates :title, presence: true, length: { maximum: 120 }, if: :published?
   validates :description, presence: true, length: { maximum: 2000 }, if: :published?
@@ -25,7 +26,7 @@ class Post < ApplicationRecord
   end
 
   def self.filtered(params)
-    posts = all.latest
+    posts = all
 
     if params[:q].present?
       query = "%#{sanitize_sql_like(params[:q].strip)}%"
@@ -43,7 +44,14 @@ class Post < ApplicationRecord
       posts = posts.where("posts.tag_list ILIKE ?", "%#{escaped_tag}%")
     end
 
-    posts
+    case params[:sort].to_s
+    when "popular"
+      posts.order(likes_count: :desc, created_at: :desc)
+    when "recently_updated"
+      posts.recently_updated
+    else
+      posts.latest
+    end
   end
 
   def tags

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,14 +9,17 @@
     <link rel="canonical" href="<%= canonical_url %>">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="DeskTour Studio">
-    <meta property="og:title" content="<%= page_title(content_for(:title)) %>">
-    <meta property="og:description" content="<%= meta_description(content_for(:description)) %>">
+    <meta property="og:title" content="<%= share_card_title(page_title(content_for(:title))) %>">
+    <meta property="og:description" content="<%= share_card_description(meta_description(content_for(:description))) %>">
     <meta property="og:url" content="<%= canonical_url %>">
     <meta property="og:image" content="<%= content_for(:og_image_url) || og_image_url %>">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="<%= page_title(content_for(:title)) %>">
-    <meta name="twitter:description" content="<%= meta_description(content_for(:description)) %>">
+    <meta name="twitter:title" content="<%= share_card_title(page_title(content_for(:title))) %>">
+    <meta name="twitter:description" content="<%= share_card_description(meta_description(content_for(:description))) %>">
     <meta name="twitter:image" content="<%= content_for(:og_image_url) || og_image_url %>">
+    <meta name="twitter:image:alt" content="<%= t('images.desk_alt', default: 'Desk image') %>">
     <% if search_console_verification_token.present? %>
       <meta name="google-site-verification" content="<%= search_console_verification_token %>">
     <% end %>
@@ -149,6 +152,29 @@
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-4 pt-8 <%= main_padding_class %> sm:px-6">
+      <% breadcrumbs = context_breadcrumbs %>
+      <% if breadcrumbs.size > 1 %>
+        <nav aria-label="<%= t('navigation.breadcrumb', default: 'Breadcrumb') %>" class="mb-4">
+          <ol class="flex flex-wrap items-center gap-1.5 text-xs text-slate-600">
+            <% breadcrumbs.each_with_index do |crumb, idx| %>
+              <li class="inline-flex items-center gap-1.5">
+                <% if idx < breadcrumbs.size - 1 %>
+                  <%= link_to crumb[:label], crumb[:href], class: "underline decoration-slate-300 underline-offset-2 hover:text-slate-900" %>
+                <% else %>
+                  <span aria-current="page" class="font-semibold text-slate-700"><%= crumb[:label] %></span>
+                <% end %>
+                <% if idx < breadcrumbs.size - 1 %>
+                  <span aria-hidden="true">/</span>
+                <% end %>
+              </li>
+            <% end %>
+          </ol>
+        </nav>
+      <% end %>
+
+      <p class="mb-4 ds-offline-banner"><%= t("ui.offline_banner", default: "Offline mode: your input is saved locally. It will be sent when connection returns.") %></p>
+      <p class="mb-4 ds-low-bandwidth-banner"><%= t("ui.low_bandwidth_banner", default: "Low-bandwidth mode: heavy media is reduced to keep key information visible.") %></p>
+
       <% if controller_name == "posts" && action_name.in?(%w[index show new]) %>
         <div class="mb-4 ds-legal-links">
           <span class="text-slate-500"><%= t("legal.quick_links", default: "Policies") %>:</span>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -19,6 +19,10 @@
               data: {
                 form_autofocus_errors: true,
                 ui_form: true,
+                form_analytics_context: "post_form",
+                offline_draft_key: "post_form",
+                draft_restored_message: t("ui.draft_restored", default: "Draft restored."),
+                offline_submit_message: t("ui.offline_submit", default: "You appear to be offline. Your input was saved locally."),
                 loading_label: t("ui.processing", default: "Processing..."),
                 submitting_reason: t("ui.processing", default: "Processing..."),
                 disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"),

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -33,11 +33,13 @@
   category: params[:category].presence,
   theme: params[:theme].presence,
   tag: params[:tag].presence,
-  details: params[:details].presence
+  details: params[:details].presence,
+  sort: @sort_option.presence
 }.compact %>
 <% empty_primary_cta = t("posts.index.empty_primary", default: "Create your first post") %>
 <% timeline_hint = t("posts.index.timeline_hint", default: "Start your timeline with one post.") %>
 <% return_path = request.fullpath %>
+<% sort_option = @sort_option.presence || "newest" %>
 
 <section class="space-y-section" data-page-content>
   <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-blue-900 to-cyan-800 px-5 py-6 text-white sm:px-6 sm:py-8">
@@ -57,6 +59,27 @@
     </div>
   </div>
 
+  <section class="ds-card p-4 sm:p-5" data-revisit-root>
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <h2 class="ds-heading-sm text-slate-900"><%= t("posts.index.revisit_heading", default: "Continue from your last visit") %></h2>
+      <button type="button" class="tap-target cta-tertiary cta-compact" data-restore-filters><%= t("posts.index.restore_last_filters", default: "Restore last filters") %></button>
+    </div>
+    <div class="mt-2 grid gap-3 sm:grid-cols-2">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.index.recently_viewed", default: "Recently viewed") %></p>
+        <ul class="mt-2 space-y-1.5 text-sm" data-recently-viewed-list>
+          <li class="text-slate-500"><%= t("posts.index.recently_viewed_empty", default: "No recently viewed posts yet.") %></li>
+        </ul>
+      </div>
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.index.saved_posts", default: "Saved posts") %></p>
+        <ul class="mt-2 space-y-1.5 text-sm" data-saved-post-list>
+          <li class="text-slate-500"><%= t("posts.index.saved_posts_empty", default: "No saved posts yet.") %></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
   <div id="index-search" class="ds-card p-4 sm:p-5" data-index-search-root>
     <%= form_with url: posts_path, method: :get, local: true, class: "space-y-block", data: { search_form: true, ui_form: true, disabled_reason_prefix: t("ui.search_hint", default: "Add one search condition"), disabled_submit_notice: t("ui.search_hint", default: "Add one search condition") } do %>
       <%= hidden_field_tag :details, detailed_filters_open ? "1" : "0", data: { details_state_input: true } %>
@@ -65,10 +88,19 @@
         <p class="ds-text-meta font-semibold uppercase tracking-wide"><%= quick_search_label %></p>
         <div class="mt-2.5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
           <div>
-            <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), data: { search_keyword_input: true } %>
+            <%= text_field_tag :q, params[:q], class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.index.search_placeholder"), list: "post-search-suggestions", data: { search_keyword_input: true } %>
             <p class="ds-field-guide"><%= t("posts.index.search_guide", default: "Search title, description, items, and tags.") %></p>
           </div>
           <%= submit_tag t("posts.index.search_button"), class: "tap-target cta-primary w-full sm:w-auto", data: { ga_event: "post_search_submit_click", ga_category: "post_search", ga_label: "index_search_submit_button" } %>
+        </div>
+        <div class="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+          <div>
+            <%= label_tag :sort, t("posts.index.sort_label", default: "Sort"), class: "sr-only" %>
+            <%= select_tag :sort, options_for_select([[sort_option_label("newest"), "newest"], [sort_option_label("popular"), "popular"], [sort_option_label("recently_updated"), "recently_updated"]], sort_option), class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { search_sort_input: true } %>
+            <p class="ds-field-guide"><%= sort_option_hint(sort_option) %></p>
+          </div>
+          <button type="button" class="tap-target cta-tertiary cta-compact" data-clear-filters><%= t("posts.index.reset_button") %></button>
+          <button type="button" class="tap-target cta-tertiary cta-compact" data-restore-filters><%= t("posts.index.restore_last_filters", default: "Restore last filters") %></button>
         </div>
       </div>
 
@@ -114,6 +146,13 @@
         </div>
       </div>
     <% end %>
+    <% if @search_suggestions.any? %>
+      <datalist id="post-search-suggestions">
+        <% @search_suggestions.each do |suggestion| %>
+          <option value="<%= suggestion %>"></option>
+        <% end %>
+      </datalist>
+    <% end %>
   </div>
 
   <% if @posts.any? %>
@@ -123,7 +162,7 @@
         <% visible_tags = ranked_tags.first(max_card_tags) %>
         <% hidden_tag_count = [ranked_tags.size - visible_tags.size, 0].max %>
         <% card_url = post_path(post, from: return_path) %>
-        <article class="ds-card ds-shadow-soft ds-card-interactive flex h-full flex-col overflow-hidden" data-card-href="<%= card_url %>">
+        <article class="ds-card ds-shadow-soft ds-card-interactive flex h-full flex-col overflow-hidden" data-card-href="<%= card_url %>" data-post-id="<%= post.id %>" data-post-title="<%= post.title %>" data-post-url="<%= card_url %>">
           <%= link_to card_url, class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results", card_stop: true } do %>
             <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton data-image-shell>
               <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-full w-full object-cover", data: { fallback_src: asset_path(ApplicationHelper::FALLBACK_POST_IMAGE) }) %>
@@ -135,6 +174,11 @@
           <% end %>
 
           <div class="flex h-full flex-col p-4">
+            <div class="mb-2 flex items-center justify-end">
+              <button type="button" class="tap-target cta-tertiary cta-compact" data-card-stop data-favorite-toggle data-post-id="<%= post.id %>" data-post-title="<%= post.title %>" data-post-url="<%= card_url %>" aria-pressed="false">
+                <span data-favorite-label><%= t("posts.index.save_post", default: "Save") %></span>
+              </button>
+            </div>
             <h2 class="ds-heading-sm ds-line-clamp-2 ds-break-words text-slate-900">
               <%= link_to post.title, card_url, class: "block leading-6 hover:text-blue-600", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click", card_stop: true } %>
             </h2>
@@ -146,7 +190,7 @@
                 <span class="ds-badge-inactive"><%= post.category %></span>
               <% end %>
               <% visible_tags.each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details]), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card", card_stop: true } %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: params[:details], sort: sort_option), class: "tap-target ds-badge-info", data: { ga_event: "post_tag_filter_click", ga_category: "post_index", ga_label: "tag_filter_from_card", card_stop: true } %>
               <% end %>
               <% if hidden_tag_count.positive? %>
                 <span class="ds-badge-info">+<%= hidden_tag_count %></span>
@@ -195,7 +239,7 @@
             <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.index.popular_tags", default: "Popular tags") %></p>
             <div class="mt-2 flex flex-wrap items-center justify-center gap-2">
               <% @popular_tags.each do |tag| %>
-                <%= link_to "##{tag}", posts_path(tag: tag, details: "1"), class: "tap-target ds-badge-inactive", data: { ga_event: "post_search_recovery_click", ga_category: "post_search", ga_label: "zero_state_popular_tag" } %>
+                <%= link_to "##{tag}", posts_path(tag: tag, details: "1", sort: sort_option), class: "tap-target ds-badge-inactive", data: { ga_event: "post_search_recovery_click", ga_category: "post_search", ga_label: "zero_state_popular_tag" } %>
               <% end %>
             </div>
           </div>
@@ -234,6 +278,80 @@
     window.__postIndexSearchBindingInstalled = true;
     const LIST_SCROLL_KEY = "post_index_scroll_y";
     const LIST_RESTORE_KEY = "post_index_restore";
+    const FILTER_STATE_KEY = "post_index_last_filters";
+    const RECENTLY_VIEWED_KEY = "post_recently_viewed";
+    const FAVORITES_KEY = "post_favorites";
+    const suggestionSet = new Set(Array.from(document.querySelectorAll("#post-search-suggestions option")).map((node) => node.value.trim()).filter((value) => value.length > 0));
+
+    const readJson = (key, fallback = []) => {
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) return fallback;
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) || typeof parsed === "object" ? parsed : fallback;
+      } catch (_) {
+        return fallback;
+      }
+    };
+
+    const writeJson = (key, value) => {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch (_) {}
+    };
+
+    const favoritePosts = () => Array.isArray(readJson(FAVORITES_KEY, [])) ? readJson(FAVORITES_KEY, []) : [];
+
+    const renderSimpleList = (selector, items, emptyLabel) => {
+      const list = document.querySelector(selector);
+      if (!list) return;
+      if (!Array.isArray(items) || items.length === 0) {
+        list.innerHTML = `<li class="text-slate-500">${emptyLabel}</li>`;
+        return;
+      }
+
+      list.innerHTML = "";
+      items.forEach((item) => {
+        const li = document.createElement("li");
+        li.innerHTML = `<a href="${item.url}" class="text-blue-700 underline-offset-2 hover:underline">${item.title}</a>`;
+        list.appendChild(li);
+      });
+    };
+
+    const renderRevisitShortcuts = () => {
+      const recent = readJson(RECENTLY_VIEWED_KEY, []).slice(0, 6);
+      const favorites = favoritePosts().slice(0, 6);
+
+      renderSimpleList(
+        "[data-recently-viewed-list]",
+        recent,
+        "<%= j(t('posts.index.recently_viewed_empty', default: 'No recently viewed posts yet.')) %>"
+      );
+      renderSimpleList(
+        "[data-saved-post-list]",
+        favorites,
+        "<%= j(t('posts.index.saved_posts_empty', default: 'No saved posts yet.')) %>"
+      );
+    };
+
+    const setFavoriteButtonState = (button) => {
+      const id = String(button.dataset.postId || "");
+      if (!id) return;
+
+      const saved = favoritePosts().some((item) => String(item.id) === id);
+      button.setAttribute("aria-pressed", String(saved));
+      const label = button.querySelector("[data-favorite-label]");
+      if (label) {
+        label.textContent = saved ? "<%= j(t('posts.index.saved_post', default: 'Saved')) %>" : "<%= j(t('posts.index.save_post', default: 'Save')) %>";
+      }
+      button.classList.toggle("font-semibold", saved);
+      button.classList.toggle("text-blue-700", saved);
+    };
+
+    const syncFavoriteButtons = () => {
+      document.querySelectorAll("[data-favorite-toggle]").forEach((button) => setFavoriteButtonState(button));
+      renderRevisitShortcuts();
+    };
 
     const markLoadedMedia = (scope = document) => {
       scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
@@ -285,6 +403,88 @@
 
       sessionStorage.setItem(LIST_SCROLL_KEY, String(window.scrollY || window.pageYOffset || 0));
       sessionStorage.setItem(LIST_RESTORE_KEY, "1");
+
+      const card = link.closest("[data-post-id]");
+      if (card) {
+        const id = String(card.dataset.postId || "");
+        const title = card.dataset.postTitle || "";
+        const url = card.dataset.postUrl || link.getAttribute("href") || "";
+        if (id && title && url) {
+          const current = readJson(RECENTLY_VIEWED_KEY, []);
+          const next = [ { id, title, url, viewedAt: Date.now() }, ...current.filter((item) => String(item.id) !== id) ].slice(0, 12);
+          writeJson(RECENTLY_VIEWED_KEY, next);
+        }
+      }
+    });
+
+    document.addEventListener("click", (event) => {
+      const favoriteButton = event.target.closest("[data-favorite-toggle]");
+      if (!favoriteButton) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const id = String(favoriteButton.dataset.postId || "");
+      const title = favoriteButton.dataset.postTitle || "";
+      const url = favoriteButton.dataset.postUrl || "";
+      if (!id || !title || !url) return;
+
+      const current = favoritePosts();
+      const exists = current.some((item) => String(item.id) === id);
+      const next = exists ? current.filter((item) => String(item.id) !== id) : [ { id, title, url, savedAt: Date.now() }, ...current ].slice(0, 50);
+      writeJson(FAVORITES_KEY, next);
+      syncFavoriteButtons();
+
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "post_favorite_toggle", {
+          event_category: "post_index",
+          event_label: exists ? "unsave" : "save",
+          post_id: id
+        });
+      }
+    });
+
+    const restoreFiltersFromStorage = () => {
+      const form = document.querySelector("[data-search-form]");
+      if (!form) return;
+
+      const stored = readJson(FILTER_STATE_KEY, {});
+      if (!stored || typeof stored !== "object") return;
+      [ "q", "category", "theme", "tag", "sort" ].forEach((name) => {
+        const field = form.querySelector(`[name='${name}']`);
+        if (!field) return;
+        field.value = String(stored[name] || "");
+      });
+
+      const detailsInput = form.querySelector("[data-details-state-input]");
+      const detailsToggle = form.querySelector("[data-details-toggle]");
+      const detailsPanel = form.querySelector("[data-details-panel]");
+      const detailsShell = form.querySelector("[data-details-shell]");
+      const icon = detailsToggle ? detailsToggle.querySelector(".js-details-toggle-icon") : null;
+      const nextExpanded = stored.details === "1";
+      if (detailsInput) detailsInput.value = nextExpanded ? "1" : "0";
+      if (detailsToggle) detailsToggle.setAttribute("aria-expanded", String(nextExpanded));
+      if (detailsPanel) detailsPanel.classList.toggle("hidden", !nextExpanded);
+      if (detailsShell) detailsShell.classList.toggle("ds-filter-shell-collapsed", !nextExpanded);
+      if (icon) icon.classList.toggle("rotate-180", nextExpanded);
+    };
+
+    document.addEventListener("click", (event) => {
+      const restoreButton = event.target.closest("[data-restore-filters]");
+      if (restoreButton) {
+        restoreFiltersFromStorage();
+        return;
+      }
+
+      const clearButton = event.target.closest("[data-clear-filters]");
+      if (!clearButton) return;
+      const form = clearButton.closest("form");
+      if (!form) return;
+      [ "q", "category", "theme", "tag", "sort" ].forEach((name) => {
+        const field = form.querySelector(`[name='${name}']`);
+        if (field) field.value = name == "sort" ? "newest" : "";
+      });
+    });
     });
 
     let lastScrollY = window.scrollY || window.pageYOffset || 0;
@@ -303,7 +503,8 @@
       const category = (form.querySelector("[name='category']")?.value || "").trim();
       const theme = (form.querySelector("[name='theme']")?.value || "").trim();
       const tag = (form.querySelector("[name='tag']")?.value || "").trim();
-      const hasSearchState = [keyword, category, theme, tag].some((value) => value.length > 0);
+      const sort = (form.querySelector("[name='sort']")?.value || "").trim();
+      const hasSearchState = [keyword, category, theme, tag].some((value) => value.length > 0) || sort === "popular" || sort === "recently_updated";
       const focusedInSearch = searchRoot.contains(document.activeElement);
       const detailsOpen = form.querySelector("[data-details-state-input]")?.value === "1";
 
@@ -344,6 +545,16 @@
     document.addEventListener("change", (event) => {
       if (!event.target.closest("[data-search-form]")) return;
       syncMobileIndexCta();
+
+      if (event.target.matches("[data-search-keyword-input]") && typeof window.gtag === "function") {
+        const value = String(event.target.value || "").trim();
+        if (!value) return;
+        window.gtag("event", "post_search_suggestion_eval", {
+          event_category: "post_search",
+          event_label: suggestionSet.has(value) ? "suggestion_match" : "free_text",
+          query_length: value.length
+        });
+      }
     });
 
     document.addEventListener("focusin", (event) => {
@@ -364,7 +575,17 @@
       const categorySet = (form.querySelector("[name='category']")?.value || "").trim().length > 0;
       const themeSet = (form.querySelector("[name='theme']")?.value || "").trim().length > 0;
       const tagSet = (form.querySelector("[name='tag']")?.value || "").trim().length > 0;
+      const sort = (form.querySelector("[name='sort']")?.value || "").trim();
       const appliedFilterCount = [categorySet, themeSet, tagSet].filter(Boolean).length;
+
+      writeJson(FILTER_STATE_KEY, {
+        q: (form.querySelector("[name='q']")?.value || "").trim(),
+        category: (form.querySelector("[name='category']")?.value || "").trim(),
+        theme: (form.querySelector("[name='theme']")?.value || "").trim(),
+        tag: (form.querySelector("[name='tag']")?.value || "").trim(),
+        sort: sort,
+        details: detailsOpen ? "1" : "0"
+      });
 
       window.gtag("event", "post_search_submit", {
         event_category: "post_search",
@@ -373,7 +594,23 @@
         category_set: categorySet,
         theme_set: themeSet,
         tag_set: tagSet,
+        sort_option: sort,
         applied_filter_count: appliedFilterCount
+      });
+    });
+
+    document.addEventListener("submit", (event) => {
+      const form = event.target.closest("[data-search-form]");
+      if (!form) return;
+
+      const detailsOpen = form.querySelector("[data-details-state-input]")?.value === "1";
+      writeJson(FILTER_STATE_KEY, {
+        q: (form.querySelector("[name='q']")?.value || "").trim(),
+        category: (form.querySelector("[name='category']")?.value || "").trim(),
+        theme: (form.querySelector("[name='theme']")?.value || "").trim(),
+        tag: (form.querySelector("[name='tag']")?.value || "").trim(),
+        sort: (form.querySelector("[name='sort']")?.value || "").trim(),
+        details: detailsOpen ? "1" : "0"
       });
     });
 
@@ -392,17 +629,23 @@
       markLoadedMedia();
       syncMobileIndexCta();
       restoreListPosition();
+      restoreFiltersFromStorage();
+      syncFavoriteButtons();
     });
     document.addEventListener("DOMContentLoaded", () => {
       markLoadedMedia();
       syncMobileIndexCta();
       restoreListPosition();
+      restoreFiltersFromStorage();
+      syncFavoriteButtons();
     });
 
     window.setTimeout(() => {
       markLoadedMedia();
       syncMobileIndexCta();
       restoreListPosition();
+      restoreFiltersFromStorage();
+      syncFavoriteButtons();
     }, 0);
   }
 </script>

--- a/app/views/posts/notifications.html.erb
+++ b/app/views/posts/notifications.html.erb
@@ -16,24 +16,51 @@
     <% end %>
   </header>
 
-  <div class="ds-card p-6">
+  <div class="ds-card p-6 space-y-5">
+    <% important_notifications = @notifications.select(&:comment_kind?) %>
+    <% secondary_notifications = @notifications.reject(&:comment_kind?) %>
     <% if @notifications.any? %>
-      <div class="space-y-3">
-        <% @notifications.each do |notification| %>
-          <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
-            <p class="text-sm text-slate-800"><%= notification.message %></p>
-            <p class="mt-1 ds-text-meta">
-              <%= timestamp_tag(notification.created_at, style: :datetime) %>
-              <% if notification.read_at.present? %>
-                <span class="ml-2 inline-flex items-center gap-1 rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-emerald-700">
-                  <%= ui_icon(:check_circle, class_name: "h-3.5 w-3.5") %>
-                  <span><%= t("notification_labels.read") %></span>
-                </span>
-              <% end %>
-            </p>
-          </div>
+      <section class="space-y-3">
+        <div class="flex items-center justify-between">
+          <h2 class="ds-heading-sm text-slate-900"><%= t("posts.notifications.important", default: "Important notifications") %></h2>
+          <span class="ds-badge-active"><%= localized_number(important_notifications.size) %></span>
+        </div>
+        <% if important_notifications.any? %>
+          <% important_notifications.each do |notification| %>
+            <div class="rounded-lg border border-blue-300 bg-blue-50 p-3">
+              <p class="text-sm font-semibold text-blue-900"><%= notification.message %></p>
+              <p class="mt-1 ds-text-meta text-blue-800"><%= timestamp_tag(notification.created_at, style: :datetime) %></p>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="ds-text-muted"><%= t("posts.notifications.important_empty", default: "No important notifications.") %></p>
         <% end %>
-      </div>
+      </section>
+
+      <section class="space-y-3 border-t border-slate-200 pt-4">
+        <div class="flex items-center justify-between">
+          <h2 class="ds-heading-sm text-slate-900"><%= t("posts.notifications.secondary", default: "Other notifications") %></h2>
+          <span class="ds-badge-info"><%= localized_number(secondary_notifications.size) %></span>
+        </div>
+        <% if secondary_notifications.any? %>
+          <% secondary_notifications.each do |notification| %>
+            <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
+              <p class="text-sm text-slate-800"><%= notification.message %></p>
+              <p class="mt-1 ds-text-meta">
+                <%= timestamp_tag(notification.created_at, style: :datetime) %>
+                <% if notification.read_at.present? %>
+                  <span class="ml-2 inline-flex items-center gap-1 rounded border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-emerald-700">
+                    <%= ui_icon(:check_circle, class_name: "h-3.5 w-3.5") %>
+                    <span><%= t("notification_labels.read") %></span>
+                  </span>
+                <% end %>
+              </p>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="ds-text-muted"><%= t("posts.notifications.secondary_empty", default: "No secondary notifications.") %></p>
+        <% end %>
+      </section>
     <% else %>
       <div class="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center">
         <p class="ds-text-support"><%= t("posts.notifications.empty_state") %></p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,6 +5,8 @@
 <% comments_count_label = t("posts.show.comments_count_label", count: comments_count, localized_count: localized_number(comments_count), default: "#{localized_number(comments_count)} comments") %>
 <% share_url = post_share_url(@post) %>
 <% share_text = post_share_text(@post) %>
+<% reading_sections_data = reading_sections(@post.description) %>
+<% long_read = @post.description.to_s.length > 700 || reading_sections_data.size > 1 %>
 
 <article class="space-y-content" data-page-content>
   <header class="space-y-4">
@@ -24,7 +26,21 @@
     </div>
 
     <h1 class="ds-heading-xl ds-break-words text-slate-900"><%= @post.title %></h1>
-    <p class="ds-text-support"><%= t("posts.show.posted_by") %> <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %></p>
+    <p class="ds-text-support">
+      <%= t("posts.show.posted_by") %>
+      <%= link_to @post.user.name, user_path(@post.user), class: "font-medium text-blue-600 hover:text-blue-700" %>
+    </p>
+    <div class="flex flex-wrap items-center gap-2 ds-text-meta text-slate-600">
+      <span class="ds-badge-info"><%= t("posts.show.profile_completion", default: "Profile %{percent}% complete", percent: @author_trust[:completion]) %></span>
+      <span class="ds-badge-info"><%= t("posts.show.author_posts", default: "%{count} published posts", count: localized_number(@author_trust[:published_posts_count])) %></span>
+      <span class="ds-badge-info"><%= t("posts.show.author_likes", default: "%{count} total likes", count: localized_number(@author_trust[:total_likes])) %></span>
+      <% if @author_trust[:last_updated_at].present? %>
+        <span class="ds-badge-info"><%= t("posts.show.author_last_updated", default: "Last updated %{date}", date: formatted_date(@author_trust[:last_updated_at])) %></span>
+      <% end %>
+      <button type="button" class="tap-target cta-tertiary cta-compact" data-favorite-toggle data-post-id="<%= @post.id %>" data-post-title="<%= @post.title %>" data-post-url="<%= share_url %>" aria-pressed="false">
+        <span data-favorite-label><%= t("posts.show.save_post", default: "Save") %></span>
+      </button>
+    </div>
     <p class="ds-text-body ds-break-words max-w-3xl"><%= truncate(@post.description.to_s.squish, length: 170) %></p>
     <a href="#comments" class="tap-target cta-tertiary cta-compact"><%= t("posts.show.comments.title") %></a>
   </header>
@@ -39,7 +55,29 @@
 
   <section class="ds-section-card space-y-4">
     <h2 class="ds-heading-lg text-slate-900"><%= t("posts.show.overview_heading", default: "Overview") %></h2>
-    <p class="ds-text-body whitespace-pre-wrap ds-break-words max-w-3xl"><%= @post.description %></p>
+    <% if long_read %>
+      <div class="rounded-lg border border-slate-200 bg-slate-50 p-3">
+        <p class="text-xs font-semibold uppercase tracking-wide text-slate-500"><%= t("posts.show.reading_toc", default: "Reading guide") %></p>
+        <ol class="mt-2 list-decimal space-y-1 pl-5 text-sm text-slate-700">
+          <% reading_sections_data.each do |section| %>
+            <li><a href="##{section[:id]}" class="underline decoration-slate-300 underline-offset-2 hover:text-slate-900"><%= section[:title] %></a></li>
+          <% end %>
+        </ol>
+      </div>
+      <details class="rounded-lg border border-slate-200 bg-white p-3">
+        <summary class="cursor-pointer text-sm font-semibold text-slate-800"><%= t("posts.show.expand_full_text", default: "Expand full text") %></summary>
+        <div class="mt-3 space-y-4">
+          <% reading_sections_data.each do |section| %>
+            <section id="<%= section[:id] %>" class="space-y-2">
+              <h3 class="ds-heading-sm text-slate-900"><%= section[:title] %></h3>
+              <p class="ds-text-body whitespace-pre-wrap ds-break-words max-w-3xl"><%= section[:body] %></p>
+            </section>
+          <% end %>
+        </div>
+      </details>
+    <% else %>
+      <p class="ds-text-body whitespace-pre-wrap ds-break-words max-w-3xl"><%= @post.description %></p>
+    <% end %>
     <% if @post.tags.any? %>
       <div class="flex flex-wrap gap-2 border-t border-slate-100 pt-4">
         <% @post.tags.each do |tag| %>
@@ -130,13 +168,14 @@
       <div class="space-y-1"><h2 class="inline-flex items-center gap-1.5 ds-heading-lg text-slate-900" id="comments-heading"><%= ui_icon(:chat, class_name: "h-5 w-5") %><span><%= t("posts.show.comments.title") %></span></h2><p class="ds-text-meta"><%= comments_count_label %></p></div>
       <a href="#comment-form" class="tap-target cta-primary cta-compact"><%= @root_comments.any? ? t("posts.show.comments.post_comment") : t("posts.show.comment_empty_cta", default: "Write the first comment") %></a>
     </div>
+    <p class="ds-trust-note"><%= t("comments.health_note", default: "Report and mute controls are available per thread. Reports are reviewed in order of urgency.") %></p>
     <p class="ds-text-support"><%= t("posts.show.comments_lead", default: "After reading the post and related items, join the conversation below.") %></p>
 
     <% if @root_comments.any? %>
       <ol class="space-y-4" aria-live="polite" aria-labelledby="comments-heading">
         <% @root_comments.each_with_index do |comment, index| %>
           <li>
-            <article id="comment-<%= comment.id %>" class="ds-thread-root" aria-label="<%= t('posts.show.comments.thread_label', default: 'Comment thread %{position}', position: index + 1) %>">
+            <article id="comment-<%= comment.id %>" class="ds-thread-root" aria-label="<%= t('posts.show.comments.thread_label', default: 'Comment thread %{position}', position: index + 1) %>" data-comment-id="<%= comment.id %>">
               <div class="flex items-center justify-between gap-3"><p class="text-sm font-medium text-slate-800 ds-break-words"><%= comment.author_name %></p></div>
               <p class="mt-0.5 ds-text-meta"><%= timestamp_tag(comment.created_at, style: :datetime) %></p>
               <p class="mt-2 whitespace-pre-wrap text-sm leading-reading text-slate-700 ds-break-words"><%= comment.body %></p>
@@ -152,7 +191,13 @@
                 </div>
               <% end %>
               <div class="mt-3 border-t border-slate-100 pt-3">
-                <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700" do %><%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %><span><%= t("posts.show.comments.reply") %></span><% end %>
+                <div class="flex flex-wrap items-center gap-1.5">
+                  <%= link_to post_path(@post, anchor: "comments", reply_to: comment.id), class: "tap-target inline-flex items-center gap-1 rounded-md px-2 text-xs text-blue-600 hover:bg-blue-50 hover:text-blue-700" do %><%= ui_icon(:arrow_uturn_left, class_name: "h-3.5 w-3.5") %><span><%= t("posts.show.comments.reply") %></span><% end %>
+                  <button type="button" class="tap-target cta-tertiary cta-compact" data-mute-comment data-comment-id="<%= comment.id %>"><%= t("posts.show.comments.mute", default: "Mute thread") %></button>
+                  <% unless post_owner?(@post) %>
+                    <button type="button" class="tap-target cta-tertiary cta-compact" data-report-comment data-comment-id="<%= comment.id %>" data-comment-author="<%= comment.author_name %>" data-comment-body="<%= truncate(comment.body.to_s.squish, length: 120) %>"><%= t("posts.show.comments.report", default: "Report") %></button>
+                  <% end %>
+                </div>
               </div>
             </article>
           </li>
@@ -169,7 +214,7 @@
         </div>
       <% end %>
 
-      <%= form_with model: [@post, @comment], class: "space-y-form ds-loading-shell", data: { form_autofocus_errors: true, ui_form: true, loading_label: t("ui.processing", default: "Processing..."), submitting_reason: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
+      <%= form_with model: [@post, @comment], class: "space-y-form ds-loading-shell", data: { form_autofocus_errors: true, ui_form: true, form_analytics_context: "comment_form", offline_draft_key: "comment_form_post_#{@post.id}", draft_restored_message: t("ui.draft_restored", default: "Draft restored."), offline_submit_message: t("ui.offline_submit", default: "You appear to be offline. Your input was saved locally."), loading_label: t("ui.processing", default: "Processing..."), submitting_reason: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
         <% if @comment.errors.any? %>
           <div class="space-y-2">
             <%= render "shared/feedback_panel", level: :error, title: t("posts.form.error_summary", default: "Please fix the following errors."), body: t("comments.form.error_recovery", default: "Please update the fields and retry."), actions: [{ label: t("ui.retry", default: "Retry"), href: "#comment-form" }, { label: t("ui.back", default: "Back"), href: post_path(@post, anchor: "comments") }] %>
@@ -229,7 +274,7 @@
   <% unless post_owner?(@post) %>
     <dialog id="report-modal-<%= @post.id %>" data-report-modal class="w-full max-w-md rounded-xl border border-slate-200 p-0 shadow-lg backdrop:bg-slate-900/30">
       <div class="border-b border-slate-200 px-4 py-3"><h2 class="text-base font-semibold text-slate-900"><%= t("posts.show.report.title") %></h2><p class="mt-1 text-xs text-slate-600"><%= t("posts.show.report.description") %></p></div>
-      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4", data: { ui_form: true, loading_label: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
+      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4", data: { ui_form: true, form_analytics_context: "report_form", loading_label: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
         <% if owned_users.any? %><div><%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %><%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: true } %></div><% end %>
         <div><%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %><%= f.select :reason, options_for_select(Report.reason_options), {}, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", data: { modal_initial_focus: owned_users.any? ? nil : true } %><p class="ds-field-guide"><%= t("reports.reason_guide", default: "Select the closest reason so moderators can triage faster.") %></p></div>
         <div><%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %><%= f.text_area :details, rows: 4, maxlength: 1000, class: "w-full rounded-lg border border-slate-300 px-3 py-2 text-sm", placeholder: t("posts.show.report.details_placeholder"), data: { char_count_max: 1000, char_count_target: "report_details_counter" }, aria: { describedby: "report_details_guide report_details_counter" } %><p id="report_details_guide" class="ds-field-guide"><%= t("reports.details_guide", default: "Optional: include concise evidence. Avoid personal information.") %></p><p id="report_details_counter" class="ds-char-counter" aria-live="polite"></p></div>
@@ -288,7 +333,27 @@
     window.__postShowUiBindingInstalled = true;
     const menuOpenMessage = "<%= j(t('navigation.menu_opened', default: 'Action menu opened')) %>";
     const menuCloseMessage = "<%= j(t('navigation.menu_closed', default: 'Action menu closed')) %>";
+    const FAVORITES_KEY = "post_favorites";
+    const RECENTLY_VIEWED_KEY = "post_recently_viewed";
+    const MUTED_COMMENTS_KEY = "muted_comment_threads";
     let lastModalTrigger = null;
+
+    const readJson = (key, fallback = []) => {
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) return fallback;
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) || typeof parsed === "object" ? parsed : fallback;
+      } catch (_) {
+        return fallback;
+      }
+    };
+
+    const writeJson = (key, value) => {
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch (_) {}
+    };
 
     const markLoadedMedia = (scope = document) => {
       scope.querySelectorAll("[data-media-skeleton]").forEach((frame) => {
@@ -308,6 +373,53 @@
       if (!target) return;
       target.classList.add("ds-reply-target-highlight");
       window.setTimeout(() => target.classList.remove("ds-reply-target-highlight"), 1600);
+    };
+
+    const syncFavoriteButtons = () => {
+      const favorites = Array.isArray(readJson(FAVORITES_KEY, [])) ? readJson(FAVORITES_KEY, []) : [];
+      document.querySelectorAll("[data-favorite-toggle]").forEach((button) => {
+        const id = String(button.dataset.postId || "");
+        const saved = favorites.some((item) => String(item.id) === id);
+        button.setAttribute("aria-pressed", String(saved));
+        const label = button.querySelector("[data-favorite-label]");
+        if (label) label.textContent = saved ? "<%= j(t('posts.show.saved_post', default: 'Saved')) %>" : "<%= j(t('posts.show.save_post', default: 'Save')) %>";
+        button.classList.toggle("font-semibold", saved);
+        button.classList.toggle("text-blue-700", saved);
+      });
+    };
+
+    const storeRecentlyViewed = () => {
+      const id = "<%= @post.id %>";
+      const title = "<%= j(@post.title) %>";
+      const url = "<%= j(post_path(@post, from: @back_to_index_path || request.fullpath)) %>";
+      const current = readJson(RECENTLY_VIEWED_KEY, []);
+      const next = [ { id, title, url, viewedAt: Date.now() }, ...current.filter((item) => String(item.id) !== id) ].slice(0, 12);
+      writeJson(RECENTLY_VIEWED_KEY, next);
+    };
+
+    const applyMutedComments = () => {
+      const muted = Array.isArray(readJson(MUTED_COMMENTS_KEY, [])) ? readJson(MUTED_COMMENTS_KEY, []) : [];
+      document.querySelectorAll("[data-comment-id]").forEach((article) => {
+        const id = String(article.dataset.commentId || "");
+        const isMuted = muted.includes(id);
+        article.dataset.muted = isMuted ? "1" : "0";
+        article.classList.toggle("opacity-60", isMuted);
+        const muteButton = article.querySelector("[data-mute-comment]");
+        if (muteButton) {
+          muteButton.textContent = isMuted ? "<%= j(t('posts.show.comments.unmute', default: 'Unmute thread')) %>" : "<%= j(t('posts.show.comments.mute', default: 'Mute thread')) %>";
+        }
+
+        let mutedBadge = article.querySelector("[data-comment-muted-badge]");
+        if (isMuted && !mutedBadge) {
+          mutedBadge = document.createElement("p");
+          mutedBadge.dataset.commentMutedBadge = "true";
+          mutedBadge.className = "ds-comment-muted mt-2";
+          mutedBadge.textContent = "<%= j(t('posts.show.comments.muted_label', default: 'Muted thread. You can unmute anytime.')) %>";
+          const body = article.querySelector("p.mt-2");
+          if (body) body.after(mutedBadge);
+        }
+        if (!isMuted && mutedBadge) mutedBadge.remove();
+      });
     };
 
     const closeMenu = (menuSelector, toggleSelector, notify = false) => {
@@ -381,6 +493,56 @@
     });
 
     document.addEventListener("click", (event) => {
+      const favoriteButton = event.target.closest("[data-favorite-toggle]");
+      if (favoriteButton) {
+        event.preventDefault();
+        const id = String(favoriteButton.dataset.postId || "");
+        const title = favoriteButton.dataset.postTitle || "";
+        const url = favoriteButton.dataset.postUrl || "";
+        if (id && title && url) {
+          const current = Array.isArray(readJson(FAVORITES_KEY, [])) ? readJson(FAVORITES_KEY, []) : [];
+          const exists = current.some((item) => String(item.id) === id);
+          const next = exists ? current.filter((item) => String(item.id) !== id) : [ { id, title, url, savedAt: Date.now() }, ...current ].slice(0, 50);
+          writeJson(FAVORITES_KEY, next);
+          syncFavoriteButtons();
+        }
+        return;
+      }
+
+      const muteButton = event.target.closest("[data-mute-comment]");
+      if (muteButton) {
+        const commentId = String(muteButton.dataset.commentId || "");
+        if (!commentId) return;
+        const current = Array.isArray(readJson(MUTED_COMMENTS_KEY, [])) ? readJson(MUTED_COMMENTS_KEY, []) : [];
+        const next = current.includes(commentId) ? current.filter((id) => id !== commentId) : [ ...current, commentId ];
+        writeJson(MUTED_COMMENTS_KEY, next);
+        applyMutedComments();
+        if (typeof window.dsNotify === "function") {
+          window.dsNotify(current.includes(commentId) ? "<%= j(t('posts.show.comments.unmuted', default: 'Thread unmuted')) %>" : "<%= j(t('posts.show.comments.muted', default: 'Thread muted')) %>", "info");
+        }
+        return;
+      }
+
+      const reportCommentButton = event.target.closest("[data-report-comment]");
+      if (reportCommentButton) {
+        const modal = document.querySelector("[data-report-modal]");
+        if (!modal) return;
+        const modalId = modal.getAttribute("id");
+        const detailsField = modal.querySelector("[name='report[details]']");
+        const author = reportCommentButton.dataset.commentAuthor || "";
+        const commentBody = reportCommentButton.dataset.commentBody || "";
+        const commentId = reportCommentButton.dataset.commentId || "";
+        if (detailsField) {
+          detailsField.value = `<%= j(t('posts.show.comments.report_template', default: 'Comment report')) %> #${commentId} (${author}): ${commentBody}`;
+          detailsField.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        openModal(reportCommentButton, modalId);
+        closeMenu("[data-mobile-actions-menu]", "[data-mobile-actions-toggle]", true);
+        closeMenu("[data-desktop-post-actions-menu]", "[data-desktop-post-actions-toggle]");
+        syncMobileActionBar();
+        return;
+      }
+
       const openButton = event.target.closest("[data-open-report-modal]");
       if (openButton) {
         openModal(openButton, openButton.getAttribute("data-open-report-modal"));
@@ -462,8 +624,8 @@
       window.visualViewport.addEventListener("scroll", syncMobileActionBar);
     }
 
-    document.addEventListener("turbo:load", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); });
-    document.addEventListener("DOMContentLoaded", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); });
-    window.setTimeout(() => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); }, 0);
+    document.addEventListener("turbo:load", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); syncFavoriteButtons(); storeRecentlyViewed(); applyMutedComments(); });
+    document.addEventListener("DOMContentLoaded", () => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); syncFavoriteButtons(); storeRecentlyViewed(); applyMutedComments(); });
+    window.setTimeout(() => { markLoadedMedia(); syncMobileActionBar(); highlightCommentFromHash(); syncFavoriteButtons(); storeRecentlyViewed(); applyMutedComments(); }, 0);
   }
 </script>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -9,6 +9,7 @@
               data: {
                 form_autofocus_errors: true,
                 ui_form: true,
+                form_analytics_context: "user_profile_form",
                 loading_label: t("ui.processing", default: "Processing..."),
                 submitting_reason: t("ui.processing", default: "Processing..."),
                 disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"),

--- a/docs/design_debt_register.md
+++ b/docs/design_debt_register.md
@@ -1,0 +1,16 @@
+# Design Debt Register
+
+Date: 2026-03-02
+
+| ID | Theme | Impact KPI | Difficulty | Dependencies | Target Date | Status |
+|---|---|---|---|---|---|---|
+| DD-001 | Full token migration for dark mode | readability / bounce rate | Medium | token map, snapshot tests | 2026-04-15 | Planned |
+| DD-002 | Admin IA/breadcrumb parity | task completion time | Low | shared breadcrumb helper | 2026-03-25 | Planned |
+| DD-003 | Comment-level moderation backend | report resolution time | High | new model/controller | 2026-05-01 | Proposed |
+| DD-004 | Saved posts server sync | return visit CTR | Medium | user auth/session design | 2026-05-15 | Proposed |
+| DD-005 | Low-bandwidth image preset | LCP on 2g | Medium | variant strategy | 2026-04-30 | Planned |
+
+## Rules
+- Every new UI debt entry must include KPI + deadline.
+- Re-prioritize weekly in design review meeting.
+- Do not close debt items without measurable verification notes.

--- a/docs/design_system.md
+++ b/docs/design_system.md
@@ -93,6 +93,14 @@
   - Desktop: expose utility menus and additional metadata only when they do not compete with the primary CTA.
 - Prevent overflow in mixed Japanese/English labels with `ds-break-words` and explicit line-clamp rules.
 
+## First View Density Limits
+- Per first viewport block:
+  - Primary CTA count: max 1
+  - Secondary CTA count: max 2
+  - Body text lines: max 8 before collapse/summary
+  - Decorative accents: max 2 visual motifs
+- Exceeding limits requires explicit rationale in PR.
+
 ## Component State Matrix
 - Every interactive component must define and visually test:
   - `default`

--- a/docs/ia_consistency_audit.md
+++ b/docs/ia_consistency_audit.md
@@ -1,0 +1,20 @@
+# Information Architecture Consistency Audit
+
+Date: 2026-03-02
+Scope: posts/index, posts/show, post/user forms, notifications, onboarding, legal pages
+
+## Audit Criteria
+- Current location visibility: breadcrumb/context path is present.
+- Next-step visibility: each screen exposes at least one forward action.
+- Policy access: legal links are visible from high-entry screens.
+- Heading structure: one `h1` per page and progressive section headings.
+
+## Findings and Implemented Actions
+- Added global breadcrumb-style context nav in layout.
+- Added onboarding quick link to major entry points.
+- Added legal quick links in header utility and key content pages.
+- Added revisit block on gallery page for "recently viewed" and "saved" shortcuts.
+
+## Open Follow-up
+- Add explicit breadcrumb coverage for admin namespace.
+- Consider hierarchical IA map in docs for future feature teams.

--- a/docs/improvement_done_definition.md
+++ b/docs/improvement_done_definition.md
@@ -1,0 +1,17 @@
+# UI Improvement Definition of Done
+
+An improvement is considered complete only when all conditions below are satisfied.
+
+## Behavior Metrics
+- Primary target KPI is measured for the full observation window.
+- Guardrail KPI remains within acceptable range.
+
+## Quality Metrics
+- No unresolved accessibility regression in audit checks.
+- Keyboard flow and focus visibility are validated.
+- Error/loading/success/disabled states are implemented and testable.
+
+## Delivery Criteria
+- Feature is documented in relevant UX/runbook docs.
+- Related tests are updated or explicit testing gaps are recorded.
+- Rollback condition is predefined.

--- a/docs/mobile_input_parity.md
+++ b/docs/mobile_input_parity.md
@@ -1,0 +1,18 @@
+# Mobile Input Parity Checklist (iOS / Android)
+
+## Scope
+- Keyboard open/close behavior
+- Focus transitions between fields
+- Safe area overlap with sticky action bars
+- Dialog and menu focus return on close
+
+## Implemented Baseline
+- Platform class tagging (`platform-ios`, `platform-android`) in UI runtime.
+- Sticky bars use safe-area-aware padding.
+- Mobile action bars hide while forms are focused.
+
+## Manual Verification Script
+1. Open post detail on iOS Safari and Android Chrome.
+2. Focus comment name/body fields and verify sticky bar hides.
+3. Open/close report modal and verify focus returns to trigger.
+4. Submit with missing required fields and verify reason text is visible.

--- a/docs/release_observation_policy.md
+++ b/docs/release_observation_policy.md
@@ -1,0 +1,21 @@
+# Release Observation Policy
+
+## Standard Observation Window
+- Minimum: 14 days per UX change batch.
+- If sample size is insufficient after 14 days, extend to 21 days.
+
+## Decision States
+- Success: KPI moved in expected direction and guardrail is stable.
+- Hold: KPI improved but guardrail unstable, or sample size insufficient.
+- Rollback: KPI regressed or guardrail breach persisted > 3 consecutive days.
+
+## Required Inputs Before Release
+- Primary KPI and expected direction.
+- Guardrail KPI.
+- Rollback trigger threshold.
+- Owner and review date.
+
+## Required Outputs After Observation
+- Outcome state (Success / Hold / Rollback).
+- Evidence summary with dates.
+- Next action (scale / tune / revert).

--- a/docs/search_suggest_evaluation.md
+++ b/docs/search_suggest_evaluation.md
@@ -1,0 +1,17 @@
+# Search Suggest Evaluation Plan
+
+## Hypothesis
+Search suggestions (titles/tags/categories/themes) reduce zero-result searches by guiding users during input.
+
+## Implemented
+- Added input datalist suggestions on gallery search field.
+- Added event `post_search_suggestion_eval` with labels:
+  - `suggestion_match`
+  - `free_text`
+
+## Success Metric
+- Primary: zero-result rate reduction.
+- Secondary: search submit-to-detail CTR improvement.
+
+## Guardrail
+- Search submit volume should not decrease significantly.

--- a/lib/tasks/accessibility_audit.rake
+++ b/lib/tasks/accessibility_audit.rake
@@ -1,0 +1,9 @@
+namespace :accessibility do
+  desc "Run recurring accessibility smoke audit"
+  task audit: :environment do
+    command = "ruby bin/rails test test/accessibility"
+    puts "[a11y] running: #{command}"
+    success = system(command)
+    abort("[a11y] accessibility audit failed") unless success
+  end
+end

--- a/test/accessibility/basic_audit_test.rb
+++ b/test/accessibility/basic_audit_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class BasicAccessibilityAuditTest < ActionDispatch::IntegrationTest
+  test "major pages keep one h1" do
+    pages = [
+      root_path,
+      new_user_path,
+      onboarding_path,
+      terms_path,
+      privacy_policy_path,
+      cookie_policy_path
+    ]
+
+    pages.each do |path|
+      get path
+      assert_response :success
+      doc = Nokogiri::HTML.parse(@response.body)
+      assert_equal 1, doc.css("h1").size, "Expected one h1 on #{path}"
+    end
+  end
+
+  test "post form required controls are labeled" do
+    post users_url, params: {
+      user: {
+        name: "Audit User",
+        bio: "Profile for audit"
+      }
+    }
+    assert_response :redirect
+
+    get new_post_path
+    assert_response :success
+    doc = Nokogiri::HTML.parse(@response.body)
+
+    required_fields = doc.css("form input[required], form textarea[required], form select[required]")
+    assert required_fields.any?, "Expected at least one required field"
+
+    required_fields.each do |field|
+      id = field["id"]
+      next if id.blank?
+      assert doc.at_css("label[for='#{id}']"), "Expected label for required field ##{id}"
+    end
+  end
+end


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/69

## 目的

  運用フェーズで顕在化しやすい残課題（品質保証・信頼形成・発見性・再訪/継続利用）を実装し、DeskTour Studio の UX/UI 改善を完了状態に近づけること。

  ## 実装内容

  - 情報アーキテクチャ一貫性: 全画面 breadcrumb 追加
  - 検索補助: 入力サジェスト導入、サジェスト評価イベント追加
  - ソート設計: newest / popular / recently_updated 追加 + 基準説明表示
  - フィルター解除/復元: 個別解除・一括解除・前回状態復元を同一領域へ集約
  - 長文読了支援: 目次/見出しジャンプ/折りたたみ全文
  - コメント健全性: コメント単位の mute/report 導線
  - 投稿者信頼シグナル: プロフィール充実度・投稿実績・総いいね・最終更新
  - 通知優先順位: 重要通知と補助通知を分離表示
  - 再訪最適化: 最近見た投稿・保存投稿のショートカット表示
  - 保存導線: 投稿カード/詳細から保存トグル（ローカル）実装
  - 共有メタ品質: OG/Twitter タイトル・説明最適化、画像サイズ/alt補強
  - フォーム離脱計測: 項目単位 blur + 離脱イベント
  - 低回線対応: 低帯域モード表示と軽量化ルール
  - オフライン再送体験: 入力内容ローカル保持/復元 + オフライン通知
  - 端末差分吸収: iOS/Android 判別クラスと safe-area 調整
  - 情報密度上限: ファーストビュー密度ルールを design system に明記
  - デザイン負債台帳: KPI/難易度/依存/期限つき台帳を追加
  - A11y 定期監査: 監査テスト + Rake タスク + CI 定期ジョブ追加
  - 観測期間標準化/完了定義: リリース観測ポリシーと DoD 文書化

  ## 方法

  - 既存 ERB 構造を維持し、data-* ベースで段階的に機能追加
  - 共通JS (ui_state.js) に計測・オフライン保持・低帯域判定を集約
  - モデル/コントローラに最小限の拡張（ソート・信頼シグナル用集計）
  - 運用項目は docs 化 + CI 自動化で継続可能な運用に接続

  ## 変更箇所

  - 検索/再訪/保存/ソート:
    [index.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\index.html.erb)
    [post.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\models\post.rb)
    [posts_controller.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\controllers\posts_controller.rb)
  - 詳細/長文/信頼/コメント健全性:
    [show.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\show.html.erb)
  - 共通ヘルパ/IA/メタ:
    [application_helper.rb](C:\Users\hahib\ruby on rails\desktour_studio\app\helpers\application_helper.rb)
    [application.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\layouts\application.html.erb)
  - オフライン/計測/低回線/端末差分:
    [ui_state.js](C:\Users\hahib\ruby on rails\desktour_studio\app\javascript\ui_state.js)
    [application.css](C:\Users\hahib\ruby on rails\desktour_studio\app\assets\tailwind\application.css)
  - 通知優先順位表示:
    [notifications.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts\notifications.html.erb)
  - フォーム計測/オフライン下書き対応:
    [_form.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\posts_form.html.erb)
    [users/_form.html.erb](C:\Users\hahib\ruby on rails\desktour_studio\app\views\users_form.html.erb)
  - A11y 定期監査:
    [accessibility_audit.rake](C:\Users\hahib\ruby on rails\desktour_studio\lib\tasks\accessibility_audit.rake)
    [basic_audit_test.rb](C:\Users\hahib\ruby on rails\desktour_studio\test\accessibility\basic_audit_test.rb)
    [ci.yml](C:\Users\hahib\ruby on rails\desktour_studio.github\workflows\ci.yml)
  - 運用ドキュメント:
    [ia_consistency_audit.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\ia_consistency_audit.md)
    [design_debt_register.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\design_debt_register.md)
    [release_observation_policy.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\release_observation_policy.md)
    [improvement_done_definition.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\improvement_done_definition.md)
    [mobile_input_parity.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\mobile_input_parity.md)
    [search_suggest_evaluation.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\search_suggest_evaluation.md)
    [design_system.md](C:\Users\hahib\ruby on rails\desktour_studio\docs\design_system.md)

  ## まとめ

  最終追補分の改善項目を、機能実装（検索・読了支援・信頼・再訪・低回線/オフライン）と運用実装（監査・観測・完了定義）まで含めて反映しました。
  「見た目の改修」ではなく、継続運用で品質を維持・検証できる状態まで揃えています。

  ## Testing

  - ruby bin/rails test test/models test/controllers test/helpers test/jobs test/accessibility
    結果: 58 runs, 184 assertions, 0 failures, 0 errors
  - bundle exec rake accessibility:audit
    結果: 成功（2 runs, 17 assertions, 0 failures）