### PR TITLE
UX Robustness: Improving conversion via step-by-step forms, error recovery, and accidental tap prevention

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -638,6 +638,10 @@
     @apply border-emerald-300 bg-emerald-50 text-emerald-800;
   }
 
+  .ds-toast-warning {
+    @apply border-amber-300 bg-amber-50 text-amber-900;
+  }
+
   .ds-toast-error {
     @apply border-red-300 bg-red-50 text-red-800;
   }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,6 +30,13 @@ class PostsController < ApplicationController
     @unread_notifications_count = post_owner?(@post) ? @post.notifications.unread.count : 0
     @back_to_index_path = sanitize_internal_back_path(params[:from])
     @author_trust = author_trust_snapshot(@post.user)
+    @related_posts, @related_posts_reason = related_posts_for(@post)
+    queue_analytics_event(
+      "related_posts_impression",
+      post_id: @post.id,
+      related_count: @related_posts.size,
+      reason: @related_posts_reason
+    )
   end
 
   def new
@@ -230,6 +237,42 @@ class PostsController < ApplicationController
       total_likes: posts_scope.sum(:likes_count),
       last_updated_at: posts_scope.maximum(:updated_at)
     }
+  end
+
+  def related_posts_for(post)
+    candidates = Post.visible.includes(:user, desk_image_attachment: :blob).where.not(id: post.id).limit(30).to_a
+    return [ [], "none" ] if candidates.empty?
+
+    target_tags = post.tags.map(&:downcase)
+    target_category = post.category.to_s.downcase
+    target_theme = post.theme.to_s.downcase
+
+    scored = candidates.map do |candidate|
+      candidate_tags = candidate.tags.map(&:downcase)
+      overlap = candidate_tags.select { |tag| target_tags.include?(tag) }
+      score = 0
+      score += overlap.size * 4
+      score += 2 if target_category.present? && candidate.category.to_s.downcase == target_category
+      score += 1 if target_theme.present? && candidate.theme.to_s.downcase == target_theme
+      score += [ candidate.likes_count.to_i / 10, 3 ].min
+
+      {
+        candidate: candidate,
+        score: score,
+        overlap: overlap.uniq.first(2)
+      }
+    end
+
+    top = scored.sort_by { |row| [ -row[:score], -row[:candidate].likes_count.to_i, -row[:candidate].created_at.to_i ] }.first(4)
+    reason = if top.any? { |row| row[:overlap].any? }
+      "tag_overlap"
+    elsif top.any? { |row| row[:score] >= 2 }
+      "category_theme"
+    else
+      "popular_fallback"
+    end
+
+    [ top, reason ]
   end
 
   def assign_owner_token(post)

--- a/app/javascript/ui_state.js
+++ b/app/javascript/ui_state.js
@@ -35,6 +35,14 @@ const writeJson = (key, value) => {
   } catch (_) {}
 };
 
+const confirmOptionsFromDataset = (dataset = {}) => ({
+  title: dataset.confirmTitle || dataset.criticalTitle || "",
+  message: dataset.confirmMessage || dataset.criticalMessage || "",
+  confirmLabel: dataset.confirmLabel || dataset.criticalConfirm || "",
+  cancelLabel: dataset.confirmCancel || "",
+  level: dataset.confirmLevel || dataset.criticalLevel || "primary"
+});
+
 const controlLabel = (field, form) => {
   if (!field) return "";
 
@@ -319,6 +327,37 @@ const bindFormState = (scope = document) => {
       updateFormState(form);
     });
 
+    form.addEventListener("submit", async (event) => {
+      if (form.dataset.criticalForm !== "true") return;
+      if (form.dataset.confirmBypassOnce === "true") {
+        form.dataset.confirmBypassOnce = "false";
+        return;
+      }
+
+      const submitter = event.submitter;
+      if (submitter?.name === "save_as_draft") return;
+
+      event.preventDefault();
+      const confirmSource = submitter || form;
+      if (typeof window.dsConfirmAction !== "function") {
+        form.dataset.confirmBypassOnce = "true";
+        if (submitter && typeof form.requestSubmit === "function") form.requestSubmit(submitter);
+        return;
+      }
+
+      const confirmed = await window.dsConfirmAction(confirmOptionsFromDataset(confirmSource.dataset || form.dataset || {}));
+      if (!confirmed) return;
+
+      form.dataset.confirmBypassOnce = "true";
+      if (submitter && typeof form.requestSubmit === "function") {
+        form.requestSubmit(submitter);
+      } else if (typeof form.requestSubmit === "function") {
+        form.requestSubmit();
+      } else {
+        form.submit();
+      }
+    });
+
     restoreDraft();
     updateFormState(form);
     trackErrorExposure();
@@ -329,18 +368,91 @@ const bindFormAbandonmentObserver = () => {
   if (window.__formAbandonmentBound) return;
   window.__formAbandonmentBound = true;
 
-  window.addEventListener("beforeunload", () => {
-    if (typeof window.gtag !== "function") return;
-    const dirtyForm = document.querySelector("form[data-ui-form][data-ui-form-dirty='true']");
+  window.addEventListener("beforeunload", (event) => {
+    const dirtyForm = document.querySelector("form[data-ui-form][data-ui-form-dirty='true']:not([data-ui-submitting='true'])");
     if (!dirtyForm) return;
     const active = dirtyForm.querySelector(":focus");
     const activeField = active ? active.getAttribute("name") : "";
-    window.gtag("event", "form_abandon", {
-      event_category: "form",
-      event_label: dirtyForm.dataset.formAnalyticsContext || "generic_form",
-      active_field: activeField
+    if (typeof window.gtag === "function") {
+      window.gtag("event", "form_abandon", {
+        event_category: "form",
+        event_label: dirtyForm.dataset.formAnalyticsContext || "generic_form",
+        active_field: activeField
+      });
+    }
+
+    const leaveMessage = dirtyForm.dataset.leaveGuardMessage;
+    if (leaveMessage && dirtyForm.dataset.uiSubmitting !== "true") {
+      event.preventDefault();
+      event.returnValue = leaveMessage;
+      return leaveMessage;
+    }
+
+    return undefined;
+  });
+};
+
+const bindDialogFocusTrap = (scope = document) => {
+  scope.querySelectorAll("dialog").forEach((dialog) => {
+    if (dialog.dataset.focusTrapBound === "1") return;
+    dialog.dataset.focusTrapBound = "1";
+
+    dialog.addEventListener("keydown", (event) => {
+      if (event.key !== "Tab" || !dialog.open) return;
+      const focusable = Array.from(dialog.querySelectorAll("a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex='0']")).filter((node) => !node.hasAttribute("disabled"));
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     });
   });
+};
+
+const bindConfirmActions = (scope = document) => {
+  if (window.__confirmBindingsInstalled) return;
+  window.__confirmBindingsInstalled = true;
+
+  document.addEventListener("click", async (event) => {
+    const trigger = event.target.closest("[data-confirm-action]");
+    if (!trigger) return;
+    if (trigger.dataset.confirmBypassOnce === "true") {
+      trigger.dataset.confirmBypassOnce = "false";
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (typeof window.dsConfirmAction !== "function") {
+      trigger.dataset.confirmBypassOnce = "true";
+      if (trigger.form && typeof trigger.form.requestSubmit === "function") {
+        trigger.form.requestSubmit(trigger);
+      }
+      return;
+    }
+
+    const confirmed = await window.dsConfirmAction(confirmOptionsFromDataset(trigger.dataset || {}));
+    if (!confirmed) return;
+
+    trigger.dataset.confirmBypassOnce = "true";
+    if (trigger.tagName === "A") {
+      const href = trigger.getAttribute("href");
+      if (href) window.location.assign(href);
+      return;
+    }
+    if (trigger.form && typeof trigger.form.requestSubmit === "function") {
+      trigger.form.requestSubmit(trigger);
+    } else if (typeof trigger.click === "function") {
+      trigger.click();
+    }
+  }, true);
 };
 
 const renderImageFallback = (image, reason = "error") => {
@@ -459,6 +571,8 @@ const initializeUiState = (scope = document) => {
   bindCharCounters(scope);
   bindFormState(scope);
   bindFormAbandonmentObserver();
+  bindDialogFocusTrap(scope);
+  bindConfirmActions(scope);
   bindImageFallback(scope);
   bindLoadingSkeleton(scope);
   showFlashToasts(scope);

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,6 +19,7 @@ class Post < ApplicationRecord
   validates :description, presence: true, length: { maximum: 2000 }, if: :published?
   validates :owner_token_digest, presence: true
   validate :desk_image_presence
+  validate :desk_image_constraints
 
   def self.digest_owner_token(token)
     Digest::SHA256.hexdigest(token.to_s)
@@ -69,6 +70,24 @@ class Post < ApplicationRecord
     return unless published?
     return if desk_image.attached?
 
-    errors.add(:desk_image, "を選択してください")
+    errors.add(:desk_image, I18n.t("posts.errors.image_required", default: "Cause: No image selected. Action: Select one image. Retry: Submit again."))
+  end
+
+  def desk_image_constraints
+    return unless desk_image.attached?
+
+    blob = desk_image.blob
+    return if blob.blank?
+
+    allowed_types = %w[image/jpeg image/png image/webp image/gif]
+    unless allowed_types.include?(blob.content_type.to_s)
+      errors.add(:desk_image, I18n.t("posts.errors.image_format", default: "Cause: Unsupported format. Action: Use JPEG, PNG, WEBP, or GIF. Retry: Choose another file and submit again."))
+    end
+
+    max_bytes = 8.megabytes
+    return unless blob.byte_size.to_i > max_bytes
+
+    max_human_size = ActiveSupport::NumberHelper.number_to_human_size(max_bytes)
+    errors.add(:desk_image, I18n.t("posts.errors.image_size", size: max_human_size, default: "Cause: File size exceeds %{size}. Action: Compress the image. Retry: Upload again."))
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,16 +103,16 @@
 
                 <section class="ds-utility-section">
                   <p class="ds-utility-section-title"><%= t("navigation.utility_settings", default: "Settings") %></p>
-                  <div class="rounded-lg border ds-border-subtle ds-surface-base p-2">
+      <div class="rounded-lg border ds-border-subtle ds-surface-base p-2">
                     <p class="mb-1 ds-text-meta font-semibold"><%= t("language.switch_aria") %></p>
                     <div class="ds-locale-switch w-full" role="group" aria-label="<%= t('language.switch_aria') %>">
-                      <%= link_to locale_switch_path(:ja), class: "ds-locale-pill #{locale_selected?(:ja) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
+                      <%= link_to locale_switch_path(:ja), class: "ds-locale-pill #{locale_selected?(:ja) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { locale_switch_link: true, target_locale: "ja", ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_ja" } do %>
                         <span><%= t("language.option_ja") %></span>
                         <% if locale_selected?(:ja) %>
                           <%= ui_icon(:check, class_name: "h-3 w-3") %>
                         <% end %>
                       <% end %>
-                      <%= link_to locale_switch_path(:en), class: "ds-locale-pill #{locale_selected?(:en) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
+                      <%= link_to locale_switch_path(:en), class: "ds-locale-pill #{locale_selected?(:en) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { locale_switch_link: true, target_locale: "en", ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "desktop_locale_en" } do %>
                         <span><%= t("language.option_en") %></span>
                         <% if locale_selected?(:en) %>
                           <%= ui_icon(:check, class_name: "h-3 w-3") %>
@@ -159,13 +159,13 @@
             <div class="rounded-lg border ds-border-subtle ds-surface-base p-2">
               <p class="mb-1 ds-text-meta font-semibold"><%= t("language.switch_aria") %></p>
               <div class="ds-locale-switch" role="group" aria-label="<%= t('language.switch_aria') %>">
-                <%= link_to locale_switch_path(:ja), class: "ds-locale-pill #{locale_selected?(:ja) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } do %>
+                <%= link_to locale_switch_path(:ja), class: "ds-locale-pill #{locale_selected?(:ja) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:ja) ? "true" : nil) }, data: { locale_switch_link: true, target_locale: "ja", mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_ja" } do %>
                   <span><%= t("language.option_ja") %></span>
                   <% if locale_selected?(:ja) %>
                     <%= ui_icon(:check, class_name: "ml-1 h-3 w-3") %>
                   <% end %>
                 <% end %>
-                <%= link_to locale_switch_path(:en), class: "ds-locale-pill #{locale_selected?(:en) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } do %>
+                <%= link_to locale_switch_path(:en), class: "ds-locale-pill #{locale_selected?(:en) ? 'ds-locale-pill-active' : 'ds-locale-pill-inactive'}", aria: { current: (locale_selected?(:en) ? "true" : nil) }, data: { locale_switch_link: true, target_locale: "en", mobile_header_action: true, ga_event: "navigation_language_switch_click", ga_category: "navigation", ga_label: "mobile_locale_en" } do %>
                   <span><%= t("language.option_en") %></span>
                   <% if locale_selected?(:en) %>
                     <%= ui_icon(:check, class_name: "ml-1 h-3 w-3") %>
@@ -231,7 +231,7 @@
         when :error
           "error"
         when :warning
-          "info"
+          "warning"
         else
           "success"
         end %>
@@ -265,6 +265,16 @@
         </div>
       </div>
     </footer>
+    <dialog id="ui-confirm-dialog" class="ds-dialog-surface w-full max-w-md rounded-xl border ds-border-subtle p-0 shadow-lg">
+      <div class="border-b ds-border-subtle px-4 py-3">
+        <h2 class="text-base font-semibold ds-text-strong" data-confirm-title><%= t("ui.confirm_title", default: "Please confirm") %></h2>
+        <p class="mt-1 text-xs ds-text-weak" data-confirm-message><%= t("ui.confirm_message", default: "Check this action before continuing.") %></p>
+      </div>
+      <div class="flex justify-end gap-2 px-4 py-4">
+        <button type="button" class="tap-target cta-tertiary" data-confirm-cancel><%= t("ui.cancel", default: "Cancel") %></button>
+        <button type="button" class="tap-target cta-primary" data-confirm-ok><%= t("ui.confirm", default: "Continue") %></button>
+      </div>
+    </dialog>
     <p id="ui-live-region" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></p>
     <div id="ui-toast-region" class="ds-toast-region" aria-live="polite" aria-atomic="true"></div>
 
@@ -273,6 +283,8 @@
         window.__mobileHeaderBindingInstalled = true;
         const menuOpenedMessage = "<%= j(t('navigation.menu_opened', default: 'Menu opened')) %>";
         const menuClosedMessage = "<%= j(t('navigation.menu_closed', default: 'Menu closed')) %>";
+        const localeSwitchSessionKey = "locale_switch_session_context";
+        let activeMenuRoot = null;
         const syncStickyInsets = () => {
           const header = document.querySelector("[data-mobile-header-root]");
           if (header) {
@@ -318,22 +330,134 @@
           announceToRegion("<%= j(t('ui.page_changed', default: 'Screen updated')) %>");
         };
 
-        window.dsNotify = (message, level = "info") => {
-          if (!message) return;
-          announceToRegion(message);
+        const trackLocaleSwitchContinuation = () => {
+          const contextRaw = sessionStorage.getItem(localeSwitchSessionKey);
+          if (!contextRaw || typeof window.gtag !== "function") return;
+          try {
+            const context = JSON.parse(contextRaw);
+            const now = Date.now();
+            const currentLocale = (document.documentElement.getAttribute("lang") || "").toLowerCase();
+            if (!context || !context.target_locale) return;
+            const sameLocale = currentLocale === String(context.target_locale).toLowerCase();
+            const elapsed = now - Number(context.at || 0);
+            if (sameLocale && elapsed <= (10 * 60 * 1000)) {
+              window.gtag("event", "language_switch_session_continued", {
+                event_category: "navigation",
+                event_label: context.target_locale,
+                elapsed_ms: elapsed
+              });
+            }
+          } catch (_) {
+          } finally {
+            sessionStorage.removeItem(localeSwitchSessionKey);
+          }
+        };
 
+        const enableMenuFocusTrap = (menuRoot, toggleButton) => {
+          activeMenuRoot = menuRoot;
+          const firstFocusable = menuRoot.querySelector("a, button, [tabindex='0']");
+          if (firstFocusable && typeof firstFocusable.focus === "function") {
+            window.setTimeout(() => firstFocusable.focus(), 0);
+          }
+          if (toggleButton) toggleButton.dataset.menuToggle = "true";
+        };
+
+        const disableMenuFocusTrap = () => {
+          activeMenuRoot = null;
+        };
+
+        const toastQueue = [];
+        let toastRendering = false;
+        const toastPolicies = {
+          success: { duration: 2200, tone: "ds-toast-success", priority: 1 },
+          info: { duration: 2600, tone: "ds-toast-info", priority: 1 },
+          warning: { duration: 3600, tone: "ds-toast-warning", priority: 2 },
+          error: { duration: 5200, tone: "ds-toast-error", priority: 3 }
+        };
+
+        const renderNextToast = () => {
+          if (toastRendering || toastQueue.length === 0) return;
+          toastQueue.sort((a, b) => b.priority - a.priority);
+          const nextToast = toastQueue.shift();
           const toastRegion = document.getElementById("ui-toast-region");
-          if (!toastRegion) return;
+          if (!toastRegion || !nextToast) return;
+
+          toastRendering = true;
           const toast = document.createElement("div");
-          const toneClass = level === "error" ? "ds-toast-error" : level === "success" ? "ds-toast-success" : "ds-toast-info";
-          toast.className = `ds-toast ${toneClass}`;
-          toast.textContent = message;
+          toast.className = `ds-toast ${nextToast.tone}`;
+          toast.textContent = nextToast.message;
           toastRegion.appendChild(toast);
           window.setTimeout(() => {
             toast.remove();
-          }, 1800);
+            toastRendering = false;
+            renderNextToast();
+          }, nextToast.duration);
+        };
+
+        window.dsNotify = (message, level = "info") => {
+          if (!message) return;
+          announceToRegion(message);
+          const key = String(level || "info");
+          const policy = toastPolicies[key] || toastPolicies.info;
+          toastQueue.push({ message, ...policy });
+          renderNextToast();
         };
         window.dsAnnounce = (message) => announceToRegion(message);
+
+        window.dsConfirmAction = (options = {}) => {
+          const dialog = document.getElementById("ui-confirm-dialog");
+          if (!dialog || typeof dialog.showModal !== "function") return Promise.resolve(false);
+
+          const titleNode = dialog.querySelector("[data-confirm-title]");
+          const messageNode = dialog.querySelector("[data-confirm-message]");
+          const cancelButton = dialog.querySelector("[data-confirm-cancel]");
+          const okButton = dialog.querySelector("[data-confirm-ok]");
+          const previousFocus = document.activeElement;
+          const level = options.level === "danger" ? "danger" : options.level === "warning" ? "warning" : "primary";
+
+          if (titleNode) titleNode.textContent = options.title || "<%= j(t('ui.confirm_title', default: 'Please confirm')) %>";
+          if (messageNode) messageNode.textContent = options.message || "<%= j(t('ui.confirm_message', default: 'Check this action before continuing.')) %>";
+          if (okButton) okButton.textContent = options.confirmLabel || "<%= j(t('ui.confirm', default: 'Continue')) %>";
+          if (cancelButton) cancelButton.textContent = options.cancelLabel || "<%= j(t('ui.cancel', default: 'Cancel')) %>";
+
+          if (okButton) {
+            okButton.classList.remove("cta-primary", "cta-warning", "cta-danger");
+            okButton.classList.add(level === "danger" ? "cta-danger" : level === "warning" ? "cta-warning" : "cta-primary");
+          }
+
+          return new Promise((resolve) => {
+            const cleanup = () => {
+              dialog.removeEventListener("cancel", onCancel);
+              if (cancelButton) cancelButton.removeEventListener("click", onCancel);
+              if (okButton) okButton.removeEventListener("click", onConfirm);
+              if (previousFocus && typeof previousFocus.focus === "function") {
+                window.setTimeout(() => previousFocus.focus(), 0);
+              }
+            };
+
+            const onCancel = (event) => {
+              if (event) event.preventDefault();
+              cleanup();
+              dialog.close();
+              resolve(false);
+            };
+
+            const onConfirm = (event) => {
+              if (event) event.preventDefault();
+              cleanup();
+              dialog.close();
+              resolve(true);
+            };
+
+            dialog.addEventListener("cancel", onCancel, { once: true });
+            if (cancelButton) cancelButton.addEventListener("click", onCancel, { once: true });
+            if (okButton) okButton.addEventListener("click", onConfirm, { once: true });
+            dialog.showModal();
+            window.setTimeout(() => {
+              (cancelButton || okButton || dialog).focus();
+            }, 0);
+          });
+        };
 
         const closeMobileHeaderMenu = (reason = "dismissed") => {
           const menu = document.querySelector("[data-mobile-header-menu]");
@@ -342,6 +466,7 @@
 
           menu.classList.add("hidden");
           if (toggle) toggle.setAttribute("aria-expanded", "false");
+          disableMenuFocusTrap();
           window.dsNotify(menuClosedMessage, "info");
           if (typeof window.gtag === "function") {
             window.gtag("event", "navigation_mobile_menu_close", {
@@ -358,6 +483,7 @@
 
           menu.classList.add("hidden");
           if (toggle) toggle.setAttribute("aria-expanded", "false");
+          disableMenuFocusTrap();
           if (typeof window.gtag === "function") {
             window.gtag("event", "navigation_desktop_utility_close", {
               event_category: "navigation",
@@ -367,6 +493,12 @@
         };
 
         document.addEventListener("click", (event) => {
+          const localeLink = event.target.closest("[data-locale-switch-link]");
+          if (localeLink) {
+            const targetLocale = localeLink.dataset.targetLocale || "";
+            sessionStorage.setItem(localeSwitchSessionKey, JSON.stringify({ target_locale: targetLocale, at: Date.now() }));
+          }
+
           const toggle = event.target.closest("[data-mobile-header-toggle]");
           if (toggle) {
             const menu = document.querySelector("[data-mobile-header-menu]");
@@ -379,6 +511,7 @@
               toggle.setAttribute("aria-expanded", "true");
               menu.classList.remove("hidden");
               window.dsNotify(menuOpenedMessage, "info");
+              enableMenuFocusTrap(menu, toggle);
             }
             return;
           }
@@ -393,6 +526,7 @@
             } else {
               desktopToggle.setAttribute("aria-expanded", "true");
               menu.classList.remove("hidden");
+              enableMenuFocusTrap(menu, desktopToggle);
             }
             return;
           }
@@ -417,15 +551,34 @@
         });
 
         document.addEventListener("keydown", (event) => {
-          if (event.key !== "Escape") return;
-          closeMobileHeaderMenu("escape");
-          closeDesktopUtilityMenu("escape");
+          if (event.key === "Escape") {
+            closeMobileHeaderMenu("escape");
+            closeDesktopUtilityMenu("escape");
+            return;
+          }
+          if (event.key !== "Tab" || !activeMenuRoot || activeMenuRoot.classList.contains("hidden")) return;
+          const candidates = Array.from(activeMenuRoot.querySelectorAll("a[href], button:not([disabled]), [tabindex='0']")).filter((node) => !node.hasAttribute("disabled"));
+          if (candidates.length === 0) return;
+          const first = candidates[0];
+          const last = candidates[candidates.length - 1];
+          const current = document.activeElement;
+          if (event.shiftKey && current === first) {
+            event.preventDefault();
+            last.focus();
+          } else if (!event.shiftKey && current === last) {
+            event.preventDefault();
+            first.focus();
+          }
         });
 
         bindStickyInsetSync();
+        trackLocaleSwitchContinuation();
         document.addEventListener("turbo:load", announceScreenTransition);
+        document.addEventListener("turbo:load", trackLocaleSwitchContinuation);
         document.addEventListener("DOMContentLoaded", announceScreenTransition);
+        document.addEventListener("DOMContentLoaded", trackLocaleSwitchContinuation);
         window.setTimeout(announceScreenTransition, 0);
+        window.setTimeout(trackLocaleSwitchContinuation, 0);
       }
     </script>
 

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -11,7 +11,7 @@
 <% tag_list_error = field_error.call(:tag_list) %>
 <% image_error = field_error.call(:desk_image) %>
 <% profile_error = field_error.call(:user) %>
-<% optional_panel_open = [category_error, theme_error, tag_list_error, post.category, post.theme, post.tag_list].any?(&:present?) %>
+<% optional_panel_open = [ category_error, theme_error, tag_list_error, post.category, post.theme, post.tag_list ].any?(&:present?) %>
 <% items_panel_open = post.items.any? { |item| item.name.present? || item.affiliate_url.present? || item.errors.any? } %>
 
 <%= form_with model: post,
@@ -26,14 +26,16 @@
                 loading_label: t("ui.processing", default: "Processing..."),
                 submitting_reason: t("ui.processing", default: "Processing..."),
                 disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"),
-                disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.")
+                disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting."),
+                leave_guard_message: t("ui.leave_guard_post_form", default: "You have unsaved post changes. Leave this page?"),
+                post_create_flow: true
               } do |f| %>
   <% if post.errors.any? %>
     <div class="space-y-2">
       <%= render "shared/feedback_panel",
                  level: :error,
                  title: t("posts.form.error_summary", default: "Please fix the following errors."),
-                 body: t("ui.error_with_recovery", default: "Please review the fields below, then retry. If the issue continues, go back and try again."),
+                 body: t("ui.error_with_recovery", default: "Cause: one or more fields are invalid. Action: review highlighted fields. Retry: submit again after fixing."),
                  actions: [
                    { label: t("ui.focus_first_error", default: "Go to first error"), href: "#post-form-fields" },
                    { label: t("ui.back", default: "Back"), href: (request.referer.presence || root_path) }
@@ -67,132 +69,215 @@
     </div>
   <% end %>
 
-  <section id="post-form-fields" class="space-y-4 rounded-xl border ds-border-subtle ds-surface-base p-4 sm:p-5">
-    <div>
-      <h2 class="ds-heading-md"><%= t("posts.form.required_section", default: "Required basics") %></h2>
-      <p class="mt-1 ds-text-support"><%= t("posts.form.required_section_lead", default: "Start with the core information for your post.") %></p>
+  <section class="rounded-xl border ds-border-subtle ds-surface-muted p-4" aria-label="<%= t('posts.form.step_progress', default: 'Create post progress') %>">
+    <div class="flex items-center justify-between gap-2">
+      <p class="ds-text-support font-semibold"><%= t("posts.form.step_progress", default: "Create post progress") %></p>
+      <p class="ds-text-meta"><span data-step-progress-text>1 / 3</span></p>
     </div>
+    <div class="mt-2 ds-progress-track" role="progressbar" aria-valuemin="1" aria-valuemax="3" aria-valuenow="1" data-step-progressbar>
+      <div class="ds-progress-fill" style="width: 33.34%" data-step-progress-fill></div>
+    </div>
+    <ol class="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+      <li class="rounded-full border ds-tone-info px-2 py-1" data-step-chip="1"><%= t("posts.form.step_basic", default: "Basic") %></li>
+      <li class="rounded-full border ds-tone-info px-2 py-1" data-step-chip="2"><%= t("posts.form.step_image", default: "Image") %></li>
+      <li class="rounded-full border ds-tone-info px-2 py-1" data-step-chip="3"><%= t("posts.form.step_confirm", default: "Confirm") %></li>
+    </ol>
+  </section>
 
-    <div class="grid gap-4 sm:grid-cols-2">
-      <% if owned_users.any? %>
+  <section id="post-form-fields" class="space-y-4" data-post-step-root>
+    <section class="space-y-4 rounded-xl border ds-border-subtle ds-surface-base p-4 sm:p-5" data-post-step-panel="1">
+      <div>
+        <h2 class="ds-heading-md"><%= t("posts.form.required_section", default: "Required basics") %></h2>
+        <p class="mt-1 ds-text-support"><%= t("posts.form.required_section_lead", default: "Start with the core information for your post.") %></p>
+      </div>
+
+      <div class="grid gap-4 sm:grid-cols-2">
+        <% if owned_users.any? %>
+          <div class="sm:col-span-2">
+            <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+            <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: input_class.call(profile_error), aria: { invalid: profile_error.present? ? "true" : nil, describedby: "post_user_id_help post_user_id_error" } %>
+            <p id="post_user_id_help" class="ds-field-guide"><%= t("posts.form.profile_guide", default: "Choose which profile is shown as the author.") %></p>
+            <% if profile_error.present? %>
+              <p id="post_user_id_error" class="ds-field-error"><%= profile_error %></p>
+            <% end %>
+          </div>
+        <% end %>
+
         <div class="sm:col-span-2">
-          <%= f.label :user_id, t("posts.form.profile_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-          <%= f.collection_select :user_id, owned_users, :id, :name, {}, class: input_class.call(profile_error), aria: { invalid: profile_error.present? ? "true" : nil, describedby: "post_user_id_help post_user_id_error" } %>
-          <p id="post_user_id_help" class="ds-field-guide"><%= t("posts.form.profile_guide", default: "Choose which profile is shown as the author.") %></p>
-          <% if profile_error.present? %>
-            <p id="post_user_id_error" class="ds-field-error"><%= profile_error %></p>
+          <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+          <%= f.text_field :title,
+                           required: true,
+                           maxlength: 120,
+                           class: input_class.call(title_error),
+                           placeholder: t("posts.form.title_placeholder"),
+                           aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_counter post_title_error" },
+                           data: { char_count_max: 120, char_count_target: "post_title_counter" } %>
+          <p id="post_title_help" class="ds-field-guide"><%= t("posts.form.title_guide", default: "Include setup style and one distinctive element. Max 120 characters.") %></p>
+          <p id="post_title_counter" class="ds-char-counter" aria-live="polite"></p>
+          <% if title_error.present? %>
+            <p id="post_title_error" class="ds-field-error"><%= title_error %></p>
           <% end %>
         </div>
-      <% end %>
 
-      <div class="sm:col-span-2">
-        <%= f.label :title, t("posts.form.title_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.text_field :title,
-                         required: true,
-                         maxlength: 120,
-                         class: input_class.call(title_error),
-                         placeholder: t("posts.form.title_placeholder"),
-                         aria: { invalid: title_error.present? ? "true" : nil, describedby: "post_title_help post_title_counter post_title_error" },
-                         data: { char_count_max: 120, char_count_target: "post_title_counter" } %>
-        <p id="post_title_help" class="ds-field-guide"><%= t("posts.form.title_guide", default: "Include setup style and one distinctive element. Max 120 characters.") %></p>
-        <p id="post_title_counter" class="ds-char-counter" aria-live="polite"></p>
-        <% if title_error.present? %>
-          <p id="post_title_error" class="ds-field-error"><%= title_error %></p>
-        <% end %>
+        <div class="sm:col-span-2">
+          <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+          <%= f.text_area :description,
+                          rows: 7,
+                          required: true,
+                          maxlength: 2000,
+                          class: input_class.call(description_error),
+                          placeholder: t("posts.form.description_placeholder"),
+                          aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_counter post_description_error" },
+                          data: { char_count_max: 2000, char_count_target: "post_description_counter" } %>
+          <p id="post_description_help" class="ds-field-guide"><%= t("posts.form.description_guide", default: "Write 3-5 sentences about layout, devices, and workflow. Do not include private information.") %></p>
+          <p id="post_description_counter" class="ds-char-counter" aria-live="polite"></p>
+          <% if description_error.present? %>
+            <p id="post_description_error" class="ds-field-error"><%= description_error %></p>
+          <% end %>
+        </div>
       </div>
 
-      <div class="sm:col-span-2">
-        <%= f.label :description, t("posts.form.description_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.text_area :description,
-                        rows: 7,
-                        required: true,
-                        maxlength: 2000,
-                        class: input_class.call(description_error),
-                        placeholder: t("posts.form.description_placeholder"),
-                        aria: { invalid: description_error.present? ? "true" : nil, describedby: "post_description_help post_description_counter post_description_error" },
-                        data: { char_count_max: 2000, char_count_target: "post_description_counter" } %>
-        <p id="post_description_help" class="ds-field-guide"><%= t("posts.form.description_guide", default: "Write 3-5 sentences about layout, devices, and workflow. Do not include private information.") %></p>
-        <p id="post_description_counter" class="ds-char-counter" aria-live="polite"></p>
-        <% if description_error.present? %>
-          <p id="post_description_error" class="ds-field-error"><%= description_error %></p>
-        <% end %>
+      <div class="flex justify-end">
+        <button type="button" class="tap-target cta-primary" data-post-step-next="1"><%= t("posts.form.next_to_image", default: "Next: image") %></button>
+      </div>
+    </section>
+
+    <section class="hidden space-y-4 rounded-xl border ds-border-subtle ds-surface-base p-4 sm:p-5" data-post-step-panel="2">
+      <div>
+        <h2 class="ds-heading-md"><%= t("posts.form.image_section", default: "Image and details") %></h2>
+        <p class="mt-1 ds-text-support"><%= t("posts.form.image_section_lead", default: "Upload one image and optionally add categorization details.") %></p>
       </div>
 
-      <div class="sm:col-span-2">
+      <div>
         <%= f.label :desk_image, t("posts.form.image_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.file_field :desk_image, required: post.published?, class: input_class.call(image_error), accept: "image/*", aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error" } %>
-        <p id="post_image_help" class="ds-field-guide"><%= t("posts.form.image_guide", default: "Use a bright landscape image (1200px+ recommended).") %></p>
+        <%= f.file_field :desk_image,
+                         required: post.published?,
+                         class: input_class.call(image_error),
+                         accept: "image/jpeg,image/png,image/webp,image/gif",
+                         aria: { invalid: image_error.present? ? "true" : nil, describedby: "post_image_help post_image_error post_image_upload_feedback" },
+                         data: { image_upload_input: true, has_existing_image: post.desk_image.attached? } %>
+        <p id="post_image_help" class="ds-field-guide"><%= t("posts.form.image_guide", default: "Use JPEG/PNG/WEBP/GIF up to 8MB. 1200px+ recommended.") %></p>
+        <p id="post_image_upload_feedback" class="ds-field-error hidden" data-image-upload-feedback></p>
         <% if image_error.present? %>
           <p id="post_image_error" class="ds-field-error"><%= image_error %></p>
         <% end %>
-      </div>
-    </div>
-  </section>
-
-  <details class="rounded-xl border ds-border-subtle ds-surface-muted p-4 sm:p-5" <%= "open" if optional_panel_open %>>
-    <summary class="cursor-pointer list-none">
-      <div>
-        <h2 class="ds-heading-md"><%= t("posts.form.optional_section", default: "Optional details") %></h2>
-        <p class="mt-1 ds-text-support"><%= t("posts.form.optional_section_lead", default: "Add category, theme, and tags to improve discoverability.") %></p>
-      </div>
-    </summary>
-
-    <div class="mt-4 grid gap-4 sm:grid-cols-2">
-      <div>
-        <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.text_field :category, class: input_class.call(category_error), placeholder: t("posts.form.category_placeholder"), list: "post-category-options", aria: { invalid: category_error.present? ? "true" : nil, describedby: "post_category_help post_category_error" } %>
-        <p id="post_category_help" class="ds-field-guide"><%= t("posts.form.category_guide", default: "Examples: Engineering, Design, Writing.") %></p>
-        <% if category_error.present? %>
-          <p id="post_category_error" class="ds-field-error"><%= category_error %></p>
-        <% end %>
+        <div class="mt-2">
+          <button type="button" class="tap-target cta-tertiary cta-compact" data-image-upload-retry><%= t("images.retry", default: "Retry") %></button>
+        </div>
       </div>
 
-      <div>
-        <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.text_field :theme, class: input_class.call(theme_error), placeholder: t("posts.form.theme_placeholder"), aria: { invalid: theme_error.present? ? "true" : nil, describedby: "post_theme_help post_theme_error" } %>
-        <p id="post_theme_help" class="ds-field-guide"><%= t("posts.form.theme_guide", default: "Examples: Dark, Minimal, Natural.") %></p>
-        <% if theme_error.present? %>
-          <p id="post_theme_error" class="ds-field-error"><%= theme_error %></p>
-        <% end %>
-      </div>
-
-      <div class="sm:col-span-2">
-        <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
-        <%= f.text_field :tag_list,
-                         maxlength: 220,
-                         class: input_class.call(tag_list_error),
-                         placeholder: t("posts.form.tags_placeholder"),
-                         list: "post-tag-options",
-                         aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_counter post_tag_list_error" },
-                         data: { char_count_max: 220, char_count_target: "post_tag_list_counter" } %>
-        <p id="post_tag_list_help" class="ds-field-guide"><%= t("posts.form.tags_guide", default: "Use up to 8 tags separated by commas. Avoid duplicates.") %></p>
-        <p id="post_tag_list_counter" class="ds-char-counter" aria-live="polite"></p>
-        <% if tag_list_error.present? %>
-          <p id="post_tag_list_error" class="ds-field-error"><%= tag_list_error %></p>
-        <% end %>
-      </div>
-    </div>
-  </details>
-
-  <details class="rounded-xl border ds-border-subtle ds-surface-muted p-4" <%= "open" if items_panel_open %>>
-    <summary class="cursor-pointer list-none text-sm font-semibold ds-text-strong"><%= t("posts.form.related_items") %></summary>
-    <div class="mt-3 space-y-4">
-      <%= f.fields_for :items do |item_fields| %>
-        <div class="grid gap-3 rounded-lg border ds-border-subtle ds-surface-base p-3 sm:grid-cols-2">
+      <details class="rounded-xl border ds-border-subtle ds-surface-muted p-4 sm:p-5" <%= "open" if optional_panel_open %>>
+        <summary class="cursor-pointer list-none">
           <div>
-            <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium ds-text-strong" %>
-            <%= item_fields.text_field :name, class: "ds-form-control", placeholder: t("posts.form.item_name_placeholder") %>
-            <p class="ds-field-guide"><%= t("posts.form.item_name_guide", default: "Example: HHKB Professional HYBRID Type-S") %></p>
+            <h2 class="ds-heading-md"><%= t("posts.form.optional_section", default: "Optional details") %></h2>
+            <p class="mt-1 ds-text-support"><%= t("posts.form.optional_section_lead", default: "Add category, theme, and tags to improve discoverability.") %></p>
           </div>
+        </summary>
+
+        <div class="mt-4 grid gap-4 sm:grid-cols-2">
           <div>
-            <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium ds-text-strong" %>
-            <%= item_fields.url_field :affiliate_url, class: "ds-form-control", placeholder: t("posts.form.affiliate_url_placeholder") %>
-            <p class="ds-field-guide"><%= t("posts.form.affiliate_url_guide", default: "Use official product page or trusted store URL.") %></p>
+            <%= f.label :category, t("posts.form.category_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+            <%= f.text_field :category, class: input_class.call(category_error), placeholder: t("posts.form.category_placeholder"), list: "post-category-options", aria: { invalid: category_error.present? ? "true" : nil, describedby: "post_category_help post_category_error" } %>
+            <p id="post_category_help" class="ds-field-guide"><%= t("posts.form.category_guide", default: "Examples: Engineering, Design, Writing.") %></p>
+            <% if category_error.present? %>
+              <p id="post_category_error" class="ds-field-error"><%= category_error %></p>
+            <% end %>
+          </div>
+
+          <div>
+            <%= f.label :theme, t("posts.form.theme_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+            <%= f.text_field :theme, class: input_class.call(theme_error), placeholder: t("posts.form.theme_placeholder"), aria: { invalid: theme_error.present? ? "true" : nil, describedby: "post_theme_help post_theme_error" } %>
+            <p id="post_theme_help" class="ds-field-guide"><%= t("posts.form.theme_guide", default: "Examples: Dark, Minimal, Natural.") %></p>
+            <% if theme_error.present? %>
+              <p id="post_theme_error" class="ds-field-error"><%= theme_error %></p>
+            <% end %>
+          </div>
+
+          <div class="sm:col-span-2">
+            <%= f.label :tag_list, t("posts.form.tags_label"), class: "mb-1 block text-sm font-medium ds-text-strong" %>
+            <%= f.text_field :tag_list,
+                             maxlength: 220,
+                             class: input_class.call(tag_list_error),
+                             placeholder: t("posts.form.tags_placeholder"),
+                             list: "post-tag-options",
+                             aria: { invalid: tag_list_error.present? ? "true" : nil, describedby: "post_tag_list_help post_tag_list_counter post_tag_list_error" },
+                             data: { char_count_max: 220, char_count_target: "post_tag_list_counter" } %>
+            <p id="post_tag_list_help" class="ds-field-guide"><%= t("posts.form.tags_guide", default: "Use up to 8 tags separated by commas. Avoid duplicates.") %></p>
+            <p id="post_tag_list_counter" class="ds-char-counter" aria-live="polite"></p>
+            <% if tag_list_error.present? %>
+              <p id="post_tag_list_error" class="ds-field-error"><%= tag_list_error %></p>
+            <% end %>
           </div>
         </div>
-      <% end %>
-    </div>
-  </details>
+      </details>
+
+      <details class="rounded-xl border ds-border-subtle ds-surface-muted p-4" <%= "open" if items_panel_open %>>
+        <summary class="cursor-pointer list-none text-sm font-semibold ds-text-strong"><%= t("posts.form.related_items") %></summary>
+        <div class="mt-3 space-y-4">
+          <%= f.fields_for :items do |item_fields| %>
+            <div class="grid gap-3 rounded-lg border ds-border-subtle ds-surface-base p-3 sm:grid-cols-2">
+              <div>
+                <%= item_fields.label :name, t("posts.form.item_name_label"), class: "mb-1 block text-xs font-medium ds-text-strong" %>
+                <%= item_fields.text_field :name, class: "ds-form-control", placeholder: t("posts.form.item_name_placeholder") %>
+                <p class="ds-field-guide"><%= t("posts.form.item_name_guide", default: "Example: HHKB Professional HYBRID Type-S") %></p>
+              </div>
+              <div>
+                <%= item_fields.label :affiliate_url, t("posts.form.affiliate_url_label"), class: "mb-1 block text-xs font-medium ds-text-strong" %>
+                <%= item_fields.url_field :affiliate_url, class: "ds-form-control", placeholder: t("posts.form.affiliate_url_placeholder") %>
+                <p class="ds-field-guide"><%= t("posts.form.affiliate_url_guide", default: "Use official product page or trusted store URL.") %></p>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </details>
+
+      <div class="flex flex-wrap justify-between gap-2">
+        <button type="button" class="tap-target cta-secondary" data-post-step-prev="2"><%= t("ui.back", default: "Back") %></button>
+        <button type="button" class="tap-target cta-primary" data-post-step-next="2"><%= t("posts.form.next_to_confirm", default: "Next: confirm") %></button>
+      </div>
+    </section>
+
+    <section class="hidden space-y-4 rounded-xl border ds-border-subtle ds-surface-base p-4 sm:p-5" data-post-step-panel="3">
+      <div>
+        <h2 class="ds-heading-md"><%= t("posts.form.confirm_section", default: "Confirm and publish") %></h2>
+        <p class="mt-1 ds-text-support"><%= t("posts.form.confirm_section_lead", default: "Review your input before publishing. You can still go back and edit.") %></p>
+      </div>
+
+      <dl class="grid gap-3 sm:grid-cols-2" data-post-review>
+        <div class="rounded-lg border ds-border-subtle ds-surface-muted p-3 sm:col-span-2">
+          <dt class="ds-text-meta font-semibold ds-text-weak"><%= t("posts.form.title_label") %></dt>
+          <dd class="mt-1 text-sm ds-text-support ds-break-words" data-review-title>-</dd>
+        </div>
+        <div class="rounded-lg border ds-border-subtle ds-surface-muted p-3 sm:col-span-2">
+          <dt class="ds-text-meta font-semibold ds-text-weak"><%= t("posts.form.description_label") %></dt>
+          <dd class="mt-1 text-sm ds-text-support ds-break-words" data-review-description>-</dd>
+        </div>
+        <div class="rounded-lg border ds-border-subtle ds-surface-muted p-3">
+          <dt class="ds-text-meta font-semibold ds-text-weak"><%= t("posts.form.category_label") %></dt>
+          <dd class="mt-1 text-sm ds-text-support ds-break-words" data-review-category>-</dd>
+        </div>
+        <div class="rounded-lg border ds-border-subtle ds-surface-muted p-3">
+          <dt class="ds-text-meta font-semibold ds-text-weak"><%= t("posts.form.theme_label") %></dt>
+          <dd class="mt-1 text-sm ds-text-support ds-break-words" data-review-theme>-</dd>
+        </div>
+      </dl>
+
+      <div class="flex flex-wrap gap-3">
+        <button type="button" class="tap-target cta-secondary" data-post-step-prev="3"><%= t("ui.back", default: "Back") %></button>
+
+        <%= f.button type: :submit, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "control", ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "publish_primary", confirm_action: true, confirm_title: t("posts.form.confirm_submit_title", default: "Publish this post?"), confirm_message: t("ui.critical_submit_message", default: "Cause: this will publish your post publicly. Action: review your content. Retry: cancel and edit if needed."), confirm_label: submit_label, confirm_level: "warning" } do %>
+          <span class="inline-flex items-center gap-1.5">
+            <%= ui_icon(:check_circle, class_name: "h-4 w-4") %>
+            <span data-submit-label><%= submit_label %></span>
+          </span>
+        <% end %>
+
+        <%= f.button type: :submit, name: "save_as_draft", value: "1", class: "tap-target cta-secondary", data: { ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "save_draft_secondary" } do %>
+          <span data-submit-label><%= t("posts.form.save_draft") %></span>
+        <% end %>
+      </div>
+    </section>
+  </section>
 
   <% if category_suggestions.any? %>
     <datalist id="post-category-options">
@@ -210,19 +295,6 @@
     </datalist>
   <% end %>
 
-  <div class="flex flex-wrap gap-3">
-    <%= f.button type: :submit, class: "tap-target cta-primary ds-cta-experiment", data: { variant: "control", ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "publish_primary" } do %>
-      <span class="inline-flex items-center gap-1.5">
-        <%= ui_icon(:check_circle, class_name: "h-4 w-4") %>
-        <span data-submit-label><%= submit_label %></span>
-      </span>
-    <% end %>
-
-    <%= f.button type: :submit, name: "save_as_draft", value: "1", class: "tap-target cta-secondary", data: { ga_event: "post_form_submit_click", ga_category: "post_form", ga_label: "save_draft_secondary" } do %>
-      <span data-submit-label><%= t("posts.form.save_draft") %></span>
-    <% end %>
-  </div>
-
   <p class="ds-text-muted">
     <%= t("posts.form.draft_restore_hint", default: "Draft is saved locally while you type. If you return later, it is restored automatically.") %>
   </p>
@@ -238,21 +310,252 @@
 <% end %>
 
 <script>
-  if (!window.__postFormErrorAutofocusInstalled) {
-    window.__postFormErrorAutofocusInstalled = true;
+  if (!window.__postFormFlowInstalled) {
+    window.__postFormFlowInstalled = true;
 
-    const focusFirstErrorField = () => {
-      const form = document.querySelector("[data-form-autofocus-errors]");
+    const withPostForm = (callback) => {
+      const form = document.querySelector("form[data-post-create-flow]");
       if (!form) return;
-      const firstInvalid = form.querySelector("[aria-invalid='true']");
-      if (!firstInvalid) return;
-      firstInvalid.focus();
-      if (typeof firstInvalid.scrollIntoView === "function") {
-        firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
-      }
+      callback(form);
     };
 
-    document.addEventListener("turbo:load", focusFirstErrorField);
-    document.addEventListener("DOMContentLoaded", focusFirstErrorField);
+    const focusFirstErrorField = () => {
+      withPostForm((form) => {
+        const firstInvalid = form.querySelector("[aria-invalid='true']");
+        if (!firstInvalid) return;
+        firstInvalid.focus();
+        if (typeof firstInvalid.scrollIntoView === "function") {
+          firstInvalid.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      });
+    };
+
+    const installFlow = () => {
+      withPostForm((form) => {
+        if (form.dataset.postFlowBound === "1") return;
+        form.dataset.postFlowBound = "1";
+
+        const maxUploadBytes = 8 * 1024 * 1024;
+        const allowedTypes = [ "image/jpeg", "image/png", "image/webp", "image/gif" ];
+        const steps = [ 1, 2, 3 ];
+        let currentStep = 1;
+
+        const progressText = form.querySelector("[data-step-progress-text]");
+        const progressBar = form.querySelector("[data-step-progressbar]");
+        const progressFill = form.querySelector("[data-step-progress-fill]");
+
+        const updateReview = () => {
+          const title = form.querySelector("#post_title")?.value?.trim() || "-";
+          const description = form.querySelector("#post_description")?.value?.trim() || "-";
+          const category = form.querySelector("#post_category")?.value?.trim() || "-";
+          const theme = form.querySelector("#post_theme")?.value?.trim() || "-";
+          const write = (selector, value) => {
+            const node = form.querySelector(selector);
+            if (node) node.textContent = value;
+          };
+          write("[data-review-title]", title);
+          write("[data-review-description]", description.length > 200 ? `${description.slice(0, 200)}...` : description);
+          write("[data-review-category]", category);
+          write("[data-review-theme]", theme);
+        };
+
+        const publishStepViewed = (step) => {
+          if (typeof window.gtag !== "function") return;
+          const labels = { 1: "start", 2: "image", 3: "confirm" };
+          window.gtag("event", "post_create_step_view", {
+            event_category: "post_form",
+            event_label: labels[step] || `step_${step}`,
+            step_number: step
+          });
+        };
+
+        const showStep = (step, opts = {}) => {
+          currentStep = step;
+          form.dataset.postCurrentStep = String(step);
+          form.querySelectorAll("[data-post-step-panel]").forEach((panel) => {
+            panel.classList.toggle("hidden", Number(panel.dataset.postStepPanel) !== step);
+          });
+          form.querySelectorAll("[data-step-chip]").forEach((chip) => {
+            const chipStep = Number(chip.dataset.stepChip);
+            chip.classList.toggle("ds-tone-info", chipStep === step);
+            chip.classList.toggle("ds-tone-success", chipStep < step);
+          });
+
+          const percent = (step / steps.length) * 100;
+          if (progressText) progressText.textContent = `${step} / ${steps.length}`;
+          if (progressFill) progressFill.style.width = `${percent}%`;
+          if (progressBar) progressBar.setAttribute("aria-valuenow", String(step));
+          updateReview();
+
+          if (!opts.silent) {
+            publishStepViewed(step);
+          }
+        };
+
+        const stepHasBlockingFields = (step) => {
+          if (step === 1) {
+            const required = [ "#post_title", "#post_description" ];
+            if (form.querySelector("#post_user_id")) required.push("#post_user_id");
+            return required.some((selector) => !(form.querySelector(selector)?.value || "").trim());
+          }
+
+          if (step === 2) {
+            const input = form.querySelector("[data-image-upload-input]");
+            if (!input || !input.required) return false;
+            const hasExisting = input.dataset.hasExistingImage === "true";
+            const hasSelectedFile = input.files && input.files.length > 0;
+            return !(hasExisting || hasSelectedFile);
+          }
+
+          return false;
+        };
+
+        const setUploadFeedback = (message = "") => {
+          const feedback = form.querySelector("[data-image-upload-feedback]");
+          const input = form.querySelector("[data-image-upload-input]");
+          if (!feedback || !input) return;
+
+          if (!message) {
+            feedback.textContent = "";
+            feedback.classList.add("hidden");
+            input.setCustomValidity("");
+            return;
+          }
+
+          feedback.textContent = message;
+          feedback.classList.remove("hidden");
+          input.setCustomValidity(message);
+          input.setAttribute("aria-invalid", "true");
+        };
+
+        const validateUpload = () => {
+          const input = form.querySelector("[data-image-upload-input]");
+          if (!input || !input.files || input.files.length === 0) {
+            setUploadFeedback("");
+            return true;
+          }
+
+          const file = input.files[0];
+          if (!allowedTypes.includes(file.type)) {
+            const message = "Cause: unsupported image format. Action: use JPEG/PNG/WEBP/GIF. Retry: choose another file.";
+            setUploadFeedback(message);
+            if (typeof window.gtag === "function") {
+              window.gtag("event", "image_upload_failure", {
+                event_category: "post_form",
+                event_label: "unsupported_format"
+              });
+            }
+            return false;
+          }
+
+          if (Number(file.size || 0) > maxUploadBytes) {
+            const message = "Cause: file exceeds 8MB. Action: compress the image. Retry: upload a smaller file.";
+            setUploadFeedback(message);
+            if (typeof window.gtag === "function") {
+              window.gtag("event", "image_upload_failure", {
+                event_category: "post_form",
+                event_label: "file_too_large",
+                file_size: Number(file.size || 0)
+              });
+            }
+            return false;
+          }
+
+          setUploadFeedback("");
+          if (typeof window.gtag === "function") {
+            window.gtag("event", "image_upload_selected", {
+              event_category: "post_form",
+              event_label: "valid_file",
+              file_size: Number(file.size || 0)
+            });
+          }
+          return true;
+        };
+
+        form.querySelectorAll("[data-post-step-next]").forEach((button) => {
+          button.addEventListener("click", () => {
+            const from = Number(button.dataset.postStepNext);
+            if (stepHasBlockingFields(from)) {
+              if (typeof window.dsNotify === "function") {
+                window.dsNotify("Complete required fields before proceeding.", "warning");
+              }
+              return;
+            }
+
+            if (from === 2 && !validateUpload()) {
+              return;
+            }
+
+            const target = Math.min(from + 1, steps.length);
+            showStep(target);
+            if (typeof window.gtag === "function") {
+              window.gtag("event", "post_create_step_transition", {
+                event_category: "post_form",
+                event_label: `${from}_to_${target}`
+              });
+            }
+          });
+        });
+
+        form.querySelectorAll("[data-post-step-prev]").forEach((button) => {
+          button.addEventListener("click", () => {
+            const from = Number(button.dataset.postStepPrev);
+            const target = Math.max(1, from - 1);
+            showStep(target);
+          });
+        });
+
+        const uploadInput = form.querySelector("[data-image-upload-input]");
+        if (uploadInput) {
+          uploadInput.addEventListener("change", validateUpload);
+        }
+
+        const retryButton = form.querySelector("[data-image-upload-retry]");
+        if (retryButton && uploadInput) {
+          retryButton.addEventListener("click", () => {
+            uploadInput.value = "";
+            setUploadFeedback("");
+            uploadInput.focus();
+            if (typeof window.gtag === "function") {
+              window.gtag("event", "image_upload_retry", {
+                event_category: "post_form",
+                event_label: "retry_button"
+              });
+            }
+          });
+        }
+
+        form.addEventListener("input", updateReview);
+        form.addEventListener("change", updateReview);
+
+        form.addEventListener("submit", () => {
+          if (typeof window.gtag !== "function") return;
+          window.gtag("event", "post_create_step_complete", {
+            event_category: "post_form",
+            event_label: form.dataset.postCurrentStep || "unknown"
+          });
+        });
+
+        window.addEventListener("beforeunload", () => {
+          if (form.dataset.uiFormDirty !== "true" || form.dataset.uiSubmitting === "true") return;
+          if (typeof window.gtag !== "function") return;
+          window.gtag("event", "post_create_step_dropout", {
+            event_category: "post_form",
+            event_label: form.dataset.postCurrentStep || "unknown"
+          });
+        });
+
+        const hasImageErrors = Boolean(form.querySelector("#post_image_error"));
+        const hasOptionalErrors = Boolean(form.querySelector("#post_category_error, #post_theme_error, #post_tag_list_error"));
+        const initialStep = hasImageErrors || hasOptionalErrors ? 2 : 1;
+        showStep(initialStep, { silent: true });
+        publishStepViewed(initialStep);
+        updateReview();
+      });
+    };
+
+    document.addEventListener("turbo:load", () => { focusFirstErrorField(); installFlow(); });
+    document.addEventListener("DOMContentLoaded", () => { focusFirstErrorField(); installFlow(); });
+    window.setTimeout(() => { focusFirstErrorField(); installFlow(); }, 0);
   }
 </script>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -59,6 +59,15 @@
     </div>
   </div>
 
+  <section class="ds-card hidden p-4 sm:p-5" data-first-visit-panel>
+    <h2 class="ds-heading-sm ds-text-strong"><%= t("posts.index.first_visit_heading", default: "First time here? Start with these steps") %></h2>
+    <p class="mt-1 ds-text-support"><%= t("posts.index.first_visit_lead", default: "Search one keyword, open a post, then create your own setup when ready.") %></p>
+    <div class="mt-3 flex flex-wrap items-center gap-2">
+      <%= link_to t("navigation.onboarding", default: "Getting started"), onboarding_path, class: "tap-target cta-secondary", data: { ga_event: "onboarding_open_click", ga_category: "onboarding", ga_label: "index_first_visit" } %>
+      <a href="#index-search" class="tap-target cta-primary"><%= t("posts.index.search_button") %></a>
+    </div>
+  </section>
+
   <section class="ds-card p-4 sm:p-5" data-revisit-root>
     <div class="flex flex-wrap items-center justify-between gap-2">
       <h2 class="ds-heading-sm ds-text-strong"><%= t("posts.index.revisit_heading", default: "Continue from your last visit") %></h2>
@@ -178,7 +187,7 @@
         <% visible_tags = ranked_tags.first(max_card_tags) %>
         <% hidden_tag_count = [ranked_tags.size - visible_tags.size, 0].max %>
         <% card_url = post_path(post, from: return_path) %>
-        <article class="ds-card ds-shadow-soft ds-card-interactive flex h-full flex-col overflow-hidden" data-card-href="<%= card_url %>" data-post-id="<%= post.id %>" data-post-title="<%= post.title %>" data-post-url="<%= card_url %>">
+        <article class="ds-card ds-shadow-soft ds-card-interactive flex h-full flex-col overflow-hidden" data-card-href="<%= card_url %>" data-card-context="search_result" data-post-id="<%= post.id %>" data-post-title="<%= post.title %>" data-post-url="<%= card_url %>">
           <%= link_to card_url, class: "block", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: filtered_results ? "from_filtered_results" : "from_default_results", card_stop: true } do %>
             <div class="ds-media-frame ds-media-frame-card ds-media-skeleton" data-media-skeleton data-image-shell>
               <%= optimized_post_image_tag(post, variant: :thumbnail, class: "h-full w-full object-cover", data: { fallback_src: asset_path(ApplicationHelper::FALLBACK_POST_IMAGE) }) %>
@@ -191,7 +200,7 @@
 
           <div class="flex h-full flex-col p-4">
             <h2 class="ds-heading-sm ds-line-clamp-2 ds-break-words ds-text-strong">
-              <%= link_to post.title, card_url, class: "block leading-6 ds-hover-link", data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click", card_stop: true } %>
+              <%= link_to post.title, card_url, class: "block leading-6 ds-hover-link", aria: { label: t("posts.index.open_post_with_title", default: "Open post: %{title}", title: post.title) }, data: { post_card_link: true, post_id: post.id, ga_event: "post_card_open", ga_category: "post_index", ga_label: "title_click", card_stop: true } %>
             </h2>
 
             <div class="mt-2 flex flex-wrap items-center gap-1.5" aria-label="Post classification">
@@ -223,7 +232,7 @@
 
             <div class="mt-auto border-t ds-border-muted pt-3">
               <div class="flex flex-wrap items-center justify-between gap-2">
-                <%= link_to t("posts.index.open_post", default: "Open post"), card_url, class: "tap-target cta-secondary cta-compact", data: { post_card_link: true, post_id: post.id, ga_event: "post_list_primary_cta_click", ga_category: "post_index", ga_label: filtered_results ? "filtered_card_primary" : "default_card_primary", card_stop: true } %>
+                <%= link_to t("posts.index.open_post", default: "Open post"), card_url, class: "tap-target cta-secondary cta-compact", aria: { label: t("posts.index.open_post_with_title", default: "Open post: %{title}", title: post.title) }, data: { post_card_link: true, post_id: post.id, ga_event: "post_list_primary_cta_click", ga_category: "post_index", ga_label: filtered_results ? "filtered_card_primary" : "default_card_primary", card_stop: true } %>
                 <button type="button" class="tap-target cta-tertiary cta-compact" data-card-stop data-favorite-toggle data-post-id="<%= post.id %>" data-post-title="<%= post.title %>" data-post-url="<%= card_url %>" aria-pressed="false" data-ga-event="post_list_secondary_cta_click" data-ga-category="post_index" data-ga-label="card_save_toggle">
                   <span data-favorite-label><%= t("posts.index.save_post", default: "Save") %></span>
                 </button>
@@ -300,6 +309,9 @@
     const ZERO_RESULT_STATE_KEY = "post_index_zero_result_state";
     const RECENTLY_VIEWED_KEY = "post_recently_viewed";
     const FAVORITES_KEY = "post_favorites";
+    const VISIT_MODE_KEY = "post_index_visit_count";
+    let lastCardTargetTap = { target: "", at: 0 };
+    let visitModeApplied = false;
     const searchContext = {
       hasSearchInput: <%= filtered_results ? "true" : "false" %>,
       resultCount: <%= @posts.size %>,
@@ -358,6 +370,29 @@
         favorites,
         "<%= j(t('posts.index.saved_posts_empty', default: 'No saved posts yet.')) %>"
       );
+    };
+
+    const applyVisitMode = () => {
+      if (visitModeApplied) return;
+      visitModeApplied = true;
+      const firstVisitPanel = document.querySelector("[data-first-visit-panel]");
+      const revisitPanel = document.querySelector("[data-revisit-root]");
+      if (!firstVisitPanel || !revisitPanel) return;
+
+      const visitCount = Number(localStorage.getItem(VISIT_MODE_KEY) || "0") + 1;
+      localStorage.setItem(VISIT_MODE_KEY, String(visitCount));
+      const firstVisit = visitCount <= 1;
+
+      firstVisitPanel.classList.toggle("hidden", !firstVisit);
+      revisitPanel.classList.toggle("hidden", firstVisit);
+
+      if (typeof window.gtag === "function") {
+        window.gtag("event", "home_visit_mode", {
+          event_category: "post_index",
+          event_label: firstVisit ? "first_visit" : "return_visit",
+          visit_count: visitCount
+        });
+      }
     };
 
     const setFavoriteButtonState = (button) => {
@@ -483,6 +518,29 @@
           writeJson(RECENTLY_VIEWED_KEY, next);
         }
       }
+    });
+
+    document.addEventListener("click", (event) => {
+      const card = event.target.closest("[data-card-context='search_result']");
+      if (!card || typeof window.gtag !== "function") return;
+      if (event.target.closest("[data-post-card-link], [data-favorite-toggle], a, button, input, select, textarea")) return;
+
+      const cardRect = card.getBoundingClientRect();
+      const relativeY = Math.max(0, Math.min(1, (event.clientY - cardRect.top) / Math.max(cardRect.height, 1)));
+      const roughArea = relativeY > 0.73 ? "actions_zone" : "content_zone";
+      const now = Date.now();
+      const elapsed = now - Number(lastCardTargetTap.at || 0);
+      const previous = String(lastCardTargetTap.target || "");
+      const current = roughArea;
+
+      if (previous && previous !== current && elapsed > 0 && elapsed <= 600) {
+        window.gtag("event", "search_card_mistap_estimate", {
+          event_category: "post_search",
+          event_label: `${previous}_to_${current}`,
+          elapsed_ms: elapsed
+        });
+      }
+      lastCardTargetTap = { target: current, at: now };
     });
 
     document.addEventListener("click", (event) => {
@@ -720,6 +778,7 @@
       restoreFiltersFromStorage();
       syncFavoriteButtons();
       reportSearchState();
+      applyVisitMode();
     });
     document.addEventListener("DOMContentLoaded", () => {
       markLoadedMedia();
@@ -728,6 +787,7 @@
       restoreFiltersFromStorage();
       syncFavoriteButtons();
       reportSearchState();
+      applyVisitMode();
     });
 
     window.setTimeout(() => {
@@ -736,6 +796,7 @@
       restoreListPosition();
       restoreFiltersFromStorage();
       syncFavoriteButtons();
+      applyVisitMode();
     }, 0);
   }
 </script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -185,6 +185,45 @@
     <% end %>
   </section>
 
+  <% if @related_posts.any? %>
+    <% related_reason_label = case @related_posts_reason
+    when "tag_overlap"
+      t("posts.show.related_reason_tags", default: "Recommended because of shared tags.")
+    when "category_theme"
+      t("posts.show.related_reason_category_theme", default: "Recommended because category/theme is similar.")
+    else
+      t("posts.show.related_reason_popular", default: "Recommended from popular recent posts.")
+    end %>
+    <section class="ds-section-card space-y-4">
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <h2 class="ds-heading-md ds-text-strong"><%= t("posts.show.related_posts", default: "Related posts") %></h2>
+        <p class="ds-text-muted"><%= related_reason_label %></p>
+      </div>
+      <div class="grid gap-3 sm:grid-cols-2">
+        <% @related_posts.each do |entry| %>
+          <% related_post = entry[:candidate] %>
+          <% matched_tags = Array(entry[:overlap]) %>
+          <% related_url = post_path(related_post, from: request.fullpath) %>
+          <article class="rounded-lg border ds-border-subtle ds-surface-muted p-3">
+            <h3 class="ds-heading-sm ds-line-clamp-2 ds-break-words">
+              <%= link_to related_post.title, related_url, class: "ds-link-underlined ds-hover-link", data: { ga_event: "related_post_click", ga_category: "post_detail", ga_label: @related_posts_reason } %>
+            </h3>
+            <p class="mt-1 ds-line-clamp-2 ds-text-support"><%= truncate(related_post.description, length: 85) %></p>
+            <div class="mt-2 flex flex-wrap items-center gap-1.5">
+              <% matched_tags.each do |tag| %>
+                <span class="ds-badge-info">#<%= tag %></span>
+              <% end %>
+              <% if matched_tags.empty? && related_post.category.present? %>
+                <span class="ds-badge-inactive"><%= related_post.category %></span>
+              <% end %>
+            </div>
+            <p class="mt-2 ds-text-meta"><%= timestamp_tag(related_post.created_at, style: :date) %></p>
+          </article>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+
   <% if post_owner?(@post) %>
     <section class="ds-card space-y-4 p-4">
       <h2 class="ds-heading-sm ds-text-strong"><%= t("posts.show.owner_actions", default: "Owner actions") %></h2>
@@ -195,7 +234,7 @@
       <div class="border-t ds-border-muted pt-3">
         <p class="ds-text-meta ds-text-danger font-semibold"><%= t("posts.show.danger_zone", default: "Danger zone") %></p>
         <p class="mt-1 ds-text-muted ds-text-danger"><%= t("posts.show.danger_zone_lead", default: "Post deletion cannot be undone.") %></p>
-        <%= button_to post_path(@post), method: :delete, form: { class: "mt-2 inline-block" }, data: { turbo_confirm: t("posts.show.actions.delete_confirm") }, class: "tap-target cta-danger" do %><%= ui_icon(:trash, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.delete") %></span><% end %>
+        <%= button_to post_path(@post), method: :delete, form: { class: "mt-2 inline-block" }, data: { confirm_action: true, confirm_title: t("posts.show.actions.delete_confirm", default: "Delete this post?"), confirm_message: t("ui.critical_delete_message", default: "Cause: this permanently removes the post. Action: review once. Retry: you can cancel now."), confirm_label: t("posts.show.actions.delete", default: "Delete"), confirm_level: "danger" }, class: "tap-target cta-danger" do %><%= ui_icon(:trash, class_name: "h-4 w-4") %><span><%= t("posts.show.actions.delete") %></span><% end %>
       </div>
     </section>
   <% end %>
@@ -203,7 +242,7 @@
   <% unless post_owner?(@post) %>
     <dialog id="report-modal-<%= @post.id %>" data-report-modal class="ds-dialog-surface w-full max-w-md rounded-xl border ds-border-subtle p-0 shadow-lg">
       <div class="border-b ds-border-subtle px-4 py-3"><h2 class="text-base font-semibold ds-text-strong"><%= t("posts.show.report.title") %></h2><p class="mt-1 text-xs ds-text-weak"><%= t("posts.show.report.description") %></p></div>
-      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4", data: { ui_form: true, form_analytics_context: "report_form", loading_label: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting.") } do |f| %>
+      <%= form_with model: [@post, @report], class: "space-y-form px-4 py-4", data: { ui_form: true, form_analytics_context: "report_form", loading_label: t("ui.processing", default: "Processing..."), disabled_reason_prefix: t("ui.disabled_reason", default: "Complete required fields"), disabled_submit_notice: t("ui.complete_required", default: "Please complete required fields before submitting."), leave_guard_message: t("ui.leave_guard_report", default: "You have unsent report input. Leave without submitting?"), critical_form: true, critical_title: t("posts.show.report.title", default: "Report this post"), critical_message: t("ui.critical_report_message", default: "Cause: this sends a moderation report. Action: check reason and details. Retry: cancel if needed."), critical_confirm: t("posts.show.report.submit", default: "Submit report"), critical_level: "warning" } do |f| %>
         <% if owned_users.any? %><div><%= f.label :reporter_user_id, t("posts.show.report.report_as_profile"), class: "mb-1 block text-sm font-medium" %><%= f.collection_select :reporter_user_id, owned_users, :id, :name, { include_blank: t("posts.show.report.anonymous") }, class: "ds-form-control", data: { modal_initial_focus: true } %></div><% end %>
         <div><%= f.label :reason, t("posts.show.report.reason"), class: "mb-1 block text-sm font-medium" %><%= f.select :reason, options_for_select(Report.reason_options), {}, class: "ds-form-control", data: { modal_initial_focus: owned_users.any? ? nil : true } %><p class="ds-field-guide"><%= t("reports.reason_guide", default: "Select the closest reason so moderators can triage faster.") %></p></div>
         <div><%= f.label :details, t("posts.show.report.details"), class: "mb-1 block text-sm font-medium" %><%= f.text_area :details, rows: 4, maxlength: 1000, class: "ds-form-control", placeholder: t("posts.show.report.details_placeholder"), data: { char_count_max: 1000, char_count_target: "report_details_counter" }, aria: { describedby: "report_details_guide report_details_counter" } %><p id="report_details_guide" class="ds-field-guide"><%= t("reports.details_guide", default: "Optional: include concise evidence. Avoid personal information.") %></p><p id="report_details_counter" class="ds-char-counter" aria-live="polite"></p></div>


### PR DESCRIPTION
## Issue
https://github.com/hamasaki-code/DeskTour-Studio/issues/76

 ## 目的

  - Remaining UX/UI Opportunities のうち、継続利用率に直結する P0 中心の実装を先行反映し、操作の一貫性・失敗時の安心感・離脱抑制を強化する。
  - あわせて、改善効果を判断するための追加計測（ステップ離脱・画像失敗/再試行・誤タップ・言語切替継続）を実装する。

  ## 実装内容

  - クリティカル操作の確認導線を統一（共通確認モーダル、取消導線、結果通知）。
  - 投稿作成フォームを 3 ステップ化（基本情報→画像/補足→確認）し、ステップ遷移/完了/離脱を計測。
  - 画像アップロードの失敗理由をユーザー向け文言で明示（形式/容量）し、再試行導線を固定。
  - 入力中離脱ガードをフォーム単位で追加（未送信時の beforeunload 警告）。
  - 検索結果カードの誤タップ推定計測を追加（カード内エリア遷移時間で推定）。
  - トースト表示ルールを統一（優先度・表示時間・warning トーン追加）。
  - 投稿詳細に関連投稿レコメンドと提示理由（タグ一致/カテゴリ・テーマ一致/人気 fallback）を追加。
  - 初回訪問と再訪でホーム表示を出し分け（初回案内厚め、再訪ショートカット優先）。
  - 言語切替後の継続セッション率計測を追加。
  - モーダル/メニューのフォーカストラップを強化。

  ## 方法

  - Rails 側でモデル・コントローラにバリデーション/推薦ロジック/イベントキューを追加。
  - ERB 側で UI 構造（3 ステップ、確認モーダル利用、初回/再訪出し分け、関連投稿表示）を更新。
  - ui_state.js に共通インタラクション層（確認処理、離脱ガード、フォーカストラップ、フォームステップ計測）を集約。
  - デザインは既存トークン体系を維持しつつ、warning toast など不足ユーティリティのみ追加。

  ## 変更箇所

  - app/views/posts/_form.html.erb
  - app/javascript/ui_state.js
  - app/views/layouts/application.html.erb
  - app/views/posts/index.html.erb
  - app/views/posts/show.html.erb
  - app/controllers/posts_controller.rb
  - app/models/post.rb
  - app/assets/tailwind/application.css

  ## まとめ

  - P0 の核である「誤操作防止」「失敗時の再起」「離脱抑制」を UI/UX と計測の両面で反映した。
  - 追加計測により、投稿作成ステップ離脱・画像失敗率・カード誤タップ・言語切替後継続の分析が可能になった。
  - 既存設計を壊さず、共通化（確認モーダル/トースト/フォーカス制御）を進めたため、以後の画面展開にも適用しやすい状態にした。

  ## Testing

  - bundle exec rubocop -f github : 成功
  - ruby bin/rails test test/controllers/posts_controller_test.rb test/controllers/reports_controller_test.rb : 成功（14
    runs, 51 assertions, 0 failures）
  - System test は環境制約で未実行（selenium-manager.exe Permission denied）

